### PR TITLE
feat(core): add the recorded-session checker

### DIFF
--- a/packages/core/src/v1/session.test.ts
+++ b/packages/core/src/v1/session.test.ts
@@ -1,0 +1,208 @@
+import { describe, expect, it } from 'vitest';
+
+import type { FlowDefinition } from './flow';
+import { checkSession, type RecordedSession } from './session';
+import { initialState, type WizardState } from './state';
+import type { FlowProblem } from './validate-flow';
+
+const passenger: FlowDefinition = {
+  id: 'passenger',
+  order: ['name', 'age'],
+  steps: { name: {}, age: {} },
+};
+
+// The fixture carries a `repeat` on purpose: iteration state lives in the frame
+// (`Frame.i`), so a checker that never sees one is a checker the flagship demo
+// would walk straight past.
+const booking: FlowDefinition = {
+  id: 'booking',
+  version: 2,
+  order: ['who', 'passengers', 'pay'],
+  steps: {
+    who: {},
+    passengers: { flow: passenger, repeat: { over: { $get: 'data.passengers' } } },
+    pay: {},
+  },
+};
+
+const frame = (over: Partial<WizardState>): WizardState => ({
+  ...initialState(),
+  status: 'idle',
+  ...over,
+});
+
+const clean: RecordedSession = {
+  flow: 'booking',
+  version: 2,
+  frames: [
+    frame({ stack: [{ flow: 'booking', step: 'who' }], visited: ['who'], rev: 1, nav: 1 }),
+    frame({
+      stack: [
+        { flow: 'booking', step: 'passengers', i: 0 },
+        { flow: 'passenger', step: 'name' },
+      ],
+      visited: ['who', 'passengers', 'name'],
+      rev: 2,
+      nav: 2,
+    }),
+    frame({
+      stack: [
+        { flow: 'booking', step: 'passengers', i: 1 },
+        { flow: 'passenger', step: 'name' },
+      ],
+      visited: ['who', 'passengers', 'name'],
+      rev: 3,
+      nav: 3,
+    }),
+    frame({
+      stack: [{ flow: 'booking', step: 'pay' }],
+      visited: ['who', 'passengers', 'name', 'pay'],
+      rev: 4,
+      nav: 4,
+    }),
+  ],
+};
+
+/** A session built from `clean` with one frame swapped for a broken one. */
+const withFrame = (index: number, over: Partial<WizardState>): RecordedSession => ({
+  ...clean,
+  frames: clean.frames.map((f, i) => (i === index ? { ...f, ...over } : f)),
+});
+
+const messages = (problems: readonly FlowProblem[]): string =>
+  problems.map((p) => `${p.path}: ${p.message}`).join('\n');
+
+describe('a recording that still matches its flow', () => {
+  it('reports nothing, repeat iterations and sub-flow frames included', () => {
+    expect(checkSession(clean, booking)).toEqual([]);
+  });
+
+  it('accepts a single-frame recording', () => {
+    const one = { ...clean, frames: clean.frames.slice(0, 1) };
+    expect(checkSession(one, booking)).toEqual([]);
+  });
+});
+
+describe('drift (E6)', () => {
+  // The failure this whole module exists to prevent: a scrubber stepping
+  // through a recording of another flow renders a plausible lie.
+  it('names a recording made against a different flow', () => {
+    const problems = checkSession({ ...clean, flow: 'checkout' }, booking);
+    expect(problems).not.toEqual([]);
+    expect(messages(problems)).toContain('this recording does not match this flow');
+    expect(messages(problems)).toContain('checkout');
+  });
+
+  it('names a recording made against an older version of the same flow', () => {
+    const problems = checkSession({ ...clean, version: 1 }, booking);
+    expect(messages(problems)).toContain('this recording does not match this flow');
+    expect(messages(problems)).toContain('version 1');
+  });
+
+  it('stays quiet when either side left the version unstamped', () => {
+    expect(checkSession({ ...clean, version: undefined }, booking)).toEqual([]);
+    expect(checkSession(clean, { ...booking, version: undefined })).toEqual([]);
+  });
+
+  it('rejects a frame whose step is not in the flow it names', () => {
+    const problems = checkSession(
+      withFrame(0, { stack: [{ flow: 'booking', step: 'seats' }], visited: ['seats'] }),
+      booking
+    );
+    expect(messages(problems)).toContain('seats');
+  });
+
+  it('rejects a frame naming a flow nobody supplied', () => {
+    const problems = checkSession(
+      withFrame(0, { stack: [{ flow: 'loyalty', step: 'tier' }], visited: ['tier'] }),
+      booking
+    );
+    expect(messages(problems)).toContain('unknown flow: loyalty');
+  });
+});
+
+describe('sub-flows by reference', () => {
+  const byRef: FlowDefinition = {
+    ...booking,
+    steps: {
+      ...booking.steps,
+      passengers: { flow: 'passenger', repeat: { over: { $get: 'data.passengers' } } },
+    },
+  };
+
+  it('cannot verify a referenced sub-flow without the registry, and says so', () => {
+    expect(messages(checkSession(clean, byRef))).toContain('unknown flow: passenger');
+  });
+
+  it('verifies it once the registry supplies it', () => {
+    expect(checkSession(clean, byRef, { passenger })).toEqual([]);
+  });
+});
+
+describe('frames that could not have come from the engine', () => {
+  it('rejects a rev that moves backwards', () => {
+    expect(messages(checkSession(withFrame(2, { rev: 1 }), booking))).toContain('frames[2].rev');
+  });
+
+  it('rejects a nav that moves backwards', () => {
+    expect(messages(checkSession(withFrame(2, { nav: 1 }), booking))).toContain('frames[2].nav');
+  });
+
+  it('allows a rev that stands still between frames', () => {
+    expect(checkSession(withFrame(2, { rev: 2, nav: 2 }), booking)).toEqual([]);
+  });
+
+  // `visited` is what `select.ts` reads to colour a breadcrumb. A current step
+  // missing from it mis-highlights every frame after it.
+  it('rejects a current step missing from visited', () => {
+    expect(messages(checkSession(withFrame(3, { visited: ['who'] }), booking))).toContain(
+      'current step'
+    );
+  });
+
+  it('rejects an empty stack outside init', () => {
+    expect(messages(checkSession(withFrame(1, { stack: [], visited: [] }), booking))).toContain(
+      'stack'
+    );
+  });
+
+  it('accepts an empty stack while the wizard is still initialising', () => {
+    const boot: RecordedSession = {
+      flow: 'booking',
+      version: 2,
+      frames: [initialState(), ...clean.frames],
+    };
+    expect(checkSession(boot, booking)).toEqual([]);
+  });
+
+  it('rejects an iteration index on a step that is not a repeat group', () => {
+    const problems = checkSession(
+      withFrame(0, { stack: [{ flow: 'booking', step: 'who', i: 0 }], visited: ['who'] }),
+      booking
+    );
+    expect(messages(problems)).toContain('not a repeat group');
+  });
+});
+
+describe('recordings that are not recordings', () => {
+  it('reports an empty recording rather than replaying nothing', () => {
+    expect(messages(checkSession({ ...clean, frames: [] }, booking))).toContain('no frames');
+  });
+
+  // A recording is JSON off a disk or a wire. It gets to be any shape at all.
+  it('survives a truncated frame and names it', () => {
+    const truncated = {
+      ...clean,
+      frames: [clean.frames[0], { stack: [{ flow: 'booking', step: 'who' }] }],
+    } as unknown as RecordedSession;
+    const problems = checkSession(truncated, booking);
+    expect(messages(problems)).toContain('frames[1]');
+    expect(messages(problems)).toContain('corrupt');
+  });
+
+  it('survives frames that are not objects at all', () => {
+    const junk = { ...clean, frames: [null, 'nope', 7] } as unknown as RecordedSession;
+    expect(() => checkSession(junk, booking)).not.toThrow();
+    expect(checkSession(junk, booking)).toHaveLength(3);
+  });
+});

