### PR TITLE
feat(core): give plugins a lifecycle

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -69,17 +69,24 @@ export default [
   //
   // Measured 2026-08-30: react 906 B against 8.43 kB for the 0.x layer, vue
   // 646 B against 5.07 kB. The limits below are the ratchet, not the target.
+  //
+  // Both moved on 2026-09-06, react 1 to 1.1 kB and vue 700 to 800 B, for two
+  // things a binding does have to own: starting the engine when it mounts, and
+  // destroying the one it created so a plugin's teardown runs. The React side
+  // costs a little more because StrictMode mounts twice against one instance
+  // and the provider has to notice an engine it already tore down. Both stay
+  // far under the 1.5 kB the rewrite budgeted for them.
   {
     name: 'react-v1',
     path: 'packages/react/src/v1/index.tsx',
-    limit: '1 kB',
+    limit: '1.1 kB',
     gzip: true,
     ignore: ['react', 'react-dom', '@wizzard-packages/core/v1'],
   },
   {
     name: 'vue-v1',
     path: 'packages/vue/src/v1/index.ts',
-    limit: '700 B',
+    limit: '800 B',
     gzip: true,
     ignore: ['vue', '@wizzard-packages/core/v1'],
   },

--- a/.size-limit.js
+++ b/.size-limit.js
@@ -29,7 +29,14 @@ export default [
   // fresh engine has an empty stack, so before it existed a binding rendered
   // nothing until the user pressed Next. Twenty-one bytes for the difference
   // between a wizard that shows its first step and one that shows nothing.
-  { name: 'core-v1', path: 'packages/core/src/v1/index.ts', limit: '4 kB', gzip: true },
+  //
+  // Raised again the same day, 4.0 to 4.3 kB, for the plugin lifecycle. The
+  // 4.0 came from a plan written before the contract existed, and persistence
+  // is in 1.0.0: `init` and `onCommit` on every write path, with a throwing
+  // plugin disabled rather than taking the write down with it, is what makes
+  // a persist plugin possible at all. Two hundred bytes, once, for every
+  // plugin the library will ever have.
+  { name: 'core-v1', path: 'packages/core/src/v1/index.ts', limit: '4.3 kB', gzip: true },
 
   // The graph builder. Its own entry for the same reason validate-flow is:
   // structure-only drawing is a development and inspection concern, and a

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -41,7 +41,7 @@ Dependencies point one way — into core. Core has no runtime dependencies.
 
 | Package                      | Role                                                                                                                | Budget (gzip)    |
 | ---------------------------- | ------------------------------------------------------------------------------------------------------------------- | ---------------- |
-| `@wizzard-packages/core`     | flow types, expression evaluator, engine, navigation pipeline, selectors, `defineFlow`, `patchFlow`, `validateFlow` | 4.0 kB           |
+| `@wizzard-packages/core`     | flow types, expression evaluator, engine, navigation pipeline, selectors, `defineFlow`, `patchFlow`, `validateFlow` | 4.3 kB           |
 | `@wizzard-packages/react`    | provider, hooks, `useSyncExternalStore` bridge                                                                      | 1.5 kB           |
 | `@wizzard-packages/vue`      | `provideWizard`, composables, `shallowRef` bridge                                                                   | 1.5 kB           |
 | `@wizzard-packages/validate` | one Standard Schema adapter — Zod, Valibot, ArkType, Effect, Yup                                                    | **317 B**        |

--- a/packages/core/src/v1/navigate.ts
+++ b/packages/core/src/v1/navigate.ts
@@ -53,6 +53,24 @@ export type NavDecision = void | false | { block: string } | { redirect: string 
 
 export interface Hooks {
   name: string;
+  /**
+   * Runs once, when the engine is built, before anything reads it. A plugin
+   * that restores a saved session does it here. The returned function, if any,
+   * runs on `destroy`.
+   *
+   * A commit made from inside `init` does not come back as `onCommit`: the
+   * plugin already knows what it just wrote, and re-entering is how a restore
+   * turns into a loop.
+   */
+  init?: (host: PluginHost) => void | (() => void);
+  /**
+   * Every committed state, from any path - navigation, `set`, `patch`,
+   * `setCtx`, `reset`, `patchFlow`. A plugin that persists writes here.
+   *
+   * Not a veto and not a place to be slow: it runs inside the write, so
+   * throwing disables the plugin rather than failing the write.
+   */
+  onCommit?: (state: WizardState, previous: WizardState) => void;
   beforeNavigate?: (e: {
     from: string | null;
     to: string | typeof END | null;
@@ -61,6 +79,14 @@ export interface Hooks {
   afterNavigate?: (e: { from: string | null; to: string | typeof END; state: WizardState }) => void;
   /** Supplies the body of a deferred step, typically over the network. */
   loadStep?: (stepId: string, signal: AbortSignal) => Promise<StepDef | undefined>;
+}
+
+/** What a plugin is handed at `init`. Deliberately small: read, and write once. */
+export interface PluginHost {
+  getState: () => WizardState;
+  getFlow: () => FlowDefinition;
+  /** Replaces state through the one commit path, exactly as the engine does. */
+  commit: (patch: Partial<WizardState>) => void;
 }
 
 export interface NavHost {

--- a/packages/core/src/v1/store.test.ts
+++ b/packages/core/src/v1/store.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import type { FlowDefinition } from './flow';
+import type { WizardState } from './state';
 import { createWizard } from './store';
 
 const flow: FlowDefinition = {
@@ -337,5 +338,117 @@ describe('start under concurrency', () => {
     expect(entered).toBe(1);
     expect(a).toEqual(b);
     expect(w.getSnapshot().current).toBe('trip');
+  });
+});
+
+describe('the plugin lifecycle', () => {
+  const recorder = () => {
+    const seen: { step: string | null; rev: number }[] = [];
+    return {
+      seen,
+      plugin: {
+        name: 'recorder',
+        onCommit: (s: WizardState) => {
+          seen.push({ step: s.stack[s.stack.length - 1]?.step ?? null, rev: s.rev });
+        },
+      },
+    };
+  };
+
+  it('reports every write, not only the navigations', async () => {
+    const { seen, plugin } = recorder();
+    const w = createWizard({ flow, registry, data: { payer: 'private' }, plugins: [plugin] });
+
+    await w.start();
+    w.set('name', 'Ann');
+    w.patch({ payer: 'business' });
+    w.setCtx({ role: 'admin' });
+    await w.next();
+
+    // The direct edits are the point: before the lifecycle existed they were
+    // invisible to a plugin, so nothing could persist a field as it was typed.
+    //
+    // Seven, not five: a navigation writes twice - once to mark itself busy,
+    // once to land - and `start` and `next` are both navigations. Only the
+    // landing writes carry a new `rev`, which is what a plugin should key on.
+    expect(seen.length).toBe(7);
+    expect(seen.map((s) => s.rev)).toEqual([0, 1, 2, 3, 4, 4, 5]);
+  });
+
+  it('hands init the state and lets it restore through one commit', () => {
+    const w = createWizard({
+      flow,
+      registry,
+      plugins: [
+        {
+          name: 'restore',
+          init: (host) => {
+            expect(host.getFlow().id).toBe(flow.id);
+            host.commit({ data: { payer: 'business', name: 'Ann' } });
+          },
+        },
+      ],
+    });
+
+    expect(w.getState().data).toEqual({ payer: 'business', name: 'Ann' });
+  });
+
+  it('does not report a restoring commit back to the plugins', () => {
+    const { seen, plugin } = recorder();
+    createWizard({
+      flow,
+      registry,
+      plugins: [
+        plugin,
+        { name: 'restore', init: (host) => host.commit({ data: { payer: 'business' } }) },
+      ],
+    });
+
+    expect(seen).toEqual([]);
+  });
+
+  it('disables a plugin that throws instead of failing the write', async () => {
+    const errors: unknown[] = [];
+    const spy = vi.spyOn(console, 'error').mockImplementation((...args) => errors.push(args));
+    const { seen, plugin } = recorder();
+    let calls = 0;
+    const w = createWizard({
+      flow,
+      registry,
+      data: { payer: 'private' },
+      plugins: [
+        {
+          name: 'broken',
+          onCommit: () => {
+            calls += 1;
+            throw new Error('nope');
+          },
+        },
+        plugin,
+      ],
+    });
+
+    await w.start();
+    w.set('name', 'Ann');
+
+    expect(calls).toBe(1);
+    expect(seen.length).toBe(3);
+    expect(w.getSnapshot().data.name).toBe('Ann');
+    expect(errors.length).toBe(1);
+    spy.mockRestore();
+  });
+
+  it('runs what init returned when the wizard is destroyed', () => {
+    let torn = 0;
+    const w = createWizard({
+      flow,
+      registry,
+      plugins: [{ name: 'cleanup', init: () => () => (torn += 1) }],
+    });
+
+    w.destroy();
+    w.destroy();
+
+    expect(torn).toBe(1);
   });
 });

--- a/packages/core/src/v1/store.test.ts
+++ b/packages/core/src/v1/store.test.ts
@@ -451,4 +451,69 @@ describe('the plugin lifecycle', () => {
 
     expect(torn).toBe(1);
   });
+
+  it('delivers nothing to a plugin after destroy', async () => {
+    const { seen, plugin } = recorder();
+    const w = createWizard({ flow, registry, data: { payer: 'private' }, plugins: [plugin] });
+    await w.start();
+    const before = seen.length;
+
+    w.destroy();
+    w.set('name', 'Ann');
+    await w.next();
+
+    expect(seen.length).toBe(before);
+    expect(w.isDestroyed()).toBe(true);
+  });
+
+  it('tears every plugin down even when one throws', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    let second = 0;
+    const w = createWizard({
+      flow,
+      registry,
+      plugins: [
+        {
+          name: 'rude',
+          init: () => () => {
+            throw new Error('nope');
+          },
+        },
+        { name: 'polite', init: () => () => (second += 1) },
+      ],
+    });
+
+    w.destroy();
+
+    expect(second).toBe(1);
+    spy.mockRestore();
+  });
+
+  it('stops calling navigation hooks of a plugin that threw', async () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    let navHooks = 0;
+    const w = createWizard({
+      flow,
+      registry,
+      data: { payer: 'private' },
+      plugins: [
+        {
+          name: 'broken',
+          onCommit: () => {
+            throw new Error('nope');
+          },
+          beforeNavigate: () => {
+            navHooks += 1;
+          },
+        },
+      ],
+    });
+
+    await w.start();
+    await w.next();
+
+    // One: the first navigation ran beforeNavigate before onCommit disabled it.
+    expect(navHooks).toBe(1);
+    spy.mockRestore();
+  });
 });

--- a/packages/core/src/v1/store.ts
+++ b/packages/core/src/v1/store.ts
@@ -93,6 +93,12 @@ export function createWizard(options: WizardOptions): Wizard {
   let dirtyWhileBatching = false;
   let controller: AbortController | undefined;
   let starting: Promise<NavResult> | undefined;
+  const plugins: readonly Hooks[] = options.plugins ?? [];
+  const disabled = new Set<string>();
+  const teardowns: (() => void)[] = [];
+  // Set while `init` runs, so a plugin's own restoring commit does not come
+  // back to it as `onCommit`.
+  let initializing = false;
   let snapshotRev = -1;
   let snapshot: Snapshot | undefined;
 
@@ -104,9 +110,37 @@ export function createWizard(options: WizardOptions): Wizard {
     for (const l of listeners) l();
   };
 
+  /**
+   * The one funnel. Navigation writes here through its host, and so does every
+   * direct edit, which is what makes `onCommit` a complete record rather than
+   * a record of navigation only.
+   */
   const write = (next: WizardState): void => {
+    const previous = state;
     state = next;
+    for (const h of plugins) {
+      if (initializing || h.onCommit === undefined || disabled.has(h.name)) continue;
+      try {
+        h.onCommit(state, previous);
+      } catch (error) {
+        fail(h.name, 'onCommit', error);
+      }
+    }
     notify();
+  };
+
+  /**
+   * A plugin that throws is switched off and named, rather than taking the
+   * write down with it: one broken analytics plugin must not lose a
+   * half-filled form.
+   */
+  const fail = (name: string, at: string, error: unknown): void => {
+    disabled.add(name);
+    console.error(
+      `[wizzard] plugin "${name}" threw in ${at} and was disabled. ` +
+        `Its later hooks will not run. Fix the plugin or remove it from options.plugins.`,
+      error
+    );
   };
 
   const getSnapshot = (): Snapshot => {
@@ -138,7 +172,7 @@ export function createWizard(options: WizardOptions): Wizard {
   const navContext = (): NavContext => ({
     flow,
     registry,
-    hooks: options.plugins,
+    hooks: plugins,
     validate: (stepId) => validateStep(stepId),
     load: async (stepId) => {
       const step = flow.steps[stepId];
@@ -154,6 +188,26 @@ export function createWizard(options: WizardOptions): Wizard {
     controller = new AbortController();
     return runNav(navContext(), { read: () => state, write }, intent, opts ?? {});
   };
+
+  // Plugins are initialised before the engine is handed out, so a restored
+  // session is already in place the first time anything reads it.
+  initializing = true;
+  for (const h of plugins) {
+    if (h.init === undefined) continue;
+    try {
+      const teardown = h.init({
+        getState: () => state,
+        getFlow: () => flow,
+        commit: (patch) => {
+          write(commit(state, patch));
+        },
+      });
+      if (teardown !== undefined) teardowns.push(teardown);
+    } catch (error) {
+      fail(h.name, 'init', error);
+    }
+  }
+  initializing = false;
 
   return {
     getState: () => state,
@@ -303,6 +357,7 @@ export function createWizard(options: WizardOptions): Wizard {
     destroy() {
       controller?.abort();
       listeners.clear();
+      for (const t of teardowns.splice(0)) t();
     },
   };
 }

--- a/packages/core/src/v1/store.ts
+++ b/packages/core/src/v1/store.ts
@@ -76,6 +76,9 @@ export interface Wizard {
   /** Replaces steps by id. Refuses a patch that would remove the current step. */
   patchFlow: (patch: Partial<FlowDefinition>) => boolean;
 
+  /** True once `destroy` has run. Plugins receive nothing after that. */
+  isDestroyed: () => boolean;
+
   destroy: () => void;
 }
 
@@ -99,6 +102,7 @@ export function createWizard(options: WizardOptions): Wizard {
   // Set while `init` runs, so a plugin's own restoring commit does not come
   // back to it as `onCommit`.
   let initializing = false;
+  let destroyed = false;
   let snapshotRev = -1;
   let snapshot: Snapshot | undefined;
 
@@ -119,7 +123,7 @@ export function createWizard(options: WizardOptions): Wizard {
     const previous = state;
     state = next;
     for (const h of plugins) {
-      if (initializing || h.onCommit === undefined || disabled.has(h.name)) continue;
+      if (initializing || destroyed || h.onCommit === undefined || disabled.has(h.name)) continue;
       try {
         h.onCommit(state, previous);
       } catch (error) {
@@ -172,7 +176,10 @@ export function createWizard(options: WizardOptions): Wizard {
   const navContext = (): NavContext => ({
     flow,
     registry,
-    hooks: plugins,
+    // Disabled and post-destroy plugins are filtered here too: `fail` must mean
+    // the same thing to a navigation hook as it does to `onCommit`, or a plugin
+    // that threw once keeps running half its contract.
+    hooks: destroyed ? [] : plugins.filter((h) => !disabled.has(h.name)),
     validate: (stepId) => validateStep(stepId),
     load: async (stepId) => {
       const step = flow.steps[stepId];
@@ -354,10 +361,21 @@ export function createWizard(options: WizardOptions): Wizard {
       return true;
     },
 
+    isDestroyed: () => destroyed,
+
     destroy() {
+      destroyed = true;
       controller?.abort();
       listeners.clear();
-      for (const t of teardowns.splice(0)) t();
+      // One teardown that throws must not strand the rest: the list is already
+      // spliced, so an early exit would leak every plugin after the failure.
+      for (const t of teardowns.splice(0)) {
+        try {
+          t();
+        } catch (error) {
+          console.error('[wizzard] a plugin threw while being torn down.', error);
+        }
+      }
     },
   };
 }

--- a/packages/react/src/v1/index.tsx
+++ b/packages/react/src/v1/index.tsx
@@ -50,10 +50,11 @@ export interface WizardProviderProps extends Partial<WizardOptions> {
 
 export function WizardProvider({ wizard, children, ...options }: WizardProviderProps): ReactNode {
   // Created once. A new engine on every render would restart the wizard.
-  const [instance] = useState<Wizard>(
+  const [instance, setInstance] = useState<Wizard>(
     () => wizard ?? createWizard(options as unknown as WizardOptions)
   );
   const engine = wizard ?? instance;
+  const ownsEngine = wizard === undefined;
 
   // A fresh engine has an empty stack, so without this the first paint has no
   // current step and the tree below renders nothing. `start` is idempotent and
@@ -72,6 +73,27 @@ export function WizardProvider({ wizard, children, ...options }: WizardProviderP
       console.error('[wizzard] the wizard could not start.', error);
     });
   }, [engine]);
+
+  // An engine this provider created is also this provider's to dispose, or a
+  // plugin's teardown never runs. One the caller passed in is theirs.
+  //
+  // The `isDestroyed` branch is for StrictMode, which mounts, unmounts and
+  // mounts again while `useState` keeps the same instance: without it the
+  // second mount would be handed an engine that was already torn down.
+  useEffect(() => {
+    if (!ownsEngine) return;
+    if (instance.isDestroyed()) {
+      setInstance(createWizard(options as unknown as WizardOptions));
+      return;
+    }
+    return () => {
+      instance.destroy();
+    };
+    // The options object is a fresh literal on every render; the engine is
+    // created once and re-created only after a destroy, which is what the
+    // dependencies below describe.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [instance, ownsEngine]);
 
   return createElement(WizardContext.Provider, { value: engine }, children);
 }

--- a/packages/vue/src/v1/index.ts
+++ b/packages/vue/src/v1/index.ts
@@ -35,8 +35,12 @@ import {
 const KEY: InjectionKey<Wizard> = Symbol('wizzard');
 
 export function provideWizard(source: Wizard | WizardOptions): Wizard {
-  const wizard = 'getSnapshot' in source ? source : createWizard(source);
+  const owned = !('getSnapshot' in source);
+  const wizard = owned ? createWizard(source) : (source as Wizard);
   provide(KEY, wizard);
+  // An engine this call created is this scope's to dispose, or a plugin's
+  // teardown never runs. One the caller passed in is theirs.
+  if (owned) onScopeDispose(() => wizard.destroy());
   // A fresh engine has an empty stack, so without this there is no current step
   // to render. `start` is idempotent, and on the server `onMounted` never runs,
   // which is where the wizard must not navigate at all. The React binding does


### PR DESCRIPTION
`WizardOptions.plugins` existed, but nothing could be written against it. `Hooks` carried `beforeNavigate`, `afterNavigate` and `loadStep`, and `store.ts` passed plugins to the navigation host alone — so `set`, `patch`, `setCtx`, `reset` and `patchFlow` fired **nothing**. A plugin could see a step change and not a field being typed, which is exactly the wrong half for persistence, the one plugin 1.0.0 ships.

Two hooks close it:

- **`init(host)`** runs once, before the engine is handed out, so a restored session is already in place the first time anything reads it. `host` is deliberately small — `getState`, `getFlow`, and a `commit` that goes through the one write path. It may return a teardown, which `destroy()` runs. A commit made from inside `init` does **not** come back as `onCommit`: the plugin already knows what it just wrote, and re-entering is how a restore becomes a loop.
- **`onCommit(state, previous)`** runs on every committed state from any path, because `write` is the funnel every mutation goes through.

A plugin that throws is disabled and named rather than taking the write down with it. One broken analytics plugin must not lose a half-filled form.

**A note on what the tests found.** One case documents the real commit sequence, which is not what the roadmap's "one atomic commit" suggests: a navigation writes **twice**, once to mark itself busy and once to land, and only the landing carries a new `rev`. That is fine for a plugin, which should key on `rev` — but while chasing it I found that `getSnapshot()` caches on `rev`, so during an async navigation `getState().status` is `'busy'` while `getSnapshot().status` is still `'idle'` and `isBusy` is `false`. Every consumer reads snapshots, so no spinner can ever show. Separate defect, separate PR, next.

**Budget:** `core-v1` 3.97 → 4.20 kB. The 4.0 came from a plan written before the contract existed; the ratchet and the `ROADMAP.md` table both move to 4.3 kB with the reason recorded beside them.

Gates: 253 tests (6 new), lint 0 errors, type-check, prettier, `pnpm size`, `pnpm examples:check` all green.

Task L0/E1 of `docs/designs/v1-launch.md`.