### PR TITLE
docs(agents): amend the rules with what the last six PRs needed

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,23 @@ cannot be serialized — predicates, validators, loaders, views. The same object
 by `defineFlow()`, by a backend, or by a generator. If a change makes a flow unserializable,
 it is the wrong change.
 
+## Where things live
+
+The tree carries two libraries at once until 0.x is deleted. Everything under a `v1`
+directory is the new engine; everything beside it is the line being retired.
+
+```
+packages/core/src/v1/   the engine: expr, resolve, navigate, commit, select, store, state, path
+                        plus its own entries - validate-flow, graph, session
+packages/core/src/      0.x. Being deleted; do not build on it
+packages/react/src/v1/  the React binding, ~200 lines. packages/react/src/* is 0.x
+packages/vue/src/v1/    the Vue binding, same shape
+packages/validate/      one Standard Schema adapter for five validation libraries
+contract/               one suite, run against both bindings, so they cannot drift apart
+examples/quickstart/    the example the README embeds and CI runs
+docs/designs/           the plan of record: v1-launch.md, flow-inspector.md
+```
+
 ## Language
 
 - Conversation, plans and task descriptions: **Russian**.
@@ -35,6 +52,12 @@ it is the wrong change.
 5. **Logic belongs in core, not in a binding.** If React and Vue both need it, it is a core
    concern. 0.x has `next`/`prev` implemented three times and the copies disagree; that class
    of bug is not allowed back.
+6. **Every `core` sub-entry is its own budget.** `validate-flow`, `graph` and `session` are
+   separate entries so a runtime bundle never carries them; re-exporting one from
+   `v1/index.ts` silently moves it into everyone's bundle. Adding an entry means a tsup
+   entry, an `exports` key and a `.size-limit.js` line in the same PR. Budgets are ratchets
+   set just above what a thing measures once it is correct - raise one with a stated reason
+   in the PR, never trim behaviour to fit one.
 
 ## Working agreement
 
@@ -51,9 +74,43 @@ an issue rather than widening the change.
 **Every block ships with its check.** Core logic gets property tests; anything a binding
 exposes gets a contract test that runs against both React and Vue.
 
+**Every failure says what to do next.** One shape, for messages that are thrown and for
+problems that are returned:
+
+```
+[wizzard] <what went wrong>. <why>. <the fix>. <docs url>#<code>
+```
+
+Single-clause messages are the thing this replaces: `unknown resolver: x` names the symptom
+and leaves the reader to find the cause.
+
+**The automated review is a second gate.** A review runs on every PR and on every push to
+one. Its comments are only reachable through the API - `gh api
+repos/ZizzX/wizzard-packages/pulls/<n>/comments`, not `gh pr view`. Read it before merging
+and answer every finding: fix it, or say why it is wrong with the evidence. It has been
+right far more often than not, and it has also blamed the wrong file, so verify each one
+against the code rather than applying it on faith. Green CI is necessary and not sufficient.
+
+**Done, for a PR.** Tests for the new behaviour; `pnpm verify` green; a changeset only when
+a published package changes in a way a user would notice (v1 is unreleased, so v1 work needs
+none until 1.0.0); and if a size budget moved, the reason is in the PR body and in the
+comment beside the budget.
+
+**The bindings are idiomatic first.** `WizardProvider` is a React component and
+`provideWizard` is a Vue function on purpose - each is what its framework expects. The hook
+names are identical across both and stay that way; the asymmetry above them is not a bug to
+fix.
+
 ## Quality gates
 
 These run in CI and must pass locally before a PR:
+
+```bash
+pnpm verify        # lint + type-check + test:run, the pre-PR command
+```
+
+Each gate on its own, and each of them narrowed while you work - the whole-repo run is a
+slow way to learn one file is wrong:
 
 ```bash
 pnpm lint          # eslint, type-aware on packages/*/src
@@ -67,6 +124,20 @@ pnpm size          # bundle budgets
 pnpm test:e2e      # playwright, react + vue demos
 ```
 
+Narrowed forms, in the order they are usually needed:
+
+```bash
+pnpm -F @wizzard-packages/core test:run -- session   # one package, one file
+pnpm -F @wizzard-packages/core type-check            # one package
+pnpm test:run -- quickstart                          # one suite, whole repo
+pnpm -F @wizzard-packages/core build                 # rebuild what the bindings import
+```
+
+The bindings import core's `dist`, not its source, so a core change is invisible to their
+tests until `build` runs.
+
+**Supported versions.** Node >= 20.11, pnpm 10, TypeScript >= 5, React >= 18, Vue >= 3.3.
+
 `pnpm size` budgets are a ratchet: they sit just above current size, so any growth fails the
 build. Raise a budget only with a stated reason in the PR.
 
@@ -74,6 +145,10 @@ The ESLint config has a **legacy quarantine** block listing 0.x source paths tha
 a lower standard. Remove an entry when its v1 replacement lands. Never add one.
 
 ## Issue tracking
+
+Issues live in `.beads/issues.jsonl` under the `wizzard-N` scheme, and the design documents
+in `docs/designs/` refer to them by that id. `tasks/session-state.md` uses an older scheme
+and is not maintained.
 
 `bd` (beads), prefix `wizzard-`:
 

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "examples:check": "node scripts/embed-examples.mjs --check",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
+    "verify": "pnpm lint && pnpm type-check && pnpm test:run",
     "test": "vitest",
     "test:run": "vitest run",
     "test:e2e": "playwright test",


### PR DESCRIPTION
The `AGENTS.md` audit from `docs/designs/v1-launch.md`. The verdict was keep it: the hard rules are specific and checkable, rule 2 is backed by a real `no-restricted-syntax` selector, and ninety-two lines is the right length. So this adds what the last six PRs actually needed rather than rewriting it.

- **Where things live.** The tree carries two libraries at once and nothing said that everything under a `v1` directory is the new one. Deleted again when 0.x goes.
- **Hard rule 6 — every `core` sub-entry is its own budget.** `validate-flow`, `graph` and `session` must never be re-exported from `v1/index.ts`, and adding an entry means a tsup entry, an `exports` key and a `.size-limit.js` line in the same PR. Learned twice, written down nowhere. It also states that a budget is a ratchet set *after* correctness — raised with a reason, never a target you trim behaviour to fit.
- **The error shape**, with a cause, a fix and a link. `unknown resolver: x` names the symptom and leaves the reader to find the rest.
- **The automated review is a second gate**: comments are API-only (`gh api …/pulls/<n>/comments`), every finding gets answered, and each gets verified against the code — it has been right far more often than not and it has also blamed the wrong file.
- **What done means for a PR**, including when a changeset is needed (v1 is unreleased, so v1 work needs none until 1.0.0).
- **The binding naming asymmetry is deliberate** — `WizardProvider` vs `provideWizard` — so nobody "fixes" it into false symmetry.
- **`pnpm verify`** as the one pre-PR command, plus the narrowed form of each gate, the note that the bindings import core's `dist` rather than its source, and the supported versions.
- **The tracker** is `.beads/issues.jsonl` under `wizzard-N`; `tasks/session-state.md` is an older scheme and is not maintained.

Gates: `pnpm verify` green (233 legacy warnings, 0 errors, 246 tests), prettier clean.

Task D1 of `docs/designs/v1-launch.md`.