### PR TITLE
feat(core): a durable snapshot format for a wizard

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -57,7 +57,17 @@ export default [
   // never persists a wizard should not carry the validator that decides whether
   // stored JSON can be trusted - and one that does persist wants it whether or
   // not it draws graphs.
-  { name: 'core-v1 snapshot', path: 'packages/core/src/v1/snapshot.ts', limit: '1 kB', gzip: true },
+  //
+  // Most of it is that validator: a deep copy on the way out, and on the way in
+  // a walk that refuses values JSON cannot round-trip, keys that reach a
+  // prototype, cycles, and anything past its bounds. Refusing a bad snapshot
+  // costs more than writing a good one, which is the right way round.
+  {
+    name: 'core-v1 snapshot',
+    path: 'packages/core/src/v1/snapshot.ts',
+    limit: '1.1 kB',
+    gzip: true,
+  },
 
   // Development and server-driven use only. Measured, but never counted against
   // the runtime budget, because shipping it to a browser is a mistake the

--- a/.size-limit.js
+++ b/.size-limit.js
@@ -53,6 +53,12 @@ export default [
   // it claims to belong to, and it is paid only by a page that replays one.
   { name: 'core-v1 session', path: 'packages/core/src/v1/session.ts', limit: '1.1 kB', gzip: true },
 
+  // The durable snapshot format. Its own entry because an application that
+  // never persists a wizard should not carry the validator that decides whether
+  // stored JSON can be trusted - and one that does persist wants it whether or
+  // not it draws graphs.
+  { name: 'core-v1 snapshot', path: 'packages/core/src/v1/snapshot.ts', limit: '1 kB', gzip: true },
+
   // Development and server-driven use only. Measured, but never counted against
   // the runtime budget, because shipping it to a browser is a mistake the
   // separate entry makes hard to commit by accident.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -73,6 +73,16 @@
         "types": "./dist/v1/session.d.cts",
         "default": "./dist/v1/session.cjs"
       }
+    },
+    "./snapshot": {
+      "import": {
+        "types": "./dist/v1/snapshot.d.ts",
+        "default": "./dist/v1/snapshot.js"
+      },
+      "require": {
+        "types": "./dist/v1/snapshot.d.cts",
+        "default": "./dist/v1/snapshot.cjs"
+      }
     }
   },
   "files": [

--- a/packages/core/src/v1/session.ts
+++ b/packages/core/src/v1/session.ts
@@ -54,7 +54,12 @@ function knownFlows(
   return known;
 }
 
-const isStackEntry = (entry: unknown): entry is Frame => {
+/**
+ * Exported because the snapshot decoder validates the same thing: a frame
+ * arriving as JSON is a frame arriving as JSON, and two copies of this check
+ * would drift the way 0.x's three navigation copies drifted.
+ */
+export const isStackEntry = (entry: unknown): entry is Frame => {
   if (entry === null || typeof entry !== 'object') return false;
   const e = entry as Partial<Frame>;
   return typeof e.flow === 'string' && typeof e.step === 'string';

--- a/packages/core/src/v1/snapshot.test.ts
+++ b/packages/core/src/v1/snapshot.test.ts
@@ -76,9 +76,9 @@ describe('decodeSnapshot', () => {
     expect(result.state.busy).toEqual([]);
     expect(result.state.errors).toEqual({});
     expect(result.state.rev).toBe(0);
-    // The epoch is carried, not reset: it is what makes anything begun before
-    // the restore resolve as superseded instead of overwriting it.
-    expect(result.state.nav).toBe(3);
+    // The epoch lands above the stored one, which is what makes a navigation
+    // begun before the restore resolve as superseded instead of overwriting it.
+    expect(result.state.nav).toBe(4);
     expect(result.state.data).toEqual({ name: { full: 'Ada' } });
   });
 
@@ -231,5 +231,53 @@ describe('migration', () => {
     });
 
     expect(result).toEqual({ restored: false, reason: 'snapshot/unreadable' });
+  });
+});
+
+describe('the epoch and the frames it restores', () => {
+  it('lands above a live navigation that is already in flight', () => {
+    const snapshot = toSnapshot(live(), flow);
+
+    // A wizard that has navigated nine times while this snapshot sat in storage.
+    const result = decodeSnapshot(flow, snapshot, { epoch: 9 });
+
+    expect(result.restored).toBe(true);
+    if (!result.restored) return;
+    expect(result.state.nav).toBe(10);
+  });
+
+  it('leaves a frame from a sub-flow to whoever can resolve it', () => {
+    // Rejecting this would refuse every snapshot taken inside a group: the step
+    // belongs to the child's steps, which this flow does not contain.
+    const snapshot = {
+      ...toSnapshot(live(), flow),
+      stack: [
+        { flow: 'signup', step: 'name' },
+        { flow: 'passenger', step: 'seat' },
+      ],
+    };
+
+    expect(decodeSnapshot(flow, snapshot).restored).toBe(true);
+  });
+
+  it('still refuses a runaway stack, not only runaway data', () => {
+    const snapshot = {
+      ...toSnapshot(live(), flow),
+      stack: [{ flow: 'signup', step: 'name', base: 'x'.repeat(1_000_001) }],
+    };
+
+    expect(decodeSnapshot(flow, snapshot)).toEqual({
+      restored: false,
+      reason: 'snapshot/too-large',
+    });
+  });
+
+  it('copies nested data rather than sharing it with live state', () => {
+    const state = live();
+    const snapshot = toSnapshot(state, flow);
+
+    (snapshot.data.name as { full: string }).full = 'Grace';
+
+    expect((state.data.name as { full: string }).full).toBe('Ada');
   });
 });

