### PR TITLE
feat(core): synthesize the end edge in the graph

### DIFF
--- a/packages/core/src/v1/graph.test.ts
+++ b/packages/core/src/v1/graph.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from 'vitest';
 
+import type { Scope } from './expr';
 import { END, type FlowDefinition } from './flow';
 import { buildGraph, type FlowGraph } from './graph';
+import { resolveNext } from './resolve';
+import { initialState, type WizardState } from './state';
 
 const flow: FlowDefinition = {
   id: 'booking',
@@ -50,7 +53,7 @@ describe('nodes', () => {
 
   it('falls back to the insertion order of `steps` when `order` is absent', () => {
     const g = buildGraph({ id: 'f', steps: { a: {}, b: {} } });
-    expect(ids(g)).toEqual(['a', 'b']);
+    expect(ids(g)).toEqual(['a', 'b', END]);
     expect(from(g, 'a')).toEqual([{ from: 'a', to: 'b', kind: 'order' }]);
     // Nothing is off-order when there is no order to be off.
     expect(node(g, 'a')?.offOrder).toBeUndefined();
@@ -109,12 +112,75 @@ describe('explicit edges', () => {
   it('adds one terminal node, only when something reaches it', () => {
     expect(node(buildGraph(flow), END)?.kind).toBe('end');
     expect(ids(buildGraph(flow)).filter((id) => id === END)).toHaveLength(1);
-    expect(node(buildGraph({ id: 'f', steps: { a: {} } }), END)).toBeUndefined();
+    // A flow whose every step routes explicitly, in a loop, never ends.
+    const cycle = buildGraph({
+      id: 'f',
+      steps: { a: { on: { next: 'b' } }, b: { on: { next: 'a' } } },
+    });
+    expect(node(cycle, END)).toBeUndefined();
   });
 
   it('keeps a target that names nothing, and flags it', () => {
     const g = buildGraph({ id: 'f', steps: { a: { on: { next: 'ghost' } } } });
     expect(from(g, 'a')).toEqual([{ from: 'a', to: 'ghost', kind: 'next', dangling: true }]);
+  });
+});
+
+describe('the synthesized end', () => {
+  it('ends the flow after the last ordered step', () => {
+    expect(from(buildGraph(flow), 'review')).toContainEqual({
+      from: 'review',
+      to: END,
+      kind: 'order',
+    });
+  });
+
+  it('ends the flow from a step that is not in `order` at all', () => {
+    // resolveNext returns END when indexOf(current) is -1. Drawing nothing
+    // here left retry looking like a dead end on a graph whose job is to
+    // show where a flow goes.
+    expect(from(buildGraph(flow), 'retry')).toEqual([{ from: 'retry', to: END, kind: 'order' }]);
+  });
+
+  it('ends the flow when every remaining step is conditional', () => {
+    // b and c can both be false, so a really can be the last step run.
+    const g = buildGraph({
+      id: 'f',
+      order: ['a', 'b', 'c'],
+      steps: { a: {}, b: { when: { $get: 'data.b' } }, c: { when: { $get: 'data.c' } } },
+    });
+    expect(from(g, 'a').map((e) => e.to)).toEqual(['b', 'c', END]);
+  });
+
+  it('leaves the end edge unlabelled rather than synthesizing a negation', () => {
+    const end = from(buildGraph(flow), 'review').find((e) => e.to === END);
+    expect(end?.when).toBeUndefined();
+  });
+
+  it('does not end a step that routes explicitly', () => {
+    expect(from(buildGraph(flow), 'payment').some((e) => e.kind === 'order')).toBe(false);
+  });
+
+  it('agrees with the resolver about where every step can go', () => {
+    // The claim this whole module rests on. Case-by-case tests say the builder
+    // does what was written down; this says what was written down matches the
+    // engine -- which is how the missing end edges were found in the first
+    // place.
+    const g = buildGraph(flow);
+    const at = (step: string): WizardState => ({
+      ...initialState(),
+      stack: [{ flow: 'booking', step }],
+    });
+
+    for (const payer of ['business', 'private']) {
+      for (const ok of [true, false]) {
+        const scope: Scope = { data: { trip: { payer }, payment: { ok } }, ctx: {} };
+        for (const step of Object.keys(flow.steps)) {
+          const target = resolveNext(flow, at(step), scope);
+          expect(from(g, step).map((e) => e.to)).toContain(target);
+        }
+      }
+    }
   });
 });
 
@@ -126,13 +192,13 @@ describe('groups', () => {
     const group = node(g, 'addr')?.group;
     expect(node(g, 'addr')?.kind).toBe('group');
     expect(group?.flowId).toBe('address');
-    expect(group?.graph && ids(group.graph)).toEqual(['line1', 'city']);
+    expect(group?.graph && ids(group.graph)).toEqual(['line1', 'city', END]);
   });
 
   it('resolves a sub-flow named by id against the registry', () => {
     const g = buildGraph({ id: 'f', steps: { addr: { flow: 'address' } } }, { address: child });
     const nested = node(g, 'addr')?.group?.graph;
-    expect(nested && ids(nested)).toEqual(['line1', 'city']);
+    expect(nested && ids(nested)).toEqual(['line1', 'city', END]);
   });
 
   it('says so when a reference cannot be resolved, rather than drawing a plain box', () => {

--- a/packages/core/src/v1/graph.ts
+++ b/packages/core/src/v1/graph.ts
@@ -172,22 +172,37 @@ function explicitEdges(
 
 /**
  * The default path: a step with no `on.next` falls through to the next entry in
- * `order` whose `when` passes.
+ * `order` whose `when` passes, and ends the flow when nothing is left.
  *
  * Which is why one edge per pair is not enough. Statically we cannot know which
  * `when` holds, so every step up to and including the first unconditional one
  * is genuinely reachable from here, and a lone edge to the immediate neighbour
- * would hide the skip that `when` exists to express.
+ * would hide the skip that `when` exists to express. By the same argument, a
+ * tail of conditional steps can all be false, so the flow can end there too.
+ *
+ * The edge to `END` carries no `when`. Expressing it would mean negating every
+ * guard it skipped past, and a synthesized compound predicate on a drawing is
+ * harder to trust than an unlabelled fallback arrow.
  */
 function fallThroughEdges(flow: FlowDefinition): GraphEdge[] {
   const walk = flow.order ?? Object.keys(flow.steps);
   const edges: GraphEdge[] = [];
 
-  for (let i = 0; i < walk.length; i++) {
-    const from = walk[i];
-    if (from === undefined || flow.steps[from]?.on?.next !== undefined) continue;
+  for (const [from, step] of Object.entries(flow.steps)) {
+    if (step.on?.next !== undefined) continue;
 
-    for (let j = i + 1; j < walk.length; j++) {
+    const at = walk.indexOf(from);
+    // Absent from `order`, so the resolver has nothing to walk and ends the
+    // flow -- the same `END` it returns past the last ordered step. Drawing
+    // nothing here would leave the step looking like a dead end on a graph
+    // whose whole job is to show where a flow goes.
+    if (at === -1) {
+      edges.push({ from, to: END, kind: 'order' });
+      continue;
+    }
+
+    let ends = true;
+    for (let j = at + 1; j < walk.length; j++) {
       const to = walk[j];
       if (to === undefined) continue;
       const target = flow.steps[to];
@@ -199,8 +214,12 @@ function fallThroughEdges(flow: FlowDefinition): GraphEdge[] {
         kind: 'order',
         ...(target.when !== undefined && { when: target.when }),
       });
-      if (target.when === undefined) break;
+      if (target.when === undefined) {
+        ends = false;
+        break;
+      }
     }
+    if (ends) edges.push({ from, to: END, kind: 'order' });
   }
   return edges;
 }


### PR DESCRIPTION
The graph builder drew no edge for a step with no `on.next`. The resolver
disagrees, in two places:

- `firstReachable` returns `END` once it walks off the end of `order`
- `resolveNext` returns `END` immediately when `order.indexOf(current)` is `-1`

Both showed up as steps with no outgoing edge -- dead ends on a graph whose
only job is to show where a flow goes. The second is the worse one: a step
deliberately left out of `order` is exactly the branch someone opens the graph
to understand.

## Three ways a flow ends, matching the engine

| | |
| --- | --- |
| past the last ordered step | `review -> @end` |
| from a step outside `order` | `retry -> @end` |
| past a tail of conditional steps | they can all be false, so the one before them can be last |

The end edge carries no `when`. Labelling it would mean negating every guard it
skipped past, and a synthesized compound predicate on a drawing is harder to
trust than an unlabelled fallback arrow.

## The test that found it

Four existing tests asserted that no terminal node appears. They encoded the
old, wrong behaviour and now assert the new one -- with the case that genuinely
never ends, every step routing explicitly in a loop, put in their place.

Added alongside them: the graph's outgoing edges must contain whatever
`resolveNext` actually returns, for every step, across four scopes. Case-by-case
tests say the builder does what was written down; this one says what was
written down matches the engine, which is how the missing edges surfaced.

27 tests in the file, 214 in the suite. `core-v1 graph` at 754 B against its
800 B ratchet; the v1 engine entry is untouched at 3.88 kB.