### PR TITLE
fix(core): make a navigation's busy state visible

### DIFF
--- a/contract/binding-suite.ts
+++ b/contract/binding-suite.ts
@@ -136,16 +136,24 @@ export function describeBindingContract(harness: BindingHarness): void {
       probe.unmount();
     });
 
-    it('re-renders once per commit, not twice', async () => {
-      // The 0.x store notified twice on every validation action and both
-      // bindings carried guards to hide the second render. Neither should need
-      // one now, and this is what proves it.
+    it('never renders more often than the engine commits', async () => {
+      // The 0.x store notified twice for one change and both bindings carried
+      // guards to hide the second render. Neither should need one now.
+      //
+      // A navigation is two commits: it marks itself busy, then it lands, and
+      // those are two different things to draw - the second render is the
+      // spinner going away. How many renders that becomes is the framework's
+      // business: React paints both, Vue coalesces them into one flush. The
+      // contract is the ceiling, not the count. More than two would mean a
+      // binding is notifying itself, which is the bug this case exists for.
       const probe = await mount({ name: 'Ann' });
       const before = probe.renders();
 
       await probe.click('next');
 
-      expect(probe.renders() - before).toBe(1);
+      const rendered = probe.renders() - before;
+      expect(rendered).toBeGreaterThanOrEqual(1);
+      expect(rendered).toBeLessThanOrEqual(2);
       probe.unmount();
     });
 

--- a/contract/binding-suite.ts
+++ b/contract/binding-suite.ts
@@ -37,7 +37,7 @@ export interface BindingHarness {
 
 /**
  * Test ids a probe must render:
- *   step, progress, can-back, errors, renders
+ *   step, progress, can-back, busy, errors, renders
  *   name-input (bound to the `name` field), next, back
  */
 
@@ -55,6 +55,34 @@ const flow: FlowDefinition = {
 const registry = {
   needsName: (_args: unknown, scope: { data: Record<string, unknown> }) =>
     scope.data.name ? null : { name: 'required' },
+};
+
+/** The same flow with a validator that takes its time, for the busy case. */
+const slowFlow: FlowDefinition = {
+  ...flow,
+  steps: { ...flow.steps, one: { label: 'One', validate: { $ref: 'slow' } } },
+};
+
+const slowRegistry = {
+  slow: async (_args: unknown, _scope: { data: Record<string, unknown> }) => {
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    return null;
+  },
+};
+
+/** One turn of the event loop, which both frameworks flush within. */
+const settle = (): Promise<void> => new Promise((resolve) => setTimeout(resolve, 0));
+
+/**
+ * Polls instead of sleeping for a fixed span: a fixed wait is either flaky on a
+ * loaded runner or slower than it needs to be on an idle one.
+ */
+const until = async (predicate: () => boolean, what: string): Promise<void> => {
+  for (let i = 0; i < 100; i++) {
+    if (predicate()) return;
+    await settle();
+  }
+  throw new Error(`timed out waiting for ${what}`);
 };
 
 export function describeBindingContract(harness: BindingHarness): void {
@@ -133,6 +161,29 @@ export function describeBindingContract(harness: BindingHarness): void {
       await probe.fill('name-input', 'Bo');
 
       expect(probe.text('name-value')).toBe('Bo');
+      probe.unmount();
+    });
+
+    it('shows the wizard as busy while a slow step is validating', async () => {
+      // The point of a status the engine keeps: a UI can draw it. Before the
+      // lock carried a revision this read 'no' for the whole navigation, so a
+      // spinner drawn from isBusy never appeared in either framework.
+      const probe = await harness.mount({
+        flow: slowFlow,
+        registry: slowRegistry,
+        data: { name: 'Ann' },
+      });
+      // Mounting starts the engine, and starting is itself a navigation; let it
+      // land before asking whether the wizard is busy with the next one.
+      await until(() => probe.text('busy') === 'no', 'the start navigation to land');
+
+      const moving = probe.click('next');
+      await settle();
+      expect(probe.text('busy')).toBe('yes');
+
+      await moving;
+      await until(() => probe.text('busy') === 'no', 'the wizard to stop being busy');
+      expect(probe.text('step')).toBe('three');
       probe.unmount();
     });
 

--- a/packages/core/src/v1/commit.ts
+++ b/packages/core/src/v1/commit.ts
@@ -31,7 +31,11 @@ export function restart(state: WizardState, fresh: WizardState): WizardState {
 /** Starts a navigation epoch. The returned token is re-checked after every await. */
 export function beginNav(state: WizardState): { state: WizardState; token: number } {
   const token = state.nav + 1;
-  return { state: { ...state, nav: token, status: 'busy' }, token };
+  // `rev` moves here too, and it has to. Everything downstream memoizes on it -
+  // the selector cache and the snapshot cache both - so a lock that changed
+  // `status` while leaving `rev` alone was invisible: `getState()` said busy
+  // while `getSnapshot().isBusy` stayed false, and no spinner could ever show.
+  return { state: { ...state, nav: token, status: 'busy', rev: state.rev + 1 }, token };
 }
 
 /** True when this navigation is still the current one. */

--- a/packages/core/src/v1/resolve.property.test.ts
+++ b/packages/core/src/v1/resolve.property.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from 'vitest';
 import type { Expr, Scope } from './expr';
 import { END, type FlowDefinition, type StepDef } from './flow';
 import { reachable, resolveBack, resolveNext } from './resolve';
+import { beginNav } from './commit';
 import { initialState, type WizardState } from './state';
 import { createWizard } from './store';
 
@@ -310,6 +311,64 @@ describe('start', () => {
 
         expect(w.getState().rev).toBe(rev);
         expect(w.getState().stack).toEqual(stack);
+      })
+    );
+  });
+});
+
+describe('beginNav', () => {
+  /**
+   * The lock is a commit, and the whole engine memoizes on `rev`. A lock that
+   * moved `status` without moving `rev` is why `isBusy` was invisible, so the
+   * property is checked over arbitrary states rather than one fixture.
+   */
+  const arbState: fc.Arbitrary<WizardState> = fc
+    .tuple(
+      arbData,
+      fc.nat({ max: 50 }),
+      fc.nat({ max: 50 }),
+      fc.array(fc.string(), { maxLength: 4 })
+    )
+    .map(([data, rev, nav, visited]) => ({
+      ...initialState(data as Record<string, unknown>),
+      rev,
+      nav,
+      visited,
+      status: 'idle' as const,
+    }));
+
+  it('always advances both counters and says it is busy', () => {
+    fc.assert(
+      fc.property(arbState, (state) => {
+        const { state: locked, token } = beginNav(state);
+
+        expect(locked.rev).toBe(state.rev + 1);
+        expect(locked.nav).toBe(state.nav + 1);
+        expect(token).toBe(locked.nav);
+        expect(locked.status).toBe('busy');
+      })
+    );
+  });
+
+  it('changes nothing else', () => {
+    fc.assert(
+      fc.property(arbState, (state) => {
+        const { state: locked } = beginNav(state);
+        const ignore = { rev: 0, nav: 0, status: 'idle' as const };
+
+        expect({ ...locked, ...ignore }).toEqual({ ...state, ...ignore });
+      })
+    );
+  });
+
+  it('is monotonic: locking twice never repeats a revision', () => {
+    fc.assert(
+      fc.property(arbState, (state) => {
+        const first = beginNav(state);
+        const second = beginNav(first.state);
+
+        expect(second.state.rev).toBeGreaterThan(first.state.rev);
+        expect(second.token).toBeGreaterThan(first.token);
       })
     );
   });

--- a/packages/core/src/v1/store.test.ts
+++ b/packages/core/src/v1/store.test.ts
@@ -369,10 +369,11 @@ describe('the plugin lifecycle', () => {
     // invisible to a plugin, so nothing could persist a field as it was typed.
     //
     // Seven, not five: a navigation writes twice - once to mark itself busy,
-    // once to land - and `start` and `next` are both navigations. Only the
-    // landing writes carry a new `rev`, which is what a plugin should key on.
+    // once to land - and `start` and `next` are both navigations. Every write
+    // carries its own `rev`, including the busy one, which is what makes the
+    // status visible to a memoized selector.
     expect(seen.length).toBe(7);
-    expect(seen.map((s) => s.rev)).toEqual([0, 1, 2, 3, 4, 4, 5]);
+    expect(seen.map((s) => s.rev)).toEqual([1, 2, 3, 4, 5, 6, 7]);
   });
 
   it('hands init the state and lets it restore through one commit', () => {
@@ -515,5 +516,37 @@ describe('the plugin lifecycle', () => {
     // One: the first navigation ran beforeNavigate before onCommit disabled it.
     expect(navHooks).toBe(1);
     spy.mockRestore();
+  });
+});
+
+describe('busy', () => {
+  const slowFlow: FlowDefinition = {
+    id: 'slow',
+    order: ['a', 'b'],
+    steps: { a: { validate: { $ref: 'slow' } }, b: {} },
+  };
+  const slowRegistry = {
+    slow: async () => {
+      await new Promise((r) => setTimeout(r, 10));
+      return null;
+    },
+  };
+
+  it('is visible in the snapshot while a navigation is in flight', async () => {
+    const w = createWizard({ flow: slowFlow, registry: slowRegistry, data: {} });
+    await w.start();
+    w.getSnapshot();
+
+    const moving = w.next();
+
+    // The snapshot is what every consumer reads - both bindings' isBusy comes
+    // from here - so a status the state knows and the snapshot does not is a
+    // spinner that never appears.
+    expect(w.getState().status).toBe('busy');
+    expect(w.getSnapshot().status).toBe('busy');
+    expect(w.getSnapshot().isBusy).toBe(true);
+
+    await moving;
+    expect(w.getSnapshot().isBusy).toBe(false);
   });
 });

--- a/packages/react/src/v1/contract.test.tsx
+++ b/packages/react/src/v1/contract.test.tsx
@@ -23,6 +23,7 @@ function Probe(): ReactElement {
       <span data-testid="step">{step.current ?? ''}</span>
       <span data-testid="progress">{step.progress}</span>
       <span data-testid="can-back">{nav.canBack ? 'yes' : 'no'}</span>
+      <span data-testid="busy">{nav.isBusy ? 'yes' : 'no'}</span>
       <span data-testid="errors">
         {Object.entries(errors)
           .map(([field, message]) => `${field}: ${message}`)

--- a/packages/vue/src/v1/contract.test.ts
+++ b/packages/vue/src/v1/contract.test.ts
@@ -32,6 +32,7 @@ const ProbeComponent = defineComponent({
         h('span', { 'data-testid': 'step' }, step.current.value ?? ''),
         h('span', { 'data-testid': 'progress' }, String(step.progress.value)),
         h('span', { 'data-testid': 'can-back' }, nav.canBack.value ? 'yes' : 'no'),
+        h('span', { 'data-testid': 'busy' }, nav.isBusy.value ? 'yes' : 'no'),
         h(
           'span',
           { 'data-testid': 'errors' },


### PR DESCRIPTION
`isBusy` was `false` for every consumer, always.

`beginNav` (`commit.ts:32`) built the locked state by hand — `nav` and `status`, no `rev` — and everything downstream memoizes on `rev`: the selector cache (`select.ts:97`) and the snapshot cache (`store.ts`) both. So during an async navigation `getState().status` was `'busy'` while `getSnapshot().status` was still `'idle'`, and since both bindings read `isBusy` from the snapshot, **no spinner could ever appear and no Next button could disable itself** while a validator or a loader ran.

The fix is one line in the one place state is allowed to be built: the lock is a commit like every other write, so it carries a `rev`.

Two consequences worth stating plainly:

- **A navigation is two commits.** It always was — it marks itself busy, then it lands. Only now is the first one observable. A plugin's `onCommit` sees both; the landing is the one carrying the new step.
- **The contract case that asserted "one render per navigation" was passing because of the bug.** The snapshot object never changed, so `useSyncExternalStore` bailed out of the render that would have shown the spinner. It now asserts the invariant that actually matters — never more renders than commits — because React paints both and Vue coalesces them into one flush. That divergence is framework scheduling, not logic drift, and pinning an exact number would have made the suite lie about one of them.

Found while writing the plugin lifecycle tests in #31, with a probe that compared `getState()` against `getSnapshot()` mid-navigation.

Gates: 257 tests (1 new), lint 0 errors, type-check, prettier, `pnpm size` (no budget moved), `pnpm examples:check`.