--- a/packages/core/src/v1/session.ts
+++ b/packages/core/src/v1/session.ts
@@ -1,0 +1,171 @@
+import { isGroup, type FlowDefinition } from './flow';
+
+import type { WizardState } from './state';
+import type { FlowProblem } from './validate-flow';
+
+/**
+ * A recorded run of a flow: the frames a scrubber replays, plus enough identity
+ * to tell whether they still belong to the flow being replayed.
+ *
+ * Pure JSON, like the flow itself. A recording is written by hand for a demo or
+ * dumped from a running wizard, and nothing downstream can tell which.
+ */
+export interface RecordedSession {
+  /** Id of the flow this was recorded against. */
+  flow: string;
+  /** `FlowDefinition.version` at record time. Absent means the producer stamped none. */
+  version?: number;
+  /** Snapshots in the order they were taken. */
+  frames: readonly WizardState[];
+}
+
+/** Same cap as the graph builder: thirty-two distinct flows deep is not nesting. */
+const MAX_DEPTH = 32;
+
+/** Every flow a frame may legitimately name: the root, its inline sub-flows, the registry. */
+function knownFlows(
+  flow: FlowDefinition,
+  subFlows: Readonly<Record<string, FlowDefinition>> | undefined
+): Map<string, FlowDefinition> {
+  const known = new Map<string, FlowDefinition>();
+  for (const [id, def] of Object.entries(subFlows ?? {})) known.set(id, def);
+
+  const seen = new Set<FlowDefinition>();
+  const walk = (f: FlowDefinition, depth: number): void => {
+    if (seen.has(f) || depth > MAX_DEPTH) return;
+    seen.add(f);
+    known.set(f.id, f);
+    for (const step of Object.values(f.steps)) {
+      if (isGroup(step) && typeof step.flow !== 'string') walk(step.flow, depth + 1);
+    }
+  };
+  walk(flow, 0);
+
+  return known;
+}
+
+/**
+ * A recording arrives as JSON, so it gets to be any shape at all. Checked
+ * against what this module actually reads, not against the whole of
+ * `WizardState` — a field nobody looks at cannot mis-render anything.
+ */
+function isFrameShaped(frame: unknown): frame is WizardState {
+  if (frame === null || typeof frame !== 'object') return false;
+  const f = frame as Partial<WizardState>;
+  return (
+    Array.isArray(f.stack) &&
+    Array.isArray(f.visited) &&
+    typeof f.status === 'string' &&
+    typeof f.rev === 'number' &&
+    typeof f.nav === 'number'
+  );
+}
+
+/**
+ * Checks a recording before a scrubber is allowed to replay it.
+ *
+ * The failure this exists to catch is drift: a recording made against an older
+ * flow still renders. Every frame draws, every breadcrumb lights up, and the
+ * whole thing is a plausible lie — the worst kind of bug, because nothing looks
+ * broken. So identity is checked first, and the frames are checked against the
+ * flow they claim to come from rather than against themselves.
+ *
+ * Pure, and never throws: a bad recording is reported the way a bad flow is,
+ * in the same `FlowProblem` register `validateFlow` uses.
+ */
+export function checkSession(
+  session: RecordedSession,
+  flow: FlowDefinition,
+  subFlows?: Readonly<Record<string, FlowDefinition>>
+): FlowProblem[] {
+  const problems: FlowProblem[] = [];
+  const report = (path: string, message: string): void => {
+    problems.push({ path, message });
+  };
+  const drift = 'this recording does not match this flow';
+
+  if (session.flow !== flow.id) {
+    report('flow', `${drift}: recorded against ${session.flow}, replayed against ${flow.id}`);
+  }
+  // Only when both sides stamped one. An unstamped producer is a gap in the
+  // recording, not evidence of drift, and reporting it would train people to
+  // ignore the one message that matters.
+  if (
+    session.version !== undefined &&
+    flow.version !== undefined &&
+    session.version !== flow.version
+  ) {
+    report(
+      'version',
+      `${drift}: recorded against version ${session.version}, flow is version ${flow.version}`
+    );
+  }
+
+  if (!Array.isArray(session.frames) || session.frames.length === 0) {
+    report('frames', 'recording has no frames');
+    return problems;
+  }
+
+  const known = knownFlows(flow, subFlows);
+  let previous: WizardState | undefined;
+
+  session.frames.forEach((frame, index) => {
+    const at = `frames[${index}]`;
+
+    if (!isFrameShaped(frame)) {
+      report(at, 'is not a wizard state — the recording is truncated or corrupt');
+      return;
+    }
+
+    // `rev` is the memoization key for every selector and `nav` the epoch token
+    // that defeats races. Either moving backwards is a state the engine could
+    // not have produced, so the frames were reordered or spliced.
+    if (previous !== undefined) {
+      if (frame.rev < previous.rev) {
+        report(`${at}.rev`, `moves backwards: ${previous.rev} then ${frame.rev}`);
+      }
+      if (frame.nav < previous.nav) {
+        report(`${at}.nav`, `moves backwards: ${previous.nav} then ${frame.nav}`);
+      }
+    }
+    previous = frame;
+
+    if (frame.stack.length === 0) {
+      if (frame.status !== 'init') {
+        report(`${at}.stack`, `is empty, but status is ${frame.status}`);
+      }
+      return;
+    }
+
+    frame.stack.forEach((entry, depth) => {
+      const path = `${at}.stack[${depth}]`;
+      const owner = known.get(entry.flow);
+      if (owner === undefined) {
+        report(path, `names an unknown flow: ${entry.flow}`);
+        return;
+      }
+
+      const step = owner.steps[entry.step];
+      if (step === undefined) {
+        report(path, `names a step ${entry.flow} does not have: ${entry.step}`);
+        return;
+      }
+
+      if (entry.i === undefined) return;
+      if (!Number.isInteger(entry.i) || entry.i < 0) {
+        report(`${path}.i`, `is not an iteration index: ${entry.i}`);
+      } else if (!isGroup(step) || step.repeat === undefined) {
+        report(`${path}.i`, `has an iteration index, but ${entry.step} is not a repeat group`);
+      }
+    });
+
+    // `select.ts` reads `visited` to colour every breadcrumb. A current step
+    // missing from it mis-highlights this frame and every frame after it.
+    const current = frame.stack[frame.stack.length - 1];
+    if (current !== undefined && !frame.visited.includes(current.step)) {
+      report(`${at}.visited`, `does not contain the current step: ${current.step}`);
+    }
+  });
+
+  return problems;
+}


