### PR TITLE
feat(core): clearOnLeave, applied in the navigation commit

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -36,7 +36,12 @@ export default [
   // plugin disabled rather than taking the write down with it, is what makes
   // a persist plugin possible at all. Two hundred bytes, once, for every
   // plugin the library will ever have.
-  { name: 'core-v1', path: 'packages/core/src/v1/index.ts', limit: '4.3 kB', gzip: true },
+  //
+  // 4.3 to 4.5 kB on 2026-09-06 for `clearOnLeave`: an immutable delete on a
+  // path and its application in the navigation commit, 133 bytes measured.
+  // The 4.3 had 34 bytes of headroom, and the field was already promised by
+  // the API behaviour table and the "clear abandoned branch data" task page.
+  { name: 'core-v1', path: 'packages/core/src/v1/index.ts', limit: '4.5 kB', gzip: true },
 
   // The graph builder. Its own entry for the same reason validate-flow is:
   // structure-only drawing is a development and inspection concern, and a

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -41,7 +41,7 @@ Dependencies point one way — into core. Core has no runtime dependencies.
 
 | Package                      | Role                                                                                                                | Budget (gzip)     |
 | ---------------------------- | ------------------------------------------------------------------------------------------------------------------- | ----------------- |
-| `@wizzard-packages/core`     | flow types, expression evaluator, engine, navigation pipeline, selectors, `defineFlow`, `patchFlow`, `validateFlow` | 4.3 kB            |
+| `@wizzard-packages/core`     | flow types, expression evaluator, engine, navigation pipeline, selectors, `defineFlow`, `patchFlow`, `validateFlow` | 4.5 kB            |
 | `@wizzard-packages/react`    | provider, hooks, `useSyncExternalStore` bridge                                                                      | 1.5 kB            |
 | `@wizzard-packages/vue`      | `provideWizard`, composables, `shallowRef` bridge                                                                   | 1.5 kB            |
 | `@wizzard-packages/validate` | one Standard Schema adapter — Zod, Valibot, ArkType, Effect, Yup                                                    | **317 B**         |

--- a/packages/core/src/v1/flow.ts
+++ b/packages/core/src/v1/flow.ts
@@ -39,6 +39,14 @@ interface StepBase {
   load?: { $ref: string; args?: Json };
   /** The body of this step arrives later, from the host. */
   deferred?: boolean;
+  /**
+   * What to forget when this step is left, forwards or backwards. Data is
+   * kept by default: a person who goes back and returns expects their answers
+   * to still be there. `true` drops the step's whole slice (`slice`, or the
+   * step id); a list drops those `data` paths, in the same path language as
+   * `set()`. Nothing is cleared on completion — that data is the submission.
+   */
+  clearOnLeave?: readonly string[] | true;
 }
 
 export interface AtomStep extends StepBase {

--- a/packages/core/src/v1/navigate.test.ts
+++ b/packages/core/src/v1/navigate.test.ts
@@ -382,3 +382,88 @@ describe('runNav — bookkeeping', () => {
     expect(host.writes[1]?.status).toBe('idle');
   });
 });
+
+describe('runNav — clearOnLeave', () => {
+  const branching: FlowDefinition = {
+    id: 'booking',
+    order: ['trip', 'company', 'payment'],
+    steps: {
+      trip: {},
+      company: { clearOnLeave: true },
+      payment: {},
+    },
+  };
+  const filled = {
+    payer: 'business',
+    trip: { city: 'Oslo' },
+    company: { name: 'Acme', vat: 'NO123' },
+  };
+
+  it('keeps the data of a step it leaves, by default', async () => {
+    const host = makeHost({ ...on('trip'), data: filled });
+    await runNav({ flow: branching }, host, { type: 'next' });
+    expect(host.read().data).toBe(filled);
+  });
+
+  it('clears the whole slice on `true`, forwards and backwards', async () => {
+    const host = makeHost({ ...on('company'), data: filled });
+    await runNav({ flow: branching }, host, { type: 'next' });
+    expect(host.read().data).toEqual({ payer: 'business', trip: { city: 'Oslo' } });
+
+    const back = makeHost({
+      ...on('company'),
+      data: filled,
+      history: [[{ flow: 'booking', step: 'trip' }]],
+    });
+    await runNav({ flow: branching }, back, { type: 'back' });
+    expect(back.read().stack[0]?.step).toBe('trip');
+    expect(back.read().data).toEqual({ payer: 'business', trip: { city: 'Oslo' } });
+  });
+
+  it('clears the declared `slice`, not the step id', async () => {
+    const flow: FlowDefinition = {
+      ...branching,
+      steps: { ...branching.steps, company: { slice: 'org', clearOnLeave: true } },
+    };
+    const host = makeHost({ ...on('company'), data: { ...filled, org: { name: 'Acme' } } });
+    await runNav({ flow }, host, { type: 'next' });
+    expect(host.read().data).toEqual(filled);
+  });
+
+  it('clears only the listed paths on an array, and leaves the rest of the slice', async () => {
+    const flow: FlowDefinition = {
+      ...branching,
+      steps: {
+        ...branching.steps,
+        company: { clearOnLeave: ['company.vat', 'payer', 'nowhere.x'] },
+      },
+    };
+    const host = makeHost({ ...on('company'), data: filled });
+    await runNav({ flow }, host, { type: 'next' });
+    expect(host.read().data).toEqual({ trip: { city: 'Oslo' }, company: { name: 'Acme' } });
+    // Untouched branches keep their identity, so selectors over them stay memoized.
+    expect(host.read().data['trip']).toBe(filled.trip);
+  });
+
+  it('keeps everything on completion: the data is what the host submits', async () => {
+    const flow: FlowDefinition = {
+      ...branching,
+      steps: { ...branching.steps, payment: { clearOnLeave: true } },
+    };
+    const host = makeHost({ ...on('payment'), data: { ...filled, payment: { card: '4242' } } });
+    const result = await runNav({ flow }, host, { type: 'next' });
+    expect(result).toEqual({ ok: true, from: 'payment', to: END });
+    expect(host.read().data['payment']).toEqual({ card: '4242' });
+  });
+
+  it('does not clear when the navigation fails', async () => {
+    const host = makeHost({ ...on('company'), data: filled });
+    const result = await runNav(
+      { flow: branching, validate: async () => ({ name: 'required' }) },
+      host,
+      { type: 'next' }
+    );
+    expect(result.ok).toBe(false);
+    expect(host.read().data).toBe(filled);
+  });
+});

