### PR TITLE
feat(core): add the flow graph builder

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -26,6 +26,11 @@ export default [
   // machinery that walks them. That is what keeps the main entry inside 4 kB.
   { name: 'core-v1', path: 'packages/core/src/v1/index.ts', limit: '3.9 kB', gzip: true },
 
+  // The graph builder. Its own entry for the same reason validate-flow is:
+  // structure-only drawing is a development and inspection concern, and a
+  // wizard that never draws itself should not carry the code that would.
+  { name: 'core-v1 graph', path: 'packages/core/src/v1/graph.ts', limit: '800 B', gzip: true },
+
   // Development and server-driven use only. Measured, but never counted against
   // the runtime budget, because shipping it to a browser is a mistake the
   // separate entry makes hard to commit by accident.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -53,6 +53,16 @@
         "types": "./dist/v1/validate-flow.d.cts",
         "default": "./dist/v1/validate-flow.cjs"
       }
+    },
+    "./graph": {
+      "import": {
+        "types": "./dist/v1/graph.d.ts",
+        "default": "./dist/v1/graph.js"
+      },
+      "require": {
+        "types": "./dist/v1/graph.d.cts",
+        "default": "./dist/v1/graph.cjs"
+      }
     }
   },
   "files": [

--- a/packages/core/src/v1/graph.test.ts
+++ b/packages/core/src/v1/graph.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, it } from 'vitest';
+
+import { END, type FlowDefinition } from './flow';
+import { buildGraph, type FlowGraph } from './graph';
+
+const flow: FlowDefinition = {
+  id: 'booking',
+  order: ['trip', 'company', 'payment', 'review'],
+  steps: {
+    trip: { on: { back: 'auto' } },
+    company: { when: { $eq: [{ $get: 'data.trip.payer' }, 'business'] } },
+    payment: {
+      on: {
+        next: [
+          { to: 'review', when: { $eq: [{ $get: 'data.payment.ok' }, true] } },
+          'retry',
+          { to: END },
+        ],
+      },
+    },
+    review: { on: { back: 'payment' } },
+    // Deliberately outside `order`: reachable only through payment's branch.
+    retry: { label: 'Try another card' },
+  },
+};
+
+const ids = (g: FlowGraph): string[] => g.nodes.map((n) => n.id);
+const node = (g: FlowGraph, id: string) => g.nodes.find((n) => n.id === id);
+const from = (g: FlowGraph, id: string) => g.edges.filter((e) => e.from === id);
+
+describe('nodes', () => {
+  it('draws every step, including one left out of `order`', () => {
+    // The whole point: `order` is the default path, not the set of steps. A
+    // graph built from `order` would hide the branch a reader came to find.
+    expect(ids(buildGraph(flow))).toEqual(
+      expect.arrayContaining(['trip', 'company', 'payment', 'review', 'retry'])
+    );
+  });
+
+  it('marks the off-order step, so the renderer can say why nothing falls into it', () => {
+    expect(node(buildGraph(flow), 'retry')?.offOrder).toBe(true);
+    expect(node(buildGraph(flow), 'trip')?.offOrder).toBeUndefined();
+  });
+
+  it('carries `when` verbatim for the renderer to label', () => {
+    expect(node(buildGraph(flow), 'company')?.when).toEqual({
+      $eq: [{ $get: 'data.trip.payer' }, 'business'],
+    });
+  });
+
+  it('falls back to the insertion order of `steps` when `order` is absent', () => {
+    const g = buildGraph({ id: 'f', steps: { a: {}, b: {} } });
+    expect(ids(g)).toEqual(['a', 'b']);
+    expect(from(g, 'a')).toEqual([{ from: 'a', to: 'b', kind: 'order' }]);
+    // Nothing is off-order when there is no order to be off.
+    expect(node(g, 'a')?.offOrder).toBeUndefined();
+  });
+
+  it('draws a deferred step as a stub', () => {
+    const g = buildGraph({ id: 'f', steps: { a: { deferred: true } } });
+    expect(node(g, 'a')?.deferred).toBe(true);
+  });
+});
+
+describe('fall-through edges', () => {
+  it('connects consecutive steps that declare no `on.next`', () => {
+    expect(from(buildGraph(flow), 'trip')).toContainEqual({
+      from: 'trip',
+      to: 'company',
+      kind: 'order',
+      when: { $eq: [{ $get: 'data.trip.payer' }, 'business'] },
+    });
+  });
+
+  it('keeps the skip edge past a conditional step', () => {
+    // company may be false at run time, in which case trip goes straight to
+    // payment. One edge per pair would hide exactly what `when` is for.
+    const g = buildGraph(flow);
+    expect(from(g, 'trip').map((e) => e.to)).toEqual(['company', 'payment']);
+    expect(from(g, 'trip')[0]?.when).toBeDefined();
+    expect(from(g, 'trip')[1]?.when).toBeUndefined();
+  });
+
+  it('stops at the first unconditional step', () => {
+    expect(from(buildGraph(flow), 'company').map((e) => e.to)).toEqual(['payment']);
+  });
+
+  it('yields to an explicit `on.next`', () => {
+    expect(from(buildGraph(flow), 'payment').every((e) => e.kind !== 'order')).toBe(true);
+  });
+});
+
+describe('explicit edges', () => {
+  it('draws one edge per target in an `on.next` array, labelled by its guard', () => {
+    const next = from(buildGraph(flow), 'payment').filter((e) => e.kind === 'next');
+    expect(next.map((e) => e.to)).toEqual(['review', 'retry', END]);
+    expect(next[0]?.when).toEqual({ $eq: [{ $get: 'data.payment.ok' }, true] });
+    expect(next[1]?.when).toBeUndefined();
+  });
+
+  it('draws an explicit back target but not `auto`', () => {
+    const g = buildGraph(flow);
+    expect(from(g, 'review')).toContainEqual({ from: 'review', to: 'payment', kind: 'back' });
+    // `auto` is resolved against the state of the moment; there is no fixed
+    // target, and a guessed arrow would be worse than none.
+    expect(from(g, 'trip').some((e) => e.kind === 'back')).toBe(false);
+  });
+
+  it('adds one terminal node, only when something reaches it', () => {
+    expect(node(buildGraph(flow), END)?.kind).toBe('end');
+    expect(ids(buildGraph(flow)).filter((id) => id === END)).toHaveLength(1);
+    expect(node(buildGraph({ id: 'f', steps: { a: {} } }), END)).toBeUndefined();
+  });
+
+  it('keeps a target that names nothing, and flags it', () => {
+    const g = buildGraph({ id: 'f', steps: { a: { on: { next: 'ghost' } } } });
+    expect(from(g, 'a')).toEqual([{ from: 'a', to: 'ghost', kind: 'next', dangling: true }]);
+  });
+});
+
+describe('groups', () => {
+  const child: FlowDefinition = { id: 'address', steps: { line1: {}, city: {} } };
+
+  it('draws an inline sub-flow in place', () => {
+    const g = buildGraph({ id: 'f', steps: { addr: { flow: child } } });
+    const group = node(g, 'addr')?.group;
+    expect(node(g, 'addr')?.kind).toBe('group');
+    expect(group?.flowId).toBe('address');
+    expect(group?.graph && ids(group.graph)).toEqual(['line1', 'city']);
+  });
+
+  it('resolves a sub-flow named by id against the registry', () => {
+    const g = buildGraph({ id: 'f', steps: { addr: { flow: 'address' } } }, { address: child });
+    const nested = node(g, 'addr')?.group?.graph;
+    expect(nested && ids(nested)).toEqual(['line1', 'city']);
+  });
+
+  it('says so when a reference cannot be resolved, rather than drawing a plain box', () => {
+    const g = buildGraph({ id: 'f', steps: { addr: { flow: 'address' } } });
+    expect(node(g, 'addr')?.group).toEqual({ flowId: 'address', opaque: 'unresolved' });
+  });
+
+  it('stops at a sub-flow that references an ancestor instead of recursing forever', () => {
+    const looper: FlowDefinition = { id: 'loop', steps: { again: { flow: 'loop' } } };
+    const g = buildGraph(looper, { loop: looper });
+    expect(node(g, 'again')?.group).toEqual({ flowId: 'loop', opaque: 'cycle' });
+  });
+
+  it('carries the repeat expression, which the definition has and the run time varies', () => {
+    const g = buildGraph({
+      id: 'f',
+      steps: { each: { flow: child, repeat: { over: { $get: 'data.items' } } } },
+    });
+    expect(node(g, 'each')?.group?.repeat).toEqual({ $get: 'data.items' });
+  });
+});
+
+describe('the graph is data', () => {
+  it('round-trips through JSON', () => {
+    // The architecture rests on this: a flow is JSON, so its graph is too, and
+    // it can be posted, cached or diffed like any other value.
+    const g = buildGraph(flow);
+    expect(JSON.parse(JSON.stringify(g))).toEqual(g);
+  });
+
+  it('carries no positions', () => {
+    // Layout belongs to the renderer. If a coordinate ever lands here, a layout
+    // library is one commit away from a published package.
+    const text = JSON.stringify(buildGraph(flow));
+    for (const key of ['"x"', '"y"', 'width', 'height', 'position']) {
+      expect(text).not.toContain(key);
+    }
+  });
+});