### PR DESCRIPTION
Closes the last silent failure the flow inspector design registers: **E6, fixture/graph drift**.

A recording made against an older flow still renders. Frames draw, breadcrumbs light up, and the scrubber shows a plausible lie. Nothing looks broken, which is what makes it the worst one in the table.

## What lands

`packages/core/src/v1/session.ts`:

```ts
interface RecordedSession { flow: string; version?: number; frames: readonly WizardState[] }
function checkSession(session, flow, subFlows?): FlowProblem[]
```

Identity first — flow id, and version when both sides stamped one. An unstamped producer is a gap in the recording, not evidence of drift, so it stays quiet rather than training people to ignore the one message that matters.

Then the frames, checked against the flow they claim to come from rather than against each other:

- every `stack` entry names a step its flow actually has
- `rev` and `nav` never move backwards — either one going back is a state the engine could not have produced
- the current step is in `visited`, which is what `select.ts` reads to colour every breadcrumb
- an iteration index only sits on a `repeat` group
- a frame that is not a wizard state at all is named, not thrown on — a recording is JSON off a disk

Pure, never throws, same `FlowProblem` register as `validateFlow`. Sub-flows resolve from inline definitions or an optional registry, mirroring `buildGraph(flow, subFlows?)`; one that cannot be resolved is reported, never skipped.

## Tests

19 new, covering the design's gaps 21-25 plus drift and sub-flow resolution. The fixture carries a `repeat` with two iterations — iteration state lives in the frame, so a checker that never sees one is a checker the demo walks straight past.

Full suite: 233 passing, lint clean, types and formatting green.

## Not in this PR

No tsup entry, subpath export or `.size-limit.js` ratchet yet. Those land with the rest of the inspector wiring, so the budget for the new entry gets set in one place instead of two.