--- a/packages/core/src/v1/navigate.ts
+++ b/packages/core/src/v1/navigate.ts
@@ -1,6 +1,7 @@
 import { add, beginNav, commit, isCurrent } from './commit';
 import { testAsync, type AsyncRegistry, type Scope } from './expr';
 import { END, type FlowDefinition, type StepDef } from './flow';
+import { unsetPath } from './path';
 import { allowedByPolicy, reachable, resolveBack, resolveNext } from './resolve';
 
 import type { WizardState } from './state';
@@ -111,6 +112,15 @@ export interface NavContext {
 
 const scopeOf = (s: WizardState): Scope => ({ data: s.data, ctx: s.ctx });
 const currentOf = (s: WizardState): string | null => s.stack[s.stack.length - 1]?.step ?? null;
+
+/** Applies the left step's `clearOnLeave`. Pure: the commit below writes the result. */
+function leave(flow: FlowDefinition, from: string, data: WizardState['data']): WizardState['data'] {
+  const step = flow.steps[from];
+  const clear = step?.clearOnLeave;
+  if (clear === undefined) return data;
+  const paths = clear === true ? [step.slice ?? from] : clear;
+  return paths.reduce((acc, path) => unsetPath(acc, path), data);
+}
 
 const superseded: NavResult = { ok: false, reason: 'superseded' };
 const aborted: NavResult = { ok: false, reason: 'aborted' };
@@ -257,6 +267,7 @@ export async function runNav(
         visited: add(before.visited, target),
         completed: forward && from !== null ? add(before.completed, from) : before.completed,
         busy: before.busy.filter((id) => id !== target),
+        data: from === null ? before.data : leave(flow, from, before.data),
       })
     );
 

--- a/packages/core/src/v1/path.property.test.ts
+++ b/packages/core/src/v1/path.property.test.ts
@@ -1,0 +1,48 @@
+import fc from 'fast-check';
+import { describe, expect, it } from 'vitest';
+
+import { getPath, setPath, unsetPath } from './path';
+
+const key = fc.stringMatching(/^[a-z]{1,4}$/);
+const index = fc.nat({ max: 3 });
+/** Dot paths mixing object keys and array indices, as a repeat group generates them. */
+const path = fc
+  .array(fc.oneof(key, index.map(String)), { minLength: 1, maxLength: 4 })
+  .map((parts) => parts.join('.'));
+const plain = fc
+  .jsonValue({ maxDepth: 3 })
+  .map((v) =>
+    v !== null && typeof v === 'object' && !Array.isArray(v) ? (v as Record<string, unknown>) : {}
+  );
+
+describe('unsetPath', () => {
+  it('removes exactly what setPath put there, and nothing else', () => {
+    fc.assert(
+      fc.property(plain, path, fc.string(), (source, p, value) => {
+        fc.pre(getPath(source, p) === undefined);
+        const withValue = setPath(source, p, value);
+        expect(getPath(withValue, p)).toBe(value);
+        expect(getPath(unsetPath(withValue, p), p)).toBeUndefined();
+      })
+    );
+  });
+
+  it('keeps an array an array when the last segment is an index', () => {
+    fc.assert(
+      fc.property(fc.array(fc.string(), { minLength: 1, maxLength: 5 }), index, (items, i) => {
+        const out = unsetPath({ list: items }, `list[${i}]`);
+        expect(Array.isArray(out.list)).toBe(true);
+        expect(out.list).toEqual(items.filter((_, at) => at !== i));
+      })
+    );
+  });
+
+  it('returns the same reference when there is nothing at the path', () => {
+    fc.assert(
+      fc.property(plain, path, (source, p) => {
+        fc.pre(getPath(source, p) === undefined);
+        expect(unsetPath(source, p)).toBe(source);
+      })
+    );
+  });
+});

