### PR TITLE
ci: give the publish check five minutes, not thirty seconds

### DIFF
--- a/scripts/verify-published.mjs
+++ b/scripts/verify-published.mjs
@@ -18,9 +18,13 @@ import { readdirSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 const REGISTRY = 'https://registry.npmjs.org';
-// ponytail: fixed retry window, enough for replication lag. Widen if this flaps.
-const ATTEMPTS = 3;
-const DELAY_MS = 10_000;
+// Replication is not uniform across packages: @wizzard-packages/vue has taken
+// minutes to become visible while every sibling published in the same batch
+// showed up at once. A 30s window called it missing three runs in a row and
+// every one of those versions is in the registry now. Five minutes covers it.
+// ponytail: fixed ceiling, raise it if a package ever needs longer.
+const ATTEMPTS = 10;
+const DELAY_MS = 30_000;
 
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 


### PR DESCRIPTION
Follow-up to #19.

The verification step called `@wizzard-packages/vue` missing on three
consecutive canary runs. It was wrong all three times — every one of those
versions is in the registry now:

```
vue canary versions: [
  '0.2.1-canary-20260904173354',
  '0.2.1-canary-20260904174051',   <- declared missing at 17:45
  '0.2.1-canary-20260904180404'    <- declared missing at 18:04
]
```

Replication is not uniform across packages. `vue` takes minutes to become
visible while every sibling published in the same batch appears at once, which
is why `core` looked like a valid control at the time and was not.

Thirty seconds was tuned against packages that replicate immediately. Ten
attempts thirty seconds apart covers what `vue` actually does, and a release
job can afford five minutes to be sure it shipped.

The E409 case #19 was built for is unaffected: those packages error out and
never publish at all, so no window makes them appear.
