### PR TITLE
ci: drop the dead tag step from Release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,15 +43,10 @@ jobs:
           NPM_CONFIG_PROVENANCE: 'true'
 
       # changeset publish reports success for packages the registry never
-      # saved, and exits 0. Never tag a release that did not fully land.
+      # saved, and exits 0. Nothing else in this job would notice, so a red
+      # step here is the only signal that a release did not fully land.
+      # Tags are already pushed by then: changesets/action creates a GitHub
+      # release per package during publish, and that creates the tag.
       - name: Verify the registry has them
         if: steps.changesets.outputs.published == 'true'
         run: node scripts/verify-published.mjs
-
-      - name: Tag release
-        if: steps.changesets.outputs.published == 'true'
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          pnpm changeset tag
-          git push --tags


### PR DESCRIPTION
`changesets/action` creates a GitHub release per package during its publish
step, and that creates the tag. The explicit `Tag release` step that ran
afterwards had nothing left to do.

Evidence from the first real release (run `33984087217`, nine packages):

- GitHub releases and tags appear at `18:29:25`–`18:29:37`
- the tag step runs at `18:30:38` and `git push --tags` prints
  `Everything up-to-date`
- getting to that no-op ran the full vitest suite (19 files) through the
  husky pre-push hook, inside the release job

So the step costs a test run and buys nothing. Removed.

The comment above the verification step claimed it kept a partial release
from being tagged. It cannot -- tags already exist by then. Rewritten to say
what the step actually does: it is the only thing in the job that would
notice a publish the registry did not save, because `changeset publish`
lists those as successful and exits 0.