### PR TITLE
fix: unblock the release pipeline and the Pages deploys

### DIFF
--- a/.github/workflows/deploy-vue-demo.yml
+++ b/.github/workflows/deploy-vue-demo.yml
@@ -1,14 +1,12 @@
 name: Deploy Vue Demo to GitHub Pages
 
+# Manual only.
+#
+# Three workflows targeted the github-pages environment and only one can own
+# the Pages site. Docs UI owns it, so every push run of this one was rejected
+# with "Branch main is not allowed to deploy to github-pages". Same treatment
+# as Deploy Demo: a button, not a deploy, until the phase 4 site replaces both.
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - 'examples/vue-demo/**'
-      - 'packages/vue/**'
-      - 'packages/core/**'
-      - '.github/workflows/deploy-vue-demo.yml'
   workflow_dispatch:
 
 permissions:

--- a/examples/vue-demo/package.json
+++ b/examples/vue-demo/package.json
@@ -13,9 +13,9 @@
   "dependencies": {
     "@wizzard-packages/adapter-zod": "workspace:*",
     "@wizzard-packages/core": "workspace:*",
-    "@wizzard-packages/devtools": "^2.0.0",
-    "@wizzard-packages/middleware": "^0.1.3",
-    "@wizzard-packages/persistence": "^0.1.3",
+    "@wizzard-packages/devtools": "workspace:*",
+    "@wizzard-packages/middleware": "workspace:*",
+    "@wizzard-packages/persistence": "workspace:*",
     "@wizzard-packages/vue": "workspace:*",
     "vue": "^3.5.13",
     "vue-router": "^4.6.4",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "docs:ui": "pnpm --filter @wizzard-packages/ui dev",
     "docs:ui:build": "pnpm --filter @wizzard-packages/ui build",
     "changeset": "changeset",
-    "release": "changeset version",
+    "release": "changeset version && pnpm install --lockfile-only",
     "release:publish": "changeset publish",
     "commit": "cz",
     "prepare": "husky || true",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -329,14 +329,14 @@ importers:
         specifier: workspace:*
         version: link:../../packages/core
       '@wizzard-packages/devtools':
-        specifier: ^2.0.0
-        version: 2.0.0(@wizzard-packages/core@packages+core)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        specifier: workspace:*
+        version: link:../../packages/devtools
       '@wizzard-packages/middleware':
-        specifier: ^0.1.3
-        version: 0.1.3
+        specifier: workspace:*
+        version: link:../../packages/middleware
       '@wizzard-packages/persistence':
-        specifier: ^0.1.3
-        version: 0.1.3
+        specifier: workspace:*
+        version: link:../../packages/persistence
       '@wizzard-packages/vue':
         specifier: workspace:*
         version: link:../../packages/vue
@@ -2238,28 +2238,6 @@ packages:
 
   '@vue/test-utils@2.4.6':
     resolution: {integrity: sha512-FMxEjOpYNYiFe0GkaHsnJPXFHxQ6m4t8vI/ElPGpMWxZKpmRvQ33OIrvRXemy6yha03RxhOlQuy+gZMC3CQSow==}
-
-  '@wizzard-packages/core@0.4.0':
-    resolution: {integrity: sha512-SADMGreoSwJYclZWTmX2btmfGX2yltvernEvEUuzjYmfKDfUH/x0GixoO8IG4Qo0igWayOc+CEpWKdxNWaKKPQ==}
-
-  '@wizzard-packages/devtools@2.0.0':
-    resolution: {integrity: sha512-lDBgrS8J/AZjxGQhF1OIkwG+pX/Rx0Cmku5eTC9lZeeMf9a8LTSt0wOiCuMD3WWghgCWZsoYRmzvw28AUvMmUg==}
-    peerDependencies:
-      '@wizzard-packages/core': 0.4.0
-      react: '>=18.0.0'
-      react-dom: '>=18.0.0'
-
-  '@wizzard-packages/middleware@0.1.3':
-    resolution: {integrity: sha512-/TB0FfvPw7X7Gds8NT8ZUUhqSw6mYl16HhPs95DTt1TCLrfTK5Tfy60WJGujrK3sidpSTqI3fJrn0j+q74NTVQ==}
-
-  '@wizzard-packages/persistence@0.1.3':
-    resolution: {integrity: sha512-ovuV1L07X50GHxXkbvA641L5C0BL6MG1TjOB07O5nndrY+aaBuHwVv/GbqfnMZWShUwHK9o/OQzybcwAKbJpug==}
-
-  '@wizzard-packages/react@0.4.0':
-    resolution: {integrity: sha512-b3WLRPzJh/7QCMfh9+d36O7DYLuIvztOcP2wqvxoR74+fq3jkroIt9hNTfhZgoaJLhHtE4VqU/WcGdsgaUNiPQ==}
-    peerDependencies:
-      react: '>=18.0.0'
-      react-dom: '>=18.0.0'
 
   JSONStream@1.3.5:
     resolution: {integrity: sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==}
@@ -6723,31 +6701,6 @@ snapshots:
     dependencies:
       js-beautify: 1.15.4
       vue-component-type-helpers: 2.2.12
-
-  '@wizzard-packages/core@0.4.0': {}
-
-  '@wizzard-packages/devtools@2.0.0(@wizzard-packages/core@packages+core)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
-    dependencies:
-      '@wizzard-packages/core': link:packages/core
-      '@wizzard-packages/react': 0.4.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
-
-  '@wizzard-packages/middleware@0.1.3':
-    dependencies:
-      '@wizzard-packages/core': 0.4.0
-
-  '@wizzard-packages/persistence@0.1.3':
-    dependencies:
-      '@wizzard-packages/core': 0.4.0
-
-  '@wizzard-packages/react@0.4.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
-    dependencies:
-      '@wizzard-packages/core': 0.4.0
-      '@wizzard-packages/middleware': 0.1.3
-      '@wizzard-packages/persistence': 0.1.3
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
 
   JSONStream@1.3.5:
     dependencies:


### PR DESCRIPTION
Three red workflows on `main`, two of which are fixed here.

## The Version Packages PR could never merge

`examples/vue-demo` linked four of its seven wizzard dependencies with
`workspace:*` and three with a published semver range. `changeset version`
rewrote those three to versions npm does not have yet, so CI's
`pnpm install --frozen-lockfile` rejected the PR release automation had just
produced:

```
ERR_PNPM_OUTDATED_LOCKFILE
  - @wizzard-packages/devtools (lockfile: ^2.0.0, manifest: ^2.0.1)
```

The same split meant the demo built devtools, middleware and persistence from
January's npm releases rather than from this repository — and the E2E suite
runs against that demo, so those three were outside its reach.

All seven now use `workspace:*`. `release` also runs
`pnpm install --lockfile-only` so a future stray range cannot separate the
lockfile from the bumps again.

## Deploy Vue Demo was rejected on every push

`Branch "main" is not allowed to deploy to github-pages due to environment
protection rules.` Only one workflow can own the Pages site, Docs UI owns it,
and this one lost the same fight Deploy Demo already lost. It becomes
`workflow_dispatch` for the same reason, until the phase 4 documentation site
replaces both.

## Verification

`pnpm release` completes locally where it previously failed, and
`pnpm install --frozen-lockfile` passes on its output. The demo builds against
workspace sources.

## Not fixed here

Canary publishing fails with `E404` on all eight packages. That is a
credentials problem, not a code one — see the note on the issue.