--- a/packages/core/src/v1/graph.test.ts
+++ b/packages/core/src/v1/graph.test.ts
@@ -146,6 +146,23 @@ describe('groups', () => {
     expect(node(g, 'again')?.group).toEqual({ flowId: 'loop', opaque: 'cycle' });
   });
 
+  it('stops at a depth cap, so pasted JSON cannot walk the stack down', () => {
+    // Thirty-three distinct sub-flows: no cycle to catch it, and a flow can
+    // arrive from a paste box.
+    const deep: Record<string, FlowDefinition> = {};
+    for (let i = 0; i < 40; i++) {
+      deep[`f${i}`] = { id: `f${i}`, steps: { down: { flow: `f${i + 1}` } } };
+    }
+    let g = buildGraph(deep.f0 as FlowDefinition, deep);
+    let depth = 0;
+    while (g.nodes[0]?.group?.graph) {
+      g = g.nodes[0].group.graph;
+      depth++;
+    }
+    expect(g.nodes[0]?.group?.opaque).toBe('too-deep');
+    expect(depth).toBeLessThan(40);
+  });
+
   it('carries the repeat expression, which the definition has and the run time varies', () => {
     const g = buildGraph({
       id: 'f',

--- a/packages/core/src/v1/graph.ts
+++ b/packages/core/src/v1/graph.ts
@@ -1,0 +1,209 @@
+import {
+  END,
+  isGroup,
+  type FlowDefinition,
+  type GroupStep,
+  type StepDef,
+  type Target,
+} from './flow';
+
+import type { Expr } from './expr';
+
+/**
+ * A flow's transition graph.
+ *
+ * Structure only, deliberately: no coordinates, no sizes, no layout. A flow is
+ * already a pure JSON value, so its graph can be one too, and keeping positions
+ * out is what lets this ship inside a published package while the site that
+ * draws it is free to pull in a layout library the package never pays for.
+ *
+ * It is also why this is its own entry. A wizard that never draws itself should
+ * not carry the code that would.
+ */
+export interface FlowGraph {
+  nodes: readonly GraphNode[];
+  edges: readonly GraphEdge[];
+}
+
+export interface GraphNode {
+  id: string;
+  kind: 'step' | 'group' | 'end';
+  label?: string;
+  /** The step's own reachability predicate, verbatim, for the renderer to label. */
+  when?: Expr;
+  /** The body arrives later from the host, so there is nothing to draw inside yet. */
+  deferred?: boolean;
+  /**
+   * The step is absent from a declared `order`, so nothing falls through to it
+   * and it is reachable only via an explicit `on.next`.
+   */
+  offOrder?: boolean;
+  group?: GroupNode;
+}
+
+export interface GroupNode {
+  /** The sub-flow's id, whether it was inlined or named by reference. */
+  flowId: string;
+  /** Present with `repeat`: the group runs once per item in this expression. */
+  repeat?: Expr;
+  /** The sub-flow drawn in place. Absent exactly when `opaque` says why. */
+  graph?: FlowGraph;
+  /**
+   * Why the sub-flow could not be drawn. A group with no nested graph and no
+   * reason would render as an ordinary box and read as working software, so
+   * the reason is part of the data and the renderer is expected to show it.
+   */
+  opaque?: 'unresolved' | 'cycle';
+}
+
+export interface GraphEdge {
+  from: string;
+  /** A step id, or `END`. */
+  to: string;
+  /**
+   * `next`/`back` come from an explicit `on`; `order` is the default
+   * fall-through the resolver uses when a step declares no `on.next`.
+   */
+  kind: 'next' | 'back' | 'order';
+  /** The condition under which this edge is taken. Absent means unconditional. */
+  when?: Expr;
+  /** `to` names neither a step in this flow nor `END`. */
+  dangling?: boolean;
+}
+
+/**
+ * Builds the graph of `flow`.
+ *
+ * `subFlows` resolves `GroupStep.flow` when it is given by id, mirroring
+ * `validateFlow(flow, registry?)`. Without it, referenced sub-flows are still
+ * drawn -- as opaque nodes that say so.
+ */
+export function buildGraph(
+  flow: FlowDefinition,
+  subFlows?: Readonly<Record<string, FlowDefinition>>
+): FlowGraph {
+  return build(flow, subFlows, [flow.id]);
+}
+
+function build(
+  flow: FlowDefinition,
+  subFlows: Readonly<Record<string, FlowDefinition>> | undefined,
+  drawing: readonly string[]
+): FlowGraph {
+  const entries = Object.entries(flow.steps);
+  const nodes: GraphNode[] = entries.map(([id, step]) =>
+    toNode(id, step, flow.order, subFlows, drawing)
+  );
+  const edges = [...explicitEdges(entries, flow), ...fallThroughEdges(flow)];
+
+  // One terminal node, and only when something actually reaches it.
+  if (edges.some((e) => e.to === END)) nodes.push({ id: END, kind: 'end' });
+
+  return { nodes, edges };
+}
+
+function toNode(
+  id: string,
+  step: StepDef,
+  order: readonly string[] | undefined,
+  subFlows: Readonly<Record<string, FlowDefinition>> | undefined,
+  drawing: readonly string[]
+): GraphNode {
+  return {
+    id,
+    kind: isGroup(step) ? 'group' : 'step',
+    ...(step.label !== undefined && { label: step.label }),
+    ...(step.when !== undefined && { when: step.when }),
+    ...(step.deferred === true && { deferred: true }),
+    ...(order !== undefined && !order.includes(id) && { offOrder: true }),
+    ...(isGroup(step) && { group: toGroup(step, subFlows, drawing) }),
+  };
+}
+
+function toGroup(
+  step: GroupStep,
+  subFlows: Readonly<Record<string, FlowDefinition>> | undefined,
+  drawing: readonly string[]
+): GroupNode {
+  // `flow` is either the definition itself or its id, and both cases need the
+  // id, so the narrowing is written out twice rather than cast once.
+  const flowId = typeof step.flow === 'string' ? step.flow : step.flow.id;
+  const sub = typeof step.flow === 'string' ? subFlows?.[step.flow] : step.flow;
+  const repeat = step.repeat === undefined ? {} : { repeat: step.repeat.over };
+
+  if (sub === undefined) return { flowId, ...repeat, opaque: 'unresolved' };
+  // A sub-flow that names an ancestor by id would otherwise recurse forever.
+  if (drawing.includes(flowId)) return { flowId, ...repeat, opaque: 'cycle' };
+
+  return { flowId, ...repeat, graph: build(sub, subFlows, [...drawing, flowId]) };
+}
+
+function explicitEdges(
+  entries: readonly (readonly [string, StepDef])[],
+  flow: FlowDefinition
+): GraphEdge[] {
+  const edges: GraphEdge[] = [];
+  for (const [id, step] of entries) {
+    const next = step.on?.next;
+    if (next !== undefined) {
+      const targets: readonly Target[] = Array.isArray(next) ? next : [next as Target];
+      for (const t of targets) edges.push(toEdge(id, t, 'next', flow));
+    }
+
+    const back = step.on?.back;
+    // `auto` is the resolver walking `order` backwards at run time against the
+    // state of the moment. There is no fixed target, and drawing a guess would
+    // be worse than drawing nothing.
+    if (back !== undefined && back !== 'auto') edges.push(toEdge(id, back, 'back', flow));
+  }
+  return edges;
+}
+
+/**
+ * The default path: a step with no `on.next` falls through to the next entry in
+ * `order` whose `when` passes.
+ *
+ * Which is why one edge per pair is not enough. Statically we cannot know which
+ * `when` holds, so every step up to and including the first unconditional one
+ * is genuinely reachable from here, and a lone edge to the immediate neighbour
+ * would hide the skip that `when` exists to express.
+ */
+function fallThroughEdges(flow: FlowDefinition): GraphEdge[] {
+  const walk = flow.order ?? Object.keys(flow.steps);
+  const edges: GraphEdge[] = [];
+
+  for (let i = 0; i < walk.length; i++) {
+    const from = walk[i];
+    if (from === undefined || flow.steps[from]?.on?.next !== undefined) continue;
+
+    for (let j = i + 1; j < walk.length; j++) {
+      const to = walk[j];
+      if (to === undefined) continue;
+      const target = flow.steps[to];
+      if (target === undefined) continue;
+
+      edges.push({
+        from,
+        to,
+        kind: 'order',
+        ...(target.when !== undefined && { when: target.when }),
+      });
+      if (target.when === undefined) break;
+    }
+  }
+  return edges;
+}
+
+function toEdge(from: string, t: Target, kind: 'next' | 'back', flow: FlowDefinition): GraphEdge {
+  const to = typeof t === 'string' ? t : t.to;
+  const when = typeof t === 'string' ? undefined : t.when;
+  return {
+    from,
+    to,
+    kind,
+    ...(when !== undefined && { when }),
+    // A branch pointing at nothing is a flow bug. It stays on the graph so it
+    // can be seen, rather than vanishing into a step that has one fewer arrow.
+    ...(to !== END && !(to in flow.steps) && { dangling: true }),
+  };
+}

--- a/packages/core/src/v1/graph.ts
+++ b/packages/core/src/v1/graph.ts
@@ -53,7 +53,7 @@ export interface GroupNode {
    * reason would render as an ordinary box and read as working software, so
    * the reason is part of the data and the renderer is expected to show it.
    */
-  opaque?: 'unresolved' | 'cycle';
+  opaque?: 'unresolved' | 'cycle' | 'too-deep';
 }
 
 export interface GraphEdge {
@@ -70,6 +70,16 @@ export interface GraphEdge {
   /** `to` names neither a step in this flow nor `END`. */
   dangling?: boolean;
 }
+
+/**
+ * How deep sub-flows are followed.
+ *
+ * A flow can arrive as pasted, untrusted JSON. The cycle guard in `toGroup`
+ * catches a sub-flow that names an ancestor, but a chain of thirty-two
+ * *distinct* ones has no cycle in it and would still walk the stack down.
+ * Nothing legitimate nests that far.
+ */
+const MAX_DEPTH = 32;
 
 /**
  * Builds the graph of `flow`.
@@ -134,6 +144,7 @@ function toGroup(
   if (sub === undefined) return { flowId, ...repeat, opaque: 'unresolved' };
   // A sub-flow that names an ancestor by id would otherwise recurse forever.
   if (drawing.includes(flowId)) return { flowId, ...repeat, opaque: 'cycle' };
+  if (drawing.length >= MAX_DEPTH) return { flowId, ...repeat, opaque: 'too-deep' };
 
   return { flowId, ...repeat, graph: build(sub, subFlows, [...drawing, flowId]) };
 }

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -3,8 +3,10 @@ import { defineConfig } from 'tsup';
 
 export default defineConfig({
   // v1 ships as its own entry so it can be tried from canary without
-  // touching the 0.x surface, and so validate-flow stays out of runtime bundles.
-  entry: ['src/index.ts', 'src/v1/index.ts', 'src/v1/validate-flow.ts'],
+  // touching the 0.x surface, and so validate-flow and graph stay out of
+  // runtime bundles: a wizard that never draws itself should not carry the
+  // code that would.
+  entry: ['src/index.ts', 'src/v1/index.ts', 'src/v1/validate-flow.ts', 'src/v1/graph.ts'],
   format: ['cjs', 'esm'],
   dts: true,
   splitting: false,


### PR DESCRIPTION
Step 2 of the flow-inspector plan. `buildGraph(flow, subFlows?)` turns a
`FlowDefinition` into `{nodes, edges}` -- pure, structure only, no coordinates.

Layout belongs to whatever draws it. Keeping positions out is what lets this
live in a published package while the site is free to pull in a layout library
the package never pays for.

## Nodes from `steps`, edges from `order`

That split is the whole task. `order` is the default path, not the set of
steps: one left out of it is reachable through an explicit `on.next`, so a
graph built from `order` would hide exactly the branch a reader opened the
graph to find. Those nodes carry `offOrder` so the renderer can say why nothing
falls into them.

Fall-through is not one edge per pair either. A step with no `on.next` lands on
the next entry whose `when` passes, so every candidate up to and including the
first unconditional one is a real edge. A lone edge to the immediate neighbour
would hide the skip that `when` exists to express.

## Nothing fails silently

Per Finding 1.2 and E3/E4 in the design review, the cases that would otherwise
render as working software name themselves in the data:

| case | result |
| --- | --- |
| sub-flow referenced by id, registry has it | drawn in place |
| sub-flow referenced by id, no registry | `opaque: 'unresolved'` |
| sub-flow naming an ancestor | `opaque: 'cycle'`, not a hang |
| `on.next` target matching no step | edge kept, `dangling: true` |
| `on.back: 'auto'` | no edge -- it has no fixed target, and a guess is worse than nothing |

The registry argument mirrors `validateFlow(flow, registry?)` rather than
inventing a second shape.

## Cost

Its own entry, `@wizzard-packages/core/graph`, ratcheted at 800 B against
705 B measured. The v1 engine entry is unchanged at 3.88 kB under its 3.9 kB
limit -- `graph.ts` is deliberately not re-exported from `v1/index.ts`, so a
wizard that never draws itself carries none of this.

`publint` clean, `attw` green on node16 CJS/ESM and bundler for the new export.

## Tests

20 cases in `graph.test.ts`, covering the acceptance list from the design doc
(linear order, conditional `on.next` array, `on.back: 'auto'`, `END`, nested
group) plus the failure modes above. Two guard the architecture rather than the
code: the graph round-trips through `JSON`, and it contains no positional key.

Not in scope: the synthesized `END` edge for a flow that simply runs out of
ordered steps -- that is the next task. An explicit `on.next: '@end'` already
draws its edge and the single terminal node.