--- a/packages/core/src/v1/snapshot.test.ts
+++ b/packages/core/src/v1/snapshot.test.ts
@@ -1,0 +1,235 @@
+import { describe, expect, it } from 'vitest';
+
+import { decodeSnapshot, toSnapshot, type Snapshot } from './snapshot';
+import { initialState } from './state';
+
+import type { FlowDefinition } from './flow';
+
+const flow: FlowDefinition = {
+  id: 'signup',
+  version: 2,
+  order: ['name', 'review'],
+  steps: { name: {}, review: {} },
+};
+
+const live = () => ({
+  ...initialState({ name: { full: 'Ada' } }, { role: 'admin' }),
+  status: 'busy' as const,
+  stack: [{ flow: 'signup', step: 'name' }],
+  history: [[{ flow: 'signup', step: 'name' }]],
+  visited: ['name'],
+  completed: ['name'],
+  dirty: ['name.full'],
+  errors: { name: { full: 'too short' } },
+  busy: ['name'],
+  rev: 7,
+  nav: 3,
+});
+
+const roundTrip = (state = live()) =>
+  decodeSnapshot(flow, JSON.parse(JSON.stringify(toSnapshot(state, flow))) as unknown);
+
+describe('toSnapshot', () => {
+  it('keeps the session and drops what only described a moment', () => {
+    const snapshot = toSnapshot(live(), flow);
+
+    expect(snapshot).toEqual({
+      v: 1,
+      flow: 'signup',
+      version: 2,
+      stack: [{ flow: 'signup', step: 'name' }],
+      history: [[{ flow: 'signup', step: 'name' }]],
+      data: { name: { full: 'Ada' } },
+      ctx: { role: 'admin' },
+      visited: ['name'],
+      completed: ['name'],
+      dirty: ['name.full'],
+      nav: 3,
+    });
+    expect(snapshot).not.toHaveProperty('status');
+    expect(snapshot).not.toHaveProperty('errors');
+    expect(snapshot).not.toHaveProperty('busy');
+    expect(snapshot).not.toHaveProperty('rev');
+  });
+
+  it('hands out a detached copy, not a window into live state', () => {
+    const state = live();
+    const snapshot = toSnapshot(state, flow);
+
+    expect(snapshot.stack).not.toBe(state.stack);
+    expect(snapshot.stack[0]).not.toBe(state.stack[0]);
+    expect(snapshot.data).not.toBe(state.data);
+  });
+
+  it('omits the version when the flow carries none', () => {
+    expect(toSnapshot(live(), { ...flow, version: undefined })).not.toHaveProperty('version');
+  });
+});
+
+describe('decodeSnapshot', () => {
+  it('restores a session and resets everything transient', () => {
+    const result = roundTrip();
+
+    expect(result.restored).toBe(true);
+    if (!result.restored) return;
+    expect(result.state.status).toBe('idle');
+    expect(result.state.busy).toEqual([]);
+    expect(result.state.errors).toEqual({});
+    expect(result.state.rev).toBe(0);
+    // The epoch is carried, not reset: it is what makes anything begun before
+    // the restore resolve as superseded instead of overwriting it.
+    expect(result.state.nav).toBe(3);
+    expect(result.state.data).toEqual({ name: { full: 'Ada' } });
+  });
+
+  it.each([
+    ['not an object', 'null', null],
+    ['a string', 'a string', 'nope'],
+    ['no version field', 'no v', { flow: 'signup', stack: [] }],
+    ['a stack that is not frames', 'bad stack', { v: 1, flow: 'signup', stack: [null] }],
+  ])('refuses %s', (_label, _name, input) => {
+    expect(decodeSnapshot(flow, input)).toEqual({
+      restored: false,
+      reason: 'snapshot/unreadable',
+    });
+  });
+
+  it('refuses a snapshot of another flow', () => {
+    const snapshot = { ...toSnapshot(live(), flow), flow: 'checkout' };
+    expect(decodeSnapshot(flow, snapshot)).toEqual({
+      restored: false,
+      reason: 'snapshot/other-flow',
+    });
+  });
+
+  it('refuses a snapshot of an older version of this flow', () => {
+    const snapshot = { ...toSnapshot(live(), flow), version: 1 };
+    expect(decodeSnapshot(flow, snapshot)).toEqual({
+      restored: false,
+      reason: 'snapshot/other-flow',
+    });
+  });
+
+  it('accepts one when either side never stamped a version', () => {
+    const unstamped = { ...flow, version: undefined };
+    const snapshot = toSnapshot(live(), unstamped);
+
+    expect(decodeSnapshot(unstamped, snapshot).restored).toBe(true);
+    expect(decodeSnapshot(flow, snapshot).restored).toBe(true);
+  });
+
+  it('refuses a frame naming a step the flow no longer has', () => {
+    const snapshot = {
+      ...toSnapshot(live(), flow),
+      stack: [{ flow: 'signup', step: 'gone' }],
+    };
+    expect(decodeSnapshot(flow, snapshot)).toEqual({
+      restored: false,
+      reason: 'snapshot/unknown-step',
+    });
+  });
+
+  it('checks the history the same way as the stack', () => {
+    const snapshot = {
+      ...toSnapshot(live(), flow),
+      history: [[{ flow: 'signup', step: 'gone' }]],
+    };
+    expect(decodeSnapshot(flow, snapshot).restored).toBe(false);
+  });
+
+  it.each([
+    ['a value JSON cannot round-trip', { at: new Date() }],
+    ['a number that is not finite', { at: Number.POSITIVE_INFINITY }],
+    ['a key that reaches the prototype', JSON.parse('{"__proto__": {"admin": true}}')],
+  ])('refuses %s in data', (_label, data) => {
+    const snapshot = { ...toSnapshot(live(), flow), data };
+    expect(decodeSnapshot(flow, snapshot)).toEqual({
+      restored: false,
+      reason: 'snapshot/unstorable',
+    });
+  });
+
+  it('refuses a cycle rather than following it', () => {
+    const data: Record<string, unknown> = {};
+    data.self = data;
+    const snapshot = { ...toSnapshot(live(), flow), data };
+
+    expect(decodeSnapshot(flow, snapshot)).toEqual({
+      restored: false,
+      reason: 'snapshot/unstorable',
+    });
+  });
+
+  it('refuses something too deep to be worth reading', () => {
+    let deep: Record<string, unknown> = { end: true };
+    for (let i = 0; i < 40; i++) deep = { deep };
+    const snapshot = { ...toSnapshot(live(), flow), data: deep };
+
+    expect(decodeSnapshot(flow, snapshot)).toEqual({
+      restored: false,
+      reason: 'snapshot/too-large',
+    });
+  });
+
+  it('refuses something too large', () => {
+    const snapshot = { ...toSnapshot(live(), flow), data: { blob: 'x'.repeat(1_000_001) } };
+    expect(decodeSnapshot(flow, snapshot)).toEqual({
+      restored: false,
+      reason: 'snapshot/too-large',
+    });
+  });
+});
+
+describe('migration', () => {
+  const older = { ...toSnapshot(live(), flow), v: 0 } as unknown as Snapshot;
+
+  it('refuses an unknown version when no migration is offered', () => {
+    expect(decodeSnapshot(flow, older)).toEqual({ restored: false, reason: 'snapshot/version' });
+  });
+
+  it('runs the migration and restores what it produced', () => {
+    const result = decodeSnapshot(flow, older, {
+      migrate: (s) => ({ ...s, v: 1 }),
+    });
+
+    expect(result.restored).toBe(true);
+  });
+
+  it('walks a chain one hop at a time', () => {
+    const ancient = { ...toSnapshot(live(), flow), v: -2 } as unknown as Snapshot;
+    const hops: number[] = [];
+
+    const result = decodeSnapshot(flow, ancient, {
+      migrate: (s) => {
+        hops.push(s.v);
+        return { ...s, v: s.v + 1 };
+      },
+    });
+
+    expect(hops).toEqual([-2, -1, 0]);
+    expect(result.restored).toBe(true);
+  });
+
+  it('gives up rather than looping when a migration stands still', () => {
+    let calls = 0;
+    const result = decodeSnapshot(flow, older, {
+      migrate: (s) => {
+        calls += 1;
+        return { ...s };
+      },
+    });
+
+    expect(result).toEqual({ restored: false, reason: 'snapshot/version' });
+    expect(calls).toBeLessThanOrEqual(16);
+  });
+
+  it('validates what the migration returned, not what it was given', () => {
+    // A host's migrate is ordinary code. Trusting its output is how a corrupt
+    // snapshot becomes a corrupt session.
+    const result = decodeSnapshot(flow, older, {
+      migrate: () => ({ v: 1, flow: 'signup', stack: 'not frames' }),
+    });
+
+    expect(result).toEqual({ restored: false, reason: 'snapshot/unreadable' });
+  });
+});