--- a/packages/core/src/v1/path.ts
+++ b/packages/core/src/v1/path.ts
@@ -67,6 +67,8 @@ export function unsetPath<T extends object>(target: T, path: string): T {
   if (last === undefined || !parent || !Object.prototype.hasOwnProperty.call(parent, last)) {
     return target;
   }
-  const { [last]: _, ...rest } = parent;
+  const rest = Array.isArray(parent)
+    ? parent.filter((_, i) => String(i) !== last)
+    : (({ [last]: _, ...kept }) => kept)(parent);
   return at ? setPath(target, at, rest) : (rest as T);
 }

--- a/packages/core/src/v1/path.ts
+++ b/packages/core/src/v1/path.ts
@@ -54,3 +54,19 @@ export function setPath<T extends object>(target: T, path: string, value: unknow
   (cur as Record<string, unknown>)[keys[keys.length - 1] as string] = value;
   return root as T;
 }
+
+/**
+ * Immutable delete. Returns the same reference when there was nothing at the
+ * path, for the same reason `setPath` does.
+ */
+export function unsetPath<T extends object>(target: T, path: string): T {
+  const keys = parse(path);
+  const last = keys.pop();
+  const at = keys.join('.');
+  const parent = getPath(target, at) as Record<string, unknown> | null | undefined;
+  if (last === undefined || !parent || !Object.prototype.hasOwnProperty.call(parent, last)) {
+    return target;
+  }
+  const { [last]: _, ...rest } = parent;
+  return at ? setPath(target, at, rest) : (rest as T);
+}

--- a/packages/core/src/v1/validate-flow.test.ts
+++ b/packages/core/src/v1/validate-flow.test.ts
@@ -77,6 +77,20 @@ describe('validateFlow', () => {
     expect(problems(flow)[0]).toMatch(/cannot be serialized/);
   });
 
+  it('catches a clearOnLeave that is neither true nor a list of paths', () => {
+    const withClear = (clearOnLeave: unknown): FlowDefinition => ({
+      ...good,
+      steps: { ...good.steps, company: { clearOnLeave: clearOnLeave as never } },
+    });
+    for (const bad of ['company', false, ['vat', 1]]) {
+      expect(problems(withClear(bad))).toEqual([
+        'steps.company.clearOnLeave: must be true or a list of data paths',
+      ]);
+    }
+    expect(problems(withClear(true))).toEqual([]);
+    expect(problems(withClear(['vat']))).toEqual([]);
+  });
+
   it('catches order problems', () => {
     expect(problems({ id: 'f', order: ['a', 'ghost'], steps: { a: {} } })).toContain(
       'order: unknown step: ghost'

--- a/packages/core/src/v1/validate-flow.ts
+++ b/packages/core/src/v1/validate-flow.ts
@@ -94,6 +94,17 @@ export function validateFlow(
       if (!(to in flow.steps)) report(`${at}.on.back`, `unknown target: ${to}`);
     }
 
+    // A flow from a backend has no types behind it, so the shape is checked here
+    // rather than discovered as a TypeError in the middle of a navigation.
+    const clear = step_.clearOnLeave as unknown;
+    if (
+      clear !== undefined &&
+      clear !== true &&
+      !(Array.isArray(clear) && clear.every((p) => typeof p === 'string'))
+    ) {
+      report(`${at}.clearOnLeave`, 'must be true or a list of data paths');
+    }
+
     // Both mechanisms at once is legal but almost always a mistake: the branch
     // wins and the reachability rule is silently ignored.
     if (step_.when !== undefined && step_.on?.next !== undefined) {


### PR DESCRIPTION
## What

L10 of `docs/designs/v1-launch.md`: `clearOnLeave?: readonly string[] | true` on `StepBase`.

- Kept by default. A person who goes back and returns expects their answers to still be there.
- `true` drops the step's whole slice: `slice`, or the step id.
- A list drops those `data` paths, in the same path language as `set()`, so a step can forget one field and keep the rest.
- Applied whenever the step is left, forwards or backwards, inside the phase 9 commit. A failed or superseded navigation clears nothing.
- Never on completion: the data at `END` is what the host submits.

`unsetPath` joins `getPath` and `setPath` in `path.ts`: immutable, and the same reference when there was nothing at the path, so untouched branches keep their identity and memoized selectors stay warm.

## Tests

Six in `navigate.test.ts`: kept by default; `true` clears forwards and backwards; the declared `slice` wins over the step id; a list clears only the listed paths and leaves the siblings' identity intact; completion keeps everything; a failed validation clears nothing.

`pnpm verify` green: 312 tests, 0 lint errors (233 legacy warnings).

## Budget

core-v1 4.3 kB to 4.5 kB. The change measures 133 bytes and the old limit had 34 bytes of headroom. The reason sits in the comment beside the budget in `.size-limit.js`, and `ROADMAP.md` matches. No changeset: v1 is unreleased.
