### PR TITLE
feat(core): start the wizard on mount

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -24,7 +24,12 @@ export default [
   // Group and repeat traversal is not in this entry and never will be: it goes
   // behind its own export, so a flow that has no sub-flows pays nothing for the
   // machinery that walks them. That is what keeps the main entry inside 4 kB.
-  { name: 'core-v1', path: 'packages/core/src/v1/index.ts', limit: '3.9 kB', gzip: true },
+  //
+  // Raised from 3.9 kB to the roadmap's 4.0 kB on 2026-09-06 for `start`: a
+  // fresh engine has an empty stack, so before it existed a binding rendered
+  // nothing until the user pressed Next. Twenty-one bytes for the difference
+  // between a wizard that shows its first step and one that shows nothing.
+  { name: 'core-v1', path: 'packages/core/src/v1/index.ts', limit: '4 kB', gzip: true },
 
   // The graph builder. Its own entry for the same reason validate-flow is:
   // structure-only drawing is a development and inspection concern, and a

--- a/contract/binding-suite.ts
+++ b/contract/binding-suite.ts
@@ -62,9 +62,11 @@ export function describeBindingContract(harness: BindingHarness): void {
     harness.mount({ flow, registry, data });
 
   describe(`binding contract: ${harness.name}`, () => {
-    it('renders the first step once the wizard starts', async () => {
+    it('is on the first step as soon as it mounts', async () => {
+      // No click. A binding starts the engine when it mounts, so the first
+      // paint already has a current step; a wizard that renders nothing until
+      // the user presses Next is the bug this case exists to catch.
       const probe = await mount();
-      await probe.click('next');
 
       expect(probe.text('step')).toBe('one');
       probe.unmount();
@@ -72,7 +74,6 @@ export function describeBindingContract(harness: BindingHarness): void {
 
     it('skips a step whose condition is false', async () => {
       const probe = await mount({ name: 'Ann', wantsTwo: false });
-      await probe.click('next');
       await probe.click('next');
 
       expect(probe.text('step')).toBe('three');
@@ -82,7 +83,6 @@ export function describeBindingContract(harness: BindingHarness): void {
     it('includes a step once its condition becomes true, without a reload', async () => {
       const probe = await mount({ name: 'Ann', wantsTwo: true });
       await probe.click('next');
-      await probe.click('next');
 
       expect(probe.text('step')).toBe('two');
       probe.unmount();
@@ -90,7 +90,6 @@ export function describeBindingContract(harness: BindingHarness): void {
 
     it('reports progress over the reachable steps only', async () => {
       const probe = await mount({ name: 'Ann', wantsTwo: false });
-      await probe.click('next');
       expect(probe.text('progress')).toBe('0');
 
       await probe.click('next');
@@ -100,7 +99,6 @@ export function describeBindingContract(harness: BindingHarness): void {
 
     it('goes back, and says so before you try', async () => {
       const probe = await mount({ name: 'Ann', wantsTwo: false });
-      await probe.click('next');
       expect(probe.text('can-back')).toBe('no');
 
       await probe.click('next');
@@ -114,7 +112,6 @@ export function describeBindingContract(harness: BindingHarness): void {
     it('blocks a forward move on invalid data and surfaces the errors', async () => {
       const probe = await mount({});
       await probe.click('next');
-      await probe.click('next');
 
       expect(probe.text('step')).toBe('one');
       expect(probe.text('errors')).toBe('name: required');
@@ -123,7 +120,6 @@ export function describeBindingContract(harness: BindingHarness): void {
 
     it('clears the block once the field is filled', async () => {
       const probe = await mount({});
-      await probe.click('next');
       await probe.click('next');
       await probe.fill('name-input', 'Ann');
       await probe.click('next');

--- a/packages/core/src/v1/resolve.property.test.ts
+++ b/packages/core/src/v1/resolve.property.test.ts
@@ -5,6 +5,7 @@ import type { Expr, Scope } from './expr';
 import { END, type FlowDefinition, type StepDef } from './flow';
 import { reachable, resolveBack, resolveNext } from './resolve';
 import { initialState, type WizardState } from './state';
+import { createWizard } from './store';
 
 /**
  * Example-based tests check the cases someone thought of. These check the
@@ -269,6 +270,47 @@ describe('reachable — properties', () => {
         }
       }),
       { numRuns: 100 }
+    );
+  });
+});
+
+describe('start', () => {
+  /**
+   * `start` is `next` from an empty stack, so whatever holds for the resolver
+   * holds for it. These are the two properties a binding depends on: it lands
+   * where the flow says the first step is, and calling it again is not a move.
+   */
+  it('lands on the first reachable step, or finishes when there is none', async () => {
+    await fc.assert(
+      fc.asyncProperty(arbLinearFlow, async ({ flow, scope }) => {
+        const w = createWizard({ flow, data: scope.data as Record<string, unknown> });
+        const active = reachable(flow, scope);
+
+        await w.start();
+
+        const current = w.getSnapshot().current;
+        if (active.length === 0) {
+          expect(current).toBeNull();
+          expect(w.getState().status).toBe('done');
+        } else {
+          expect(current).toBe(active[0]);
+        }
+      })
+    );
+  });
+
+  it('is idempotent for any flow: a second call commits nothing', async () => {
+    await fc.assert(
+      fc.asyncProperty(arbBranchingFlow, async ({ flow, scope }) => {
+        const w = createWizard({ flow, data: scope.data as Record<string, unknown> });
+        await w.start();
+        const { rev, stack } = w.getState();
+
+        await w.start();
+
+        expect(w.getState().rev).toBe(rev);
+        expect(w.getState().stack).toEqual(stack);
+      })
     );
   });
 });

--- a/packages/core/src/v1/store.test.ts
+++ b/packages/core/src/v1/store.test.ts
@@ -314,3 +314,28 @@ describe('start', () => {
     expect(w.getSnapshot().errors).toEqual({});
   });
 });
+
+describe('start under concurrency', () => {
+  it('runs the pipeline once when two mounts race', async () => {
+    let entered = 0;
+    const w = createWizard({
+      flow,
+      registry,
+      data: { payer: 'private', name: 'Ann' },
+      plugins: [
+        {
+          name: 'count',
+          beforeNavigate: () => {
+            entered += 1;
+          },
+        },
+      ],
+    });
+
+    const [a, b] = await Promise.all([w.start(), w.start()]);
+
+    expect(entered).toBe(1);
+    expect(a).toEqual(b);
+    expect(w.getSnapshot().current).toBe('trip');
+  });
+});

--- a/packages/core/src/v1/store.test.ts
+++ b/packages/core/src/v1/store.test.ts
@@ -275,3 +275,42 @@ describe('patchFlow', () => {
     expect(w.getSnapshot().current).toBe('trip');
   });
 });
+
+describe('start', () => {
+  it('enters the first reachable step, which a fresh wizard is not on', () => {
+    const w = make();
+    expect(w.getSnapshot().current).toBeNull();
+
+    return w.start().then((r) => {
+      expect(r).toEqual({ ok: true, from: null, to: 'trip' });
+      expect(w.getSnapshot().current).toBe('trip');
+    });
+  });
+
+  it('is idempotent: a second call navigates nowhere', async () => {
+    const w = make();
+    await w.start();
+    const rev = w.getState().rev;
+
+    const again = await w.start();
+
+    expect(again).toEqual({ ok: true, from: 'trip', to: 'trip' });
+    expect(w.getState().rev).toBe(rev);
+  });
+
+  it('skips a step whose condition is false, like any other move', async () => {
+    const w = make({ payer: 'business', name: 'Ann' });
+    await w.start();
+    expect(w.getSnapshot().current).toBe('trip');
+  });
+
+  it('does not validate on the way in', async () => {
+    // Starting is not a step forward: an empty form must not open with errors
+    // on a field nobody has touched yet.
+    const w = make({});
+    await w.start();
+
+    expect(w.getSnapshot().current).toBe('trip');
+    expect(w.getSnapshot().errors).toEqual({});
+  });
+});

--- a/packages/core/src/v1/store.ts
+++ b/packages/core/src/v1/store.ts
@@ -1,11 +1,11 @@
 import { commit, restart } from './commit';
+import { END, type FlowDefinition, type StepDef } from './flow';
 import { runNav, type Hooks, type NavContext, type NavResult } from './navigate';
 import { getPath, setPath } from './path';
 import { createSelector, type Derived } from './select';
 import { initialState, type WizardState } from './state';
 
 import type { AsyncRegistry, Json, Scope } from './expr';
-import type { FlowDefinition, StepDef } from './flow';
 
 /**
  * The store.
@@ -92,6 +92,7 @@ export function createWizard(options: WizardOptions): Wizard {
   let batching = false;
   let dirtyWhileBatching = false;
   let controller: AbortController | undefined;
+  let starting: Promise<NavResult> | undefined;
   let snapshotRev = -1;
   let snapshot: Snapshot | undefined;
 
@@ -192,9 +193,30 @@ export function createWizard(options: WizardOptions): Wizard {
       // `next` from an empty stack resolves to the first reachable step, which
       // is exactly what starting means; the guard is only here so that calling
       // it twice - two mounts of the same wizard, say - is not a step forward.
-      const current = state.stack[state.stack.length - 1]?.step;
-      if (current !== undefined) return Promise.resolve({ ok: true, from: current, to: current });
-      return navigate({ type: 'next' }, { validate: false });
+      //
+      // The guard reads `status`, not the stack: a flow whose every step is
+      // unreachable finishes on the first start and leaves the stack empty
+      // again, and a second call must not walk it a second time.
+      // The in-flight check comes first. Phase 0 of the pipeline bumps the
+      // epoch synchronously, so by the time a second mount calls in, `status`
+      // already says busy while the first attempt has committed nothing yet -
+      // answering from `status` there would report a finished flow. Two mounts
+      // of one engine share one attempt, so an enter guard or a deferred step's
+      // loader runs once, not twice.
+      if (starting !== undefined) return starting;
+
+      // Read `status`, not the stack: a flow whose every step is unreachable
+      // finishes on the first start and leaves the stack empty again, and a
+      // second call must not walk it a second time.
+      const current = state.stack[state.stack.length - 1]?.step ?? null;
+      if (state.status !== 'init') {
+        return Promise.resolve({ ok: true, from: current, to: current ?? END });
+      }
+
+      starting = navigate({ type: 'next' }, { validate: false }).finally(() => {
+        starting = undefined;
+      });
+      return starting;
     },
     next: (opts) => navigate({ type: 'next' }, opts),
     back: () => navigate({ type: 'back' }),

--- a/packages/core/src/v1/store.ts
+++ b/packages/core/src/v1/store.ts
@@ -50,6 +50,12 @@ export interface Wizard {
   /** Calls back only when the value at a data path changes. */
   watch: (path: string, listener: (value: unknown) => void) => () => void;
 
+  /**
+   * Enters the first reachable step. A fresh wizard has an empty stack, so
+   * until this runs there is no current step and a UI has nothing to draw.
+   * Idempotent: once a step is current, this reports it and navigates nowhere.
+   */
+  start: () => Promise<NavResult>;
   next: (opts?: { validate?: boolean }) => Promise<NavResult>;
   back: () => Promise<NavResult>;
   go: (to: string, opts?: { validate?: boolean; force?: boolean }) => Promise<NavResult>;
@@ -182,6 +188,14 @@ export function createWizard(options: WizardOptions): Wizard {
       return () => listeners.delete(wrapped);
     },
 
+    start() {
+      // `next` from an empty stack resolves to the first reachable step, which
+      // is exactly what starting means; the guard is only here so that calling
+      // it twice - two mounts of the same wizard, say - is not a step forward.
+      const current = state.stack[state.stack.length - 1]?.step;
+      if (current !== undefined) return Promise.resolve({ ok: true, from: current, to: current });
+      return navigate({ type: 'next' }, { validate: false });
+    },
     next: (opts) => navigate({ type: 'next' }, opts),
     back: () => navigate({ type: 'back' }),
     go: (to, opts) => navigate({ type: 'go', to, force: opts?.force }, opts),

--- a/packages/react/src/v1/index.tsx
+++ b/packages/react/src/v1/index.tsx
@@ -12,6 +12,7 @@ import {
   createElement,
   useCallback,
   useContext,
+  useEffect,
   useRef,
   useState,
   useSyncExternalStore,
@@ -45,7 +46,17 @@ export function WizardProvider({ wizard, children, ...options }: WizardProviderP
   const [instance] = useState<Wizard>(
     () => wizard ?? createWizard(options as unknown as WizardOptions)
   );
-  return createElement(WizardContext.Provider, { value: wizard ?? instance }, children);
+  const engine = wizard ?? instance;
+
+  // A fresh engine has an empty stack, so without this the first paint has no
+  // current step and the tree below renders nothing. `start` is idempotent and
+  // the effect never runs on the server, which is where the wizard must not
+  // navigate at all.
+  useEffect(() => {
+    void engine.start();
+  }, [engine]);
+
+  return createElement(WizardContext.Provider, { value: engine }, children);
 }
 
 export function useWizard(): Wizard {

--- a/packages/react/src/v1/index.tsx
+++ b/packages/react/src/v1/index.tsx
@@ -13,6 +13,7 @@ import {
   useCallback,
   useContext,
   useEffect,
+  useLayoutEffect,
   useRef,
   useState,
   useSyncExternalStore,
@@ -35,6 +36,12 @@ import {
 
 const WizardContext = createContext<Wizard | null>(null);
 
+/**
+ * `useLayoutEffect` in the browser, `useEffect` on the server - where neither
+ * runs, and where React warns about the layout one. The standard shim.
+ */
+const useIsomorphicLayoutEffect = typeof window === 'undefined' ? useEffect : useLayoutEffect;
+
 export interface WizardProviderProps extends Partial<WizardOptions> {
   /** An existing engine. Supply this or `flow`, not both. */
   wizard?: Wizard;
@@ -52,8 +59,18 @@ export function WizardProvider({ wizard, children, ...options }: WizardProviderP
   // current step and the tree below renders nothing. `start` is idempotent and
   // the effect never runs on the server, which is where the wizard must not
   // navigate at all.
-  useEffect(() => {
-    void engine.start();
+  // A layout effect, so the start begins before the browser paints rather than
+  // after it. It cannot remove the first frame entirely - the pipeline is
+  // asynchronous, so the step arrives a microtask later - but it is the earlier
+  // of the two moments React offers, and on the server neither runs at all.
+  //
+  // The rejection is caught rather than dropped: a first step with a loader
+  // that fails is an ordinary network error, and an unhandled rejection is not
+  // an error channel.
+  useIsomorphicLayoutEffect(() => {
+    engine.start().catch((error: unknown) => {
+      console.error('[wizzard] the wizard could not start.', error);
+    });
   }, [engine]);
 
   return createElement(WizardContext.Provider, { value: engine }, children);

--- a/packages/vue/src/v1/index.ts
+++ b/packages/vue/src/v1/index.ts
@@ -42,7 +42,11 @@ export function provideWizard(source: Wizard | WizardOptions): Wizard {
   // which is where the wizard must not navigate at all. The React binding does
   // the same thing in an effect — the contract suite checks both.
   onMounted(() => {
-    void wizard.start();
+    wizard.start().catch((error: unknown) => {
+      // A first step whose loader fails is an ordinary network error. Dropping
+      // the promise would turn it into an unhandled rejection instead.
+      console.error('[wizzard] the wizard could not start.', error);
+    });
   });
   return wizard;
 }

--- a/packages/vue/src/v1/index.ts
+++ b/packages/vue/src/v1/index.ts
@@ -8,6 +8,7 @@ import {
 import {
   computed,
   inject,
+  onMounted,
   onScopeDispose,
   provide,
   shallowRef,
@@ -36,6 +37,13 @@ const KEY: InjectionKey<Wizard> = Symbol('wizzard');
 export function provideWizard(source: Wizard | WizardOptions): Wizard {
   const wizard = 'getSnapshot' in source ? source : createWizard(source);
   provide(KEY, wizard);
+  // A fresh engine has an empty stack, so without this there is no current step
+  // to render. `start` is idempotent, and on the server `onMounted` never runs,
+  // which is where the wizard must not navigate at all. The React binding does
+  // the same thing in an effect — the contract suite checks both.
+  onMounted(() => {
+    void wizard.start();
+  });
   return wizard;
 }
 


### PR DESCRIPTION
Writing the quickstart example turned up a gap the test suite was hiding: a fresh engine has an empty stack, so `current` is `null` and a binding renders **nothing** until the user presses Next. The pasted README example would have shown two buttons and no form.

The contract suite hid it because every case opened with a `click('next')` that existed only to reach step one.

**`start()`** enters the first reachable step, and does nothing when a step is already current — two mounts of one engine are not a step forward. It does not validate on the way in: an untouched form must not open with errors. Both bindings call it on mount (React effect, Vue `onMounted`), where the server never runs and the wizard must not navigate at all.

The contract suite now asserts the first step is on screen at first paint, on both bindings, which is the case that would have caught this.

**Budget:** `core-v1` goes 3.90 → 3.92 kB. The ratchet moves to the roadmap's stated 4 kB, and `.size-limit.js` records why: twenty-one bytes for the difference between a wizard that shows its first step and one that shows nothing.

Gates: 243 tests pass (4 new), lint 0 errors, types clean, `pnpm size` green, prettier clean.