--- a/packages/core/src/v1/snapshot.ts
+++ b/packages/core/src/v1/snapshot.ts
@@ -1,0 +1,254 @@
+import { isStackEntry } from './session';
+
+import type { FlowDefinition } from './flow';
+import type { Frame, WizardState } from './state';
+
+/**
+ * The durable shape of a wizard.
+ *
+ * A running wizard has fields that describe a moment rather than a session:
+ * whether a navigation is in flight, which steps are loading, the errors a
+ * validator produced, and the revision counter the selectors memoize on. None
+ * of them survive a reload, and storing them is how a restored wizard comes
+ * back stuck in `busy` with errors nobody can clear.
+ *
+ * So a snapshot is the session and nothing else, plus the identity needed to
+ * tell whether it still belongs to the flow being restored, plus `v`: the
+ * format's own version, which is what lets a host migrate a snapshot written
+ * by an older release instead of throwing it away.
+ */
+export interface Snapshot {
+  /** Format version. Bumped when this shape changes, never for a flow change. */
+  v: 1;
+  /** `FlowDefinition.id` at the time it was written. */
+  flow: string;
+  /** `FlowDefinition.version`, when the flow carried one. */
+  version?: number;
+  stack: readonly Frame[];
+  history: readonly (readonly Frame[])[];
+  data: Readonly<Record<string, unknown>>;
+  ctx: Readonly<Record<string, unknown>>;
+  visited: readonly string[];
+  completed: readonly string[];
+  dirty: readonly string[];
+  /** The navigation epoch, so a restored wizard cannot be raced by an older one. */
+  nav: number;
+}
+
+export type RestoreReason =
+  /** Not an object, or not this format. */
+  | 'snapshot/unreadable'
+  /** A `v` this build does not know and `migrate` did not handle. */
+  | 'snapshot/version'
+  /** The flow id or its version differs from the one being restored into. */
+  | 'snapshot/other-flow'
+  /** A frame names a step the flow no longer has. */
+  | 'snapshot/unknown-step'
+  /** Values JSON cannot round-trip, or a key that would poison a prototype. */
+  | 'snapshot/unstorable'
+  /** Larger or deeper than the bounds below. */
+  | 'snapshot/too-large';
+
+export type RestoreResult =
+  | { restored: true; state: WizardState }
+  | { restored: false; reason: RestoreReason };
+
+export interface DecodeOptions {
+  /**
+   * Upgrades a snapshot written by an older format. Called until it returns
+   * something at the current version or gives up by returning the input
+   * unchanged, so a host can write one hop at a time rather than one function
+   * that knows every past shape.
+   */
+  migrate?: (snapshot: { v: number } & Record<string, unknown>) => unknown;
+}
+
+/** Bounds, so a crafted or runaway snapshot cannot hang the tab that reads it. */
+const MAX_BYTES = 1_000_000;
+const MAX_DEPTH = 32;
+const MAX_MIGRATIONS = 16;
+
+/** Keys that would reach the prototype chain if they were ever assigned through. */
+const POISON = new Set(['__proto__', 'constructor', 'prototype']);
+
+const CURRENT: Snapshot['v'] = 1;
+
+/**
+ * A session, detached from the engine.
+ *
+ * The result is a fresh object with no reference into live state: handing out
+ * something a host could mutate would put a second writer next to `commit.ts`,
+ * which is the one thing the engine's design does not allow.
+ */
+export function toSnapshot(state: WizardState, flow: FlowDefinition): Snapshot {
+  return {
+    v: CURRENT,
+    flow: flow.id,
+    ...(flow.version === undefined ? {} : { version: flow.version }),
+    stack: state.stack.map((f) => ({ ...f })),
+    history: state.history.map((frames) => frames.map((f) => ({ ...f }))),
+    data: { ...state.data },
+    ctx: { ...state.ctx },
+    visited: [...state.visited],
+    completed: [...state.completed],
+    dirty: [...state.dirty],
+    nav: state.nav,
+  };
+}
+
+/**
+ * Turns stored JSON back into state, or says why it will not.
+ *
+ * Pure: it decides, and hands the caller a state to install. Installing is the
+ * plugin's job and goes through `commit`, so a restore is a commit like any
+ * other write and the epoch moves with it - anything begun before the restore
+ * resolves as superseded rather than overwriting what was just put back.
+ *
+ * The order matters. Read the envelope, migrate, then validate what migration
+ * produced: a host's `migrate` is ordinary code that can return nonsense, and
+ * trusting its output is how a corrupt snapshot becomes a corrupt session.
+ */
+export function decodeSnapshot(
+  flow: FlowDefinition,
+  input: unknown,
+  options: DecodeOptions = {}
+): RestoreResult {
+  if (input === null || typeof input !== 'object') return fail('snapshot/unreadable');
+
+  let candidate = input as { v?: unknown } & Record<string, unknown>;
+  if (typeof candidate.v !== 'number') return fail('snapshot/unreadable');
+
+  for (let hop = 0; candidate.v !== CURRENT; hop++) {
+    if (options.migrate === undefined || hop >= MAX_MIGRATIONS) return fail('snapshot/version');
+    // `unknown`, because a host's migration is ordinary code: it can return
+    // null, a string, or the object it was handed, and the loop has to survive
+    // all three rather than trust the signature.
+    const next: unknown = options.migrate(candidate as { v: number } & Record<string, unknown>);
+    if (next === null || typeof next !== 'object' || next === candidate) {
+      return fail('snapshot/version');
+    }
+    candidate = next as { v?: unknown } & Record<string, unknown>;
+    if (typeof candidate.v !== 'number') return fail('snapshot/unreadable');
+  }
+
+  if (!isSnapshotShaped(candidate)) return fail('snapshot/unreadable');
+  const snapshot = candidate;
+
+  if (snapshot.flow !== flow.id) return fail('snapshot/other-flow');
+  // A version is only compared when both sides have one: an unstamped flow is a
+  // producer that never versioned itself, not evidence of a mismatch.
+  if (
+    snapshot.version !== undefined &&
+    flow.version !== undefined &&
+    snapshot.version !== flow.version
+  ) {
+    return fail('snapshot/other-flow');
+  }
+
+  const frames = [...snapshot.stack, ...snapshot.history.flat()];
+  if (frames.some((f) => flow.steps[f.step] === undefined)) return fail('snapshot/unknown-step');
+
+  const storable = checkStorable({ data: snapshot.data, ctx: snapshot.ctx });
+  if (storable !== null) return fail(storable);
+
+  return {
+    restored: true,
+    state: {
+      status: 'idle',
+      stack: snapshot.stack,
+      history: snapshot.history,
+      data: snapshot.data,
+      ctx: snapshot.ctx,
+      visited: snapshot.visited,
+      completed: snapshot.completed,
+      dirty: snapshot.dirty,
+      // Transient, every one of them: a reload ends whatever was in flight, no
+      // step is loading, and errors are recomputed by the next validation
+      // rather than trusted from storage, where they may describe data that has
+      // since been edited.
+      errors: {},
+      busy: [],
+      rev: 0,
+      nav: snapshot.nav,
+    },
+  };
+}
+
+const fail = (reason: RestoreReason): RestoreResult => ({ restored: false, reason });
+
+const isStringArray = (value: unknown): value is string[] =>
+  Array.isArray(value) && value.every((v) => typeof v === 'string');
+
+const isPlainObject = (value: unknown): value is Record<string, unknown> =>
+  value !== null && typeof value === 'object' && !Array.isArray(value);
+
+function isSnapshotShaped(
+  value: Record<string, unknown>
+): value is Snapshot & Record<string, unknown> {
+  return (
+    typeof value.flow === 'string' &&
+    (value.version === undefined || typeof value.version === 'number') &&
+    Array.isArray(value.stack) &&
+    value.stack.every(isStackEntry) &&
+    Array.isArray(value.history) &&
+    value.history.every((frames) => Array.isArray(frames) && frames.every(isStackEntry)) &&
+    isPlainObject(value.data) &&
+    isPlainObject(value.ctx) &&
+    isStringArray(value.visited) &&
+    isStringArray(value.completed) &&
+    isStringArray(value.dirty) &&
+    typeof value.nav === 'number'
+  );
+}
+
+/**
+ * Walks what will be stored, looking for the three ways JSON lies: values it
+ * cannot round-trip, keys that reach a prototype, and a shape too big or too
+ * deep to be worth the tab it would be read in.
+ *
+ * `undefined`, `NaN` and `Infinity` all survive `JSON.stringify` as something
+ * other than themselves, and a `Date` comes back a string. A wizard that
+ * restored one of those would be quietly wrong rather than loudly broken, and
+ * quietly wrong is the failure this whole format exists to avoid.
+ */
+function checkStorable(value: unknown): RestoreReason | null {
+  const seen = new Set<object>();
+  let bytes = 0;
+
+  const walk = (node: unknown, depth: number): RestoreReason | null => {
+    if (depth > MAX_DEPTH) return 'snapshot/too-large';
+    if (node === null || typeof node === 'boolean') return null;
+
+    if (typeof node === 'number') {
+      return Number.isFinite(node) ? null : 'snapshot/unstorable';
+    }
+    if (typeof node === 'string') {
+      bytes += node.length;
+      return bytes > MAX_BYTES ? 'snapshot/too-large' : null;
+    }
+    if (typeof node !== 'object') return 'snapshot/unstorable';
+    if (seen.has(node)) return 'snapshot/unstorable';
+    seen.add(node);
+
+    if (Array.isArray(node)) {
+      for (const item of node) {
+        const problem = walk(item, depth + 1);
+        if (problem !== null) return problem;
+      }
+      return null;
+    }
+
+    if (Object.getPrototypeOf(node) !== Object.prototype) return 'snapshot/unstorable';
+
+    for (const [key, child] of Object.entries(node)) {
+      if (POISON.has(key)) return 'snapshot/unstorable';
+      bytes += key.length;
+      if (bytes > MAX_BYTES) return 'snapshot/too-large';
+      const problem = walk(child, depth + 1);
+      if (problem !== null) return problem;
+    }
+    return null;
+  };
+
+  return walk(value, 0);
+}

--- a/packages/core/src/v1/snapshot.ts
+++ b/packages/core/src/v1/snapshot.ts
@@ -55,6 +55,12 @@ export type RestoreResult =
 
 export interface DecodeOptions {
   /**
+   * The engine's current epoch, when restoring into a live wizard. The restored
+   * state always lands above it, so a navigation begun before the restore
+   * resolves as superseded instead of overwriting what was just put back.
+   */
+  epoch?: number;
+  /**
    * Upgrades a snapshot written by an older format. Called until it returns
    * something at the current version or gives up by returning the input
    * unchanged, so a host can write one hop at a time rather than one function
@@ -87,13 +93,33 @@ export function toSnapshot(state: WizardState, flow: FlowDefinition): Snapshot {
     ...(flow.version === undefined ? {} : { version: flow.version }),
     stack: state.stack.map((f) => ({ ...f })),
     history: state.history.map((frames) => frames.map((f) => ({ ...f }))),
-    data: { ...state.data },
-    ctx: { ...state.ctx },
+    data: detach(state.data),
+    ctx: detach(state.ctx),
     visited: [...state.visited],
     completed: [...state.completed],
     dirty: [...state.dirty],
     nav: state.nav,
   };
+}
+
+/**
+ * A deep copy of the plain parts.
+ *
+ * A shallow spread would leave every nested object shared with live state, so
+ * `snapshot.data.name.full = 'x'` would reach into the engine - a second writer
+ * beside `commit.ts`, which is the one thing the design does not allow.
+ *
+ * Anything that is not a plain object or an array is copied by reference and
+ * left for `decodeSnapshot` to refuse: a `Date` is a bug to report at the
+ * boundary, not something to quietly convert on the way out.
+ */
+function detach<T>(value: T): T {
+  if (Array.isArray(value)) return value.map(detach) as unknown as T;
+  if (value === null || typeof value !== 'object') return value;
+  if (Object.getPrototypeOf(value) !== Object.prototype) return value;
+  const out: Record<string, unknown> = {};
+  for (const [key, child] of Object.entries(value)) out[key] = detach(child);
+  return out as T;
 }
 
 /**
@@ -145,10 +171,16 @@ export function decodeSnapshot(
     return fail('snapshot/other-flow');
   }
 
+  // Only frames belonging to this flow can be checked here. A frame naming a
+  // sub-flow is checked by whoever can resolve that sub-flow; rejecting it
+  // would refuse every legitimate snapshot taken inside a group.
   const frames = [...snapshot.stack, ...snapshot.history.flat()];
-  if (frames.some((f) => flow.steps[f.step] === undefined)) return fail('snapshot/unknown-step');
+  const mine = frames.filter((f) => f.flow === flow.id);
+  if (mine.some((f) => flow.steps[f.step] === undefined)) return fail('snapshot/unknown-step');
 
-  const storable = checkStorable({ data: snapshot.data, ctx: snapshot.ctx });
+  // The whole snapshot, not only what a host put in it: a stack or a history
+  // can run away just as easily as a data blob can.
+  const storable = checkStorable(snapshot);
   if (storable !== null) return fail(storable);
 
   return {
@@ -169,7 +201,10 @@ export function decodeSnapshot(
       errors: {},
       busy: [],
       rev: 0,
-      nav: snapshot.nav,
+      // Always above both the stored epoch and the live one. Carrying the
+      // stored number verbatim would leave a navigation already in flight
+      // holding a token that still counts as current, and it would win.
+      nav: Math.max(snapshot.nav, options.epoch ?? 0) + 1,
     },
   };
 }

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
     'src/v1/validate-flow.ts',
     'src/v1/graph.ts',
     'src/v1/session.ts',
+    'src/v1/snapshot.ts',
   ],
   format: ['cjs', 'esm'],
   dts: true,


### PR DESCRIPTION
Persistence needs a shape that survives a reload, and `WizardState` is not it. Four of its fields describe a moment rather than a session — whether a navigation is in flight, which steps are loading, the errors a validator produced, and the `rev` the selectors memoize on. Storing them is how a restored wizard comes back stuck in `busy` with errors nobody can clear.

**`toSnapshot(state, flow)`** keeps the session and drops those four, plus the identity — flow id and version — needed to tell whether it still belongs to the flow being restored. It hands back a **detached copy**: a live reference would put a second writer next to `commit.ts`.

**`decodeSnapshot(flow, input, { migrate })`** is a pure decoder that returns `{ restored: true, state }` or `{ restored: false, reason }`. State, not a boolean, because the plugin installs it through `commit` — which is what makes a restore a commit like any other write, with the epoch moving so anything begun before it resolves as `superseded` instead of overwriting what was just put back.

The order is envelope → migrate → validate, and that order is the point: a host's `migrate` is ordinary code that can return `null`, a string, or the object it was handed, so it is typed `unknown` and its output is validated rather than trusted. Migration walks one hop at a time (`v: -2 → -1 → 0 → 1`), so a host writes one upgrade per release instead of one function that knows every past shape, and it gives up rather than looping when a migration stands still.

Refused, each with its own reason: another flow, an older version of this one, a frame naming a step that no longer exists (reusing `session.ts`'s frame checker rather than a second copy that would drift), values JSON cannot round-trip (`Date`, `NaN`, `Infinity`, `undefined`), keys that reach a prototype, cycles, and anything past 1 MB or 32 deep.

**Budget:** its own entry at 966 B against a 1 kB ratchet. An application that never persists a wizard should not carry the validator that decides whether stored JSON can be trusted — hard rule 6, tsup entry and `exports` key in the same commit.

Gates: 286 tests (24 new), lint 0 errors, type-check, prettier, `publint`, `attw`, `pnpm size`, `pnpm examples:check`.

Task L4a of `docs/designs/v1-launch.md`. The `/persist` plugin (L4b) sits on top of this and the lifecycle hooks from #31.