### PR TITLE
ci: verify the registry after publishing

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -4,6 +4,9 @@
 name: Canary
 
 on:
+  # Publishing is only testable by publishing. Without this the only way to
+  # retry a token or a registry hiccup is to re-run an old push.
+  workflow_dispatch:
   push:
     branches: [main]
     paths:
@@ -52,3 +55,9 @@ jobs:
         run: |
           pnpm changeset version --snapshot canary
           pnpm changeset publish --tag canary --no-git-tag
+
+      # changeset publish reports success for packages the registry never
+      # saved, and exits 0. Ask the registry what actually landed.
+      - name: Verify the registry has them
+        if: steps.check.outputs.count != '0'
+        run: node scripts/verify-published.mjs

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,6 +42,12 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: 'true'
 
+      # changeset publish reports success for packages the registry never
+      # saved, and exits 0. Never tag a release that did not fully land.
+      - name: Verify the registry has them
+        if: steps.changesets.outputs.published == 'true'
+        run: node scripts/verify-published.mjs
+
       - name: Tag release
         if: steps.changesets.outputs.published == 'true'
         run: |

--- a/scripts/verify-published.mjs
+++ b/scripts/verify-published.mjs
@@ -1,0 +1,79 @@
+// Ask the registry what actually landed.
+//
+// `changeset publish` lists a package under "packages published successfully"
+// even when the registry never saved it, and the job still exits 0. Seen twice:
+// canary attempt 5 dropped four packages behind an E409, attempt 6 dropped
+// @wizzard-packages/vue with no error line at all. A green release is not
+// evidence that anything shipped.
+//
+// Every publishable package's package.json version must exist on npm — true
+// after a canary snapshot (all packages get a fresh version) and after a real
+// release (bumped packages are new, untouched ones were already published).
+// Run this only when a publish actually ran.
+//
+// `changeset publish` is idempotent, so the fix for a failure here is to re-run
+// the workflow: it skips what landed and retries what didn't.
+
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const REGISTRY = 'https://registry.npmjs.org';
+// ponytail: fixed retry window, enough for replication lag. Widen if this flaps.
+const ATTEMPTS = 3;
+const DELAY_MS = 10_000;
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+function publishablePackages() {
+  return readdirSync('packages', { withFileTypes: true })
+    .filter((e) => e.isDirectory())
+    .map((e) => join('packages', e.name, 'package.json'))
+    .map((p) => {
+      try {
+        return JSON.parse(readFileSync(p, 'utf8'));
+      } catch {
+        return null;
+      }
+    })
+    .filter((p) => p && !p.private && p.name && p.version)
+    .map(({ name, version }) => ({ name, version }));
+}
+
+async function isPublished(name, version) {
+  const res = await fetch(`${REGISTRY}/${name.replace('/', '%2f')}`, {
+    headers: { accept: 'application/json' },
+  });
+  if (res.status === 404) return false;
+  if (!res.ok) throw new Error(`${name}: registry returned ${res.status}`);
+  const packument = await res.json();
+  return Boolean(packument.versions?.[version]);
+}
+
+const expected = publishablePackages();
+if (expected.length === 0) {
+  console.error('No publishable packages found under packages/ — check the layout.');
+  process.exit(1);
+}
+
+let missing = expected;
+for (let attempt = 1; attempt <= ATTEMPTS && missing.length > 0; attempt++) {
+  if (attempt > 1) await sleep(DELAY_MS);
+  const checked = await Promise.all(
+    missing.map(async (pkg) => ({ ...pkg, found: await isPublished(pkg.name, pkg.version) }))
+  );
+  missing = checked.filter((p) => !p.found);
+}
+
+for (const { name, version } of expected) {
+  const gone = missing.some((m) => m.name === name);
+  console.log(`${gone ? 'MISSING' : 'ok     '}  ${name}@${version}`);
+}
+
+if (missing.length > 0) {
+  console.error(
+    `\n${missing.length} package(s) reported as published are not in the registry.` +
+      `\nRe-run this workflow: changeset publish skips what landed and retries the rest.`
+  );
+  process.exit(1);
+}
+console.log(`\nAll ${expected.length} packages verified in the registry.`);


### PR DESCRIPTION
## The problem

`changeset publish` lists a package under "packages published successfully"
even when the registry never saved it, and the job still exits 0.

Two runs of the Canary workflow prove it:

- **attempt 5** — four packages failed with `E409 Failed to save packument`,
  all four were listed as published anyway.
- **attempt 6** — the run went green with zero `npm error` lines, listed
  `@wizzard-packages/vue@0.2.1-canary-20260904174051` as published, and the
  registry still only has `...-canary-20260904173354`. `core` in the same run
  has both timestamps, so this is not replication lag.

A green Release run was never evidence that anything shipped. On a real
release that means a package can be silently skipped and its version burned,
with no gate to catch it.

## The fix

Publishing is unchanged. `changeset publish` is idempotent — it skips what
landed and retries the rest, which is exactly how attempt 6 healed attempt 5's
four failures. So a partial publish only needs to be *noticed*, not prevented.

`scripts/verify-published.mjs` reads every publishable package's version from
`packages/*/package.json` and asks the registry whether that version exists.
It retries three times over 30s to absorb genuine replication lag, then prints
a per-package table and exits non-zero if anything is missing.

The invariant holds for both publish paths: after a canary snapshot every
package has a fresh version, and after a release the bumped packages are new
while untouched ones were already published.

Wired in as:

- **Canary** — after `changeset publish`, gated on the same changeset count.
- **Release** — after the changesets action and **before** `Tag release`, so a
  partial release is never tagged.

## Also

Canary gains `workflow_dispatch`. It is path-filtered to `packages/**` and
`.changeset/**`, so the only way to retest a token or a registry hiccup was to
re-run an old push.

## Verification

Run against the live registry on the current working tree, where
`@wizzard-packages/validate@0.0.0` is genuinely unpublished:

```
ok       @wizzard-packages/adapter-yup@0.1.3
ok       @wizzard-packages/adapter-zod@0.1.3
ok       @wizzard-packages/core@0.4.0
ok       @wizzard-packages/devtools@2.0.0
ok       @wizzard-packages/middleware@0.1.3
ok       @wizzard-packages/persistence@0.1.3
ok       @wizzard-packages/react@0.4.0
MISSING  @wizzard-packages/validate@0.0.0
ok       @wizzard-packages/vue@0.2.0

1 package(s) reported as published are not in the registry.
exit=1
```

No changeset: this touches CI only, nothing publishable changes.
