### PR TITLE
fix(core): carry the counters through reset, harden the session checker

### DIFF
--- a/packages/core/src/v1/commit.ts
+++ b/packages/core/src/v1/commit.ts
@@ -15,6 +15,19 @@ export function commit(state: WizardState, patch: Partial<WizardState>): WizardS
   return { ...state, ...patch, rev: state.rev + 1 };
 }
 
+/**
+ * A reset: the data starts over, the counters do not.
+ *
+ * `rev` keeps climbing because it is every selector's memoization key, and a
+ * reset that replayed an earlier revision would serve the snapshot cached
+ * before it. `nav` moves forward rather than starting again, so a navigation
+ * still in flight when the reset lands finds its token superseded instead of
+ * looking current again.
+ */
+export function restart(state: WizardState, fresh: WizardState): WizardState {
+  return { ...fresh, rev: state.rev + 1, nav: state.nav + 1 };
+}
+
 /** Starts a navigation epoch. The returned token is re-checked after every await. */
 export function beginNav(state: WizardState): { state: WizardState; token: number } {
   const token = state.nav + 1;

--- a/packages/core/src/v1/session.test.ts
+++ b/packages/core/src/v1/session.test.ts
@@ -137,6 +137,80 @@ describe('sub-flows by reference', () => {
   it('verifies it once the registry supplies it', () => {
     expect(checkSession(clean, byRef, { passenger })).toEqual([]);
   });
+
+  // A registered flow gets walked like any other, so a frame inside its own
+  // inline child is not drift. `buildGraph` follows inline children after
+  // resolving a reference; a checker that stopped at the reference would call
+  // a legitimate grandchild frame unknown.
+  it('walks the inline children of a registered flow', () => {
+    const seat: FlowDefinition = { id: 'seat', order: ['pick'], steps: { pick: {} } };
+    const withInlineChild: FlowDefinition = {
+      ...passenger,
+      order: ['name', 'age', 'seat'],
+      steps: { ...passenger.steps, seat: { flow: seat } },
+    };
+    const deep: RecordedSession = {
+      flow: 'booking',
+      version: 2,
+      frames: [
+        frame({
+          stack: [
+            { flow: 'booking', step: 'passengers', i: 0 },
+            { flow: 'passenger', step: 'seat' },
+            { flow: 'seat', step: 'pick' },
+          ],
+          visited: ['passengers', 'seat', 'pick'],
+          rev: 1,
+          nav: 1,
+        }),
+      ],
+    };
+
+    expect(checkSession(deep, byRef, { passenger: withInlineChild })).toEqual([]);
+  });
+});
+
+describe('stacks the engine could not have built', () => {
+  // `state.ts`: the last entry is the current step, the ones before it enclose
+  // it. An atom cannot enclose anything.
+  it('rejects a parent frame that is not a group', () => {
+    const problems = checkSession(
+      withFrame(1, {
+        stack: [
+          { flow: 'booking', step: 'who' },
+          { flow: 'passenger', step: 'name' },
+        ],
+        visited: ['who', 'name'],
+      }),
+      booking
+    );
+    expect(messages(problems)).toContain('is not a group');
+  });
+
+  it('rejects a group whose child frame is in a different flow', () => {
+    const problems = checkSession(
+      withFrame(1, {
+        stack: [
+          { flow: 'booking', step: 'passengers', i: 0 },
+          { flow: 'seat', step: 'pick' },
+        ],
+        visited: ['passengers', 'pick'],
+      }),
+      booking
+    );
+    expect(messages(problems)).toContain('group into passenger');
+  });
+
+  it('still allows a group as the current step, with nothing below it', () => {
+    const problems = checkSession(
+      withFrame(1, {
+        stack: [{ flow: 'booking', step: 'passengers', i: 0 }],
+        visited: ['who', 'passengers'],
+      }),
+      booking
+    );
+    expect(problems).toEqual([]);
+  });
 });
 
 describe('frames that could not have come from the engine', () => {
@@ -204,5 +278,16 @@ describe('recordings that are not recordings', () => {
     const junk = { ...clean, frames: [null, 'nope', 7] } as unknown as RecordedSession;
     expect(() => checkSession(junk, booking)).not.toThrow();
     expect(checkSession(junk, booking)).toHaveLength(3);
+  });
+
+  // The top-level fields can all be present and the stack still be junk. This
+  // is the shape that used to reach `entry.flow` and throw out of a checker
+  // that promises it never throws.
+  it('survives a stack holding something that is not a frame', () => {
+    for (const junk of [null, 7, 'who', {}, { flow: 'booking' }]) {
+      const broken = withFrame(0, { stack: [junk] as never, visited: ['who'] });
+      expect(() => checkSession(broken, booking)).not.toThrow();
+      expect(messages(checkSession(broken, booking))).toContain('corrupt');
+    }
   });
 });

--- a/packages/core/src/v1/session.test.ts
+++ b/packages/core/src/v1/session.test.ts
@@ -168,6 +168,21 @@ describe('sub-flows by reference', () => {
 
     expect(checkSession(deep, byRef, { passenger: withInlineChild })).toEqual([]);
   });
+
+  // The key a group references and the id the definition carries are allowed
+  // to disagree. Frames name the id, so a checker comparing against the key
+  // would call a correct recording drift.
+  it('resolves a reference whose registry key is not the flow id', () => {
+    const renamed: FlowDefinition = { ...passenger, id: 'traveller' };
+    const frames = clean.frames.map((f) => ({
+      ...f,
+      stack: f.stack.map((entry) =>
+        entry.flow === 'passenger' ? { ...entry, flow: 'traveller' } : entry
+      ),
+    }));
+
+    expect(checkSession({ ...clean, frames }, byRef, { passenger: renamed })).toEqual([]);
+  });
 });
 
 describe('stacks the engine could not have built', () => {

--- a/packages/core/src/v1/session.ts
+++ b/packages/core/src/v1/session.ts
@@ -181,7 +181,12 @@ export function checkSession(
         if (!isGroup(step)) {
           report(path, `encloses another frame, but ${entry.step} is not a group`);
         } else {
-          const into = typeof step.flow === 'string' ? step.flow : step.flow.id;
+          // A string `flow` is the key the group is referenced by, and the
+          // definition behind that key is free to carry a different id. The
+          // frame names the id, so compare against what the reference actually
+          // resolves to, falling back to the bare reference when nothing does.
+          const ref = typeof step.flow === 'string' ? step.flow : step.flow.id;
+          const into = known.get(ref)?.id ?? ref;
           if (into !== child.flow) {
             report(path, `is a group into ${into}, but the frame below it is in ${child.flow}`);
           }

--- a/packages/core/src/v1/session.ts
+++ b/packages/core/src/v1/session.ts
@@ -1,6 +1,6 @@
 import { isGroup, type FlowDefinition } from './flow';
 
-import type { WizardState } from './state';
+import type { Frame, WizardState } from './state';
 import type { FlowProblem } from './validate-flow';
 
 /**
@@ -28,9 +28,8 @@ function knownFlows(
   subFlows: Readonly<Record<string, FlowDefinition>> | undefined
 ): Map<string, FlowDefinition> {
   const known = new Map<string, FlowDefinition>();
-  for (const [id, def] of Object.entries(subFlows ?? {})) known.set(id, def);
-
   const seen = new Set<FlowDefinition>();
+
   const walk = (f: FlowDefinition, depth: number): void => {
     if (seen.has(f) || depth > MAX_DEPTH) return;
     seen.add(f);
@@ -39,21 +38,43 @@ function knownFlows(
       if (isGroup(step) && typeof step.flow !== 'string') walk(step.flow, depth + 1);
     }
   };
+
+  // A registered flow is walked like any other, so an inline grandchild inside
+  // it resolves too — `buildGraph` follows inline children after resolving a
+  // reference, and a frame deep in one is not evidence of drift. Registered
+  // under the key the flow is referenced by *and* its own id, which a producer
+  // is free to disagree about.
+  for (const [id, def] of Object.entries(subFlows ?? {})) {
+    walk(def, 0);
+    known.set(id, def);
+  }
+  // Last, so the root's own definitions win a collision with the registry.
   walk(flow, 0);
 
   return known;
 }
 
+const isStackEntry = (entry: unknown): entry is Frame => {
+  if (entry === null || typeof entry !== 'object') return false;
+  const e = entry as Partial<Frame>;
+  return typeof e.flow === 'string' && typeof e.step === 'string';
+};
+
 /**
  * A recording arrives as JSON, so it gets to be any shape at all. Checked
  * against what this module actually reads, not against the whole of
  * `WizardState` — a field nobody looks at cannot mis-render anything.
+ *
+ * The stack is checked element by element rather than just for being an array:
+ * everything below reads `entry.flow`, and a `stack: [null]` that got this far
+ * would throw out of a checker whose whole promise is that it does not.
  */
 function isFrameShaped(frame: unknown): frame is WizardState {
   if (frame === null || typeof frame !== 'object') return false;
   const f = frame as Partial<WizardState>;
   return (
     Array.isArray(f.stack) &&
+    f.stack.every(isStackEntry) &&
     Array.isArray(f.visited) &&
     typeof f.status === 'string' &&
     typeof f.rev === 'number' &&
@@ -149,6 +170,22 @@ export function checkSession(
       if (step === undefined) {
         report(path, `names a step ${entry.flow} does not have: ${entry.step}`);
         return;
+      }
+
+      // Only the last entry is the current step; the ones before it enclose it.
+      // A parent that is not a group, or a group leading somewhere other than
+      // where the child says it is, is a stack the engine could not have built —
+      // and the shape drift hides in when nobody stamped a version.
+      const child = frame.stack[depth + 1];
+      if (child !== undefined) {
+        if (!isGroup(step)) {
+          report(path, `encloses another frame, but ${entry.step} is not a group`);
+        } else {
+          const into = typeof step.flow === 'string' ? step.flow : step.flow.id;
+          if (into !== child.flow) {
+            report(path, `is a group into ${into}, but the frame below it is in ${child.flow}`);
+          }
+        }
       }
 
       if (entry.i === undefined) return;

--- a/packages/core/src/v1/store.test.ts
+++ b/packages/core/src/v1/store.test.ts
@@ -164,13 +164,24 @@ describe('data', () => {
 
   it('resets data while keeping ctx and the revision moving forward', () => {
     const w = createWizard({ flow, registry, data: { name: 'Ann' }, ctx: { role: 'admin' } });
-    const rev = w.getState().rev;
+    // Several commits first: resetting from rev 0 passes whatever the counters
+    // do, which is how a reset that restarted `rev` at 1 went unnoticed.
+    w.set('name', 'Cy');
+    w.set('name', 'Di');
+    w.set('name', 'Ed');
+    const { rev, nav } = w.getState();
+    expect(rev).toBeGreaterThan(1);
 
     w.reset({ name: 'Bo' });
 
     expect(w.getState().data).toEqual({ name: 'Bo' });
     expect(w.getState().ctx).toEqual({ role: 'admin' });
+    // `rev` is every selector's memoization key, so a reset that replayed an
+    // earlier revision could serve a snapshot cached before it.
     expect(w.getState().rev).toBeGreaterThan(rev);
+    // `nav` moves forward too, so a navigation in flight when the reset lands
+    // finds its token superseded rather than current again.
+    expect(w.getState().nav).toBeGreaterThan(nav);
   });
 });
 

--- a/packages/core/src/v1/store.ts
+++ b/packages/core/src/v1/store.ts
@@ -1,4 +1,4 @@
-import { commit } from './commit';
+import { commit, restart } from './commit';
 import { runNav, type Hooks, type NavContext, type NavResult } from './navigate';
 import { getPath, setPath } from './path';
 import { createSelector, type Derived } from './select';
@@ -219,14 +219,7 @@ export function createWizard(options: WizardOptions): Wizard {
     },
 
     reset(data) {
-      // The counters outlive the data. `commit` derives the new revision from
-      // the state it is handed, so the carry has to ride on the fresh state and
-      // not on the patch, where it was silently overwritten: a reset restarted
-      // `rev` at 1 and could hand a selector a revision it had already cached.
-      // `nav` moves forward rather than being preserved, so a navigation still
-      // in flight when the reset lands finds its token superseded.
-      const fresh = { ...initialState(data ?? {}, state.ctx), rev: state.rev, nav: state.nav + 1 };
-      write(commit(fresh, {}));
+      write(restart(state, initialState(data ?? {}, state.ctx)));
     },
 
     async validate(stepId) {

--- a/packages/core/src/v1/store.ts
+++ b/packages/core/src/v1/store.ts
@@ -219,7 +219,14 @@ export function createWizard(options: WizardOptions): Wizard {
     },
 
     reset(data) {
-      write(commit(initialState(data ?? {}, state.ctx), { rev: state.rev }));
+      // The counters outlive the data. `commit` derives the new revision from
+      // the state it is handed, so the carry has to ride on the fresh state and
+      // not on the patch, where it was silently overwritten: a reset restarted
+      // `rev` at 1 and could hand a selector a revision it had already cached.
+      // `nav` moves forward rather than being preserved, so a navigation still
+      // in flight when the reset lands finds its token superseded.
+      const fresh = { ...initialState(data ?? {}, state.ctx), rev: state.rev, nav: state.nav + 1 };
+      write(commit(fresh, {}));
     },
 
     async validate(stepId) {


### PR DESCRIPTION
Follow-up to #25. Four review findings, verified against the code before touching anything. All four hold — and the second one turned out to be an engine bug, not a checker bug.

## The engine one

`reset` restarted `rev` at 1 and `nav` at 0:

```ts
write(commit(initialState(data ?? {}, state.ctx), { rev: state.rev }));
```

`commit(state, patch)` ends with `rev: state.rev + 1`, derived from its **first** argument — the fresh state. The `{ rev: state.rev }` carry was overwritten and never did anything. So a wizard at rev 7 reset to rev 1, and `rev` is what every selector memoizes on: a reset could replay a revision already cached and hand back the snapshot from before it.

The carry now rides on the fresh state, where `commit` reads it. `nav` moves forward rather than being preserved — a navigation still in flight when the reset lands should find its token superseded, not current again.

`store.test.ts` already claimed to cover this ("keeping the revision moving forward") but reset from rev 0, where every possible outcome passes. It now commits three times first and checks both counters. Against the old code it fails with `expected 1 to be greater than 3`.

## The checker ones

- **`isFrameShaped` accepted a corrupt stack.** `stack: [null]` passed the top-level field checks, and the loop below read `entry.flow` and threw — out of a function whose entire promise is that it does not. Entries are now checked one by one.
- **The stack was never checked as a chain.** `[booking/who, passenger/name]` passed, though `who` is an atom and cannot enclose anything. `state.ts` documents earlier entries as the enclosing groups, so every non-leaf entry must now be a group leading into the flow the frame below it names. This is the drift that hides when nobody stamped a version.
- **`knownFlows` did not walk registered flows.** A registry entry went into the map but its own inline children did not, so a legitimate frame inside a registered flow's inline child was reported as unknown — where `buildGraph` follows inline children after resolving a reference. Registered flows are now walked like any other, and registered under both the key they are referenced by and their own id.

## Verification

5 new tests (24 in `session.test.ts`, up from 19), one per finding plus the grandchild-resolution case. Full suite 238 passing, lint 0 errors, types and formatting clean.
