### PR TITLE
feat(core): type the wizard against its flow, add the expression builder

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -74,6 +74,19 @@ export default [
     gzip: true,
   },
 
+  // The typed expression builder. Its own entry because it is an authoring
+  // concern: `eq(get('data.plan'), 'pro')` compiles to the JSON the evaluator
+  // reads, so a flow that arrives as JSON was built elsewhere and its runtime
+  // pays nothing for the functions that would have written it.
+  //
+  // Measured 2026-09-06 at 147 B: thirteen one-line functions and a type.
+  {
+    name: 'core-v1 expr',
+    path: 'packages/core/src/v1/expr-builder.ts',
+    limit: '200 B',
+    gzip: true,
+  },
+
   // Development and server-driven use only. Measured, but never counted against
   // the runtime budget, because shipping it to a browser is a mistake the
   // separate entry makes hard to commit by accident.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,7 @@ directory is the new engine; everything beside it is the line being retired.
 
 ```
 packages/core/src/v1/   the engine: expr, resolve, navigate, commit, select, store, state, path
-                        plus its own entries - validate-flow, graph, session
+                        plus its own entries - validate-flow, graph, session, snapshot, expr
 packages/core/src/      0.x. Being deleted; do not build on it
 packages/react/src/v1/  the React binding, ~200 lines. packages/react/src/* is 0.x
 packages/vue/src/v1/    the Vue binding, same shape
@@ -52,8 +52,8 @@ docs/designs/           the plan of record: v1-launch.md, flow-inspector.md
 5. **Logic belongs in core, not in a binding.** If React and Vue both need it, it is a core
    concern. 0.x has `next`/`prev` implemented three times and the copies disagree; that class
    of bug is not allowed back.
-6. **Every `core` sub-entry is its own budget.** `validate-flow`, `graph` and `session` are
-   separate entries so a runtime bundle never carries them; re-exporting one from
+6. **Every `core` sub-entry is its own budget.** `validate-flow`, `graph`, `session`,
+   `snapshot` and `expr` are separate entries so a runtime bundle never carries them; re-exporting one from
    `v1/index.ts` silently moves it into everyone's bundle. Adding an entry means a tsup
    entry, an `exports` key and a `.size-limit.js` line in the same PR. Budgets are ratchets
    set just above what a thing measures once it is correct - raise one with a stated reason

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -83,6 +83,16 @@
         "types": "./dist/v1/snapshot.d.cts",
         "default": "./dist/v1/snapshot.cjs"
       }
+    },
+    "./expr": {
+      "import": {
+        "types": "./dist/v1/expr-builder.d.ts",
+        "default": "./dist/v1/expr-builder.js"
+      },
+      "require": {
+        "types": "./dist/v1/expr-builder.d.cts",
+        "default": "./dist/v1/expr-builder.cjs"
+      }
     }
   },
   "files": [

--- a/packages/core/src/v1/define.test.ts
+++ b/packages/core/src/v1/define.test.ts
@@ -116,7 +116,7 @@ describe('typed wizard', () => {
     expectTypeOf<StepIdOf<typeof signup>>().toEqualTypeOf<'name' | 'plan' | 'review' | 'extras'>();
     expectTypeOf<DataOf<typeof signup>['plan']>().toEqualTypeOf<{ tier: 'free' | 'pro' }>();
     expectTypeOf<DataOf<typeof signup>['extras']>().toEqualTypeOf<{ items: string[] }>();
-    expectTypeOf(wizard.get('name')).toEqualTypeOf<{ full: string }>();
+    expectTypeOf(wizard.get('name')).toEqualTypeOf<{ full: string } | undefined>();
     expectTypeOf(wizard.get('review')).toEqualTypeOf<unknown>();
     expectTypeOf(wizard.get('name.full')).toEqualTypeOf<unknown>();
     expectTypeOf(wizard.go)
@@ -127,6 +127,8 @@ describe('typed wizard', () => {
     void wizard.go('nope');
     // @ts-expect-error not the shape `plan` declared
     wizard.set('plan', { tier: 'gold' });
+    // @ts-expect-error a nested path is untyped, a step id is not
+    wizard.set('plan', 'pro');
     // @ts-expect-error not a step of this flow
     await wizard.validate('nope');
 
@@ -152,7 +154,7 @@ describe('typed wizard', () => {
 
   it('stays at inference depth one on a forty-step flow', () => {
     const wizard = createWizard({ flow: forty });
-    expectTypeOf(wizard.get('s40')).toEqualTypeOf<{ v40: number }>();
+    expectTypeOf(wizard.get('s40')).toEqualTypeOf<{ v40: number } | undefined>();
     wizard.set('s01', { v1: 1 });
     expect(wizard.get('s01')).toEqual({ v1: 1 });
   });

--- a/packages/core/src/v1/define.test.ts
+++ b/packages/core/src/v1/define.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, expectTypeOf, it } from 'vitest';
+
+import { defineFlow, group, step, type DataOf, type StepIdOf } from './define';
+import { END, type FlowDefinition } from './flow';
+import { createWizard, type Wizard } from './store';
+
+const signup = defineFlow({
+  id: 'signup',
+  order: ['name', 'plan', 'review'],
+  steps: {
+    name: step<{ full: string }>({ label: 'Your name' }),
+    plan: step<{ tier: 'free' | 'pro' }>(),
+    review: step(),
+    extras: group<{ items: string[] }>({ flow: { id: 'extras', steps: {} } }),
+  },
+});
+
+/**
+ * Forty steps, the size at which a definition inferred from its own shape
+ * makes tsserver stall. The slice types ride on a phantom instead, so this
+ * file has to type-check as fast as a three-step one — `pnpm type-check` is
+ * the gate.
+ */
+const forty = defineFlow({
+  id: 'forty',
+  order: [
+    's01',
+    's02',
+    's03',
+    's04',
+    's05',
+    's06',
+    's07',
+    's08',
+    's09',
+    's10',
+    's11',
+    's12',
+    's13',
+    's14',
+    's15',
+    's16',
+    's17',
+    's18',
+    's19',
+    's20',
+    's21',
+    's22',
+    's23',
+    's24',
+    's25',
+    's26',
+    's27',
+    's28',
+    's29',
+    's30',
+    's31',
+    's32',
+    's33',
+    's34',
+    's35',
+    's36',
+    's37',
+    's38',
+    's39',
+    's40',
+  ],
+  steps: {
+    s01: step<{ v1: number }>(),
+    s02: step<{ v2: number }>(),
+    s03: step<{ v3: number }>(),
+    s04: step<{ v4: number }>(),
+    s05: step<{ v5: number }>(),
+    s06: step<{ v6: number }>(),
+    s07: step<{ v7: number }>(),
+    s08: step<{ v8: number }>(),
+    s09: step<{ v9: number }>(),
+    s10: step<{ v10: number }>(),
+    s11: step<{ v11: number }>(),
+    s12: step<{ v12: number }>(),
+    s13: step<{ v13: number }>(),
+    s14: step<{ v14: number }>(),
+    s15: step<{ v15: number }>(),
+    s16: step<{ v16: number }>(),
+    s17: step<{ v17: number }>(),
+    s18: step<{ v18: number }>(),
+    s19: step<{ v19: number }>(),
+    s20: step<{ v20: number }>(),
+    s21: step<{ v21: number }>(),
+    s22: step<{ v22: number }>(),
+    s23: step<{ v23: number }>(),
+    s24: step<{ v24: number }>(),
+    s25: step<{ v25: number }>(),
+    s26: step<{ v26: number }>(),
+    s27: step<{ v27: number }>(),
+    s28: step<{ v28: number }>(),
+    s29: step<{ v29: number }>(),
+    s30: step<{ v30: number }>(),
+    s31: step<{ v31: number }>(),
+    s32: step<{ v32: number }>(),
+    s33: step<{ v33: number }>(),
+    s34: step<{ v34: number }>(),
+    s35: step<{ v35: number }>(),
+    s36: step<{ v36: number }>(),
+    s37: step<{ v37: number }>(),
+    s38: step<{ v38: number }>(),
+    s39: step<{ v39: number }>(),
+    s40: step<{ v40: number }>(),
+  },
+});
+
+describe('typed wizard', () => {
+  it('threads the flow through createWizard', async () => {
+    const wizard = createWizard({ flow: signup });
+
+    expectTypeOf<StepIdOf<typeof signup>>().toEqualTypeOf<'name' | 'plan' | 'review' | 'extras'>();
+    expectTypeOf<DataOf<typeof signup>['plan']>().toEqualTypeOf<{ tier: 'free' | 'pro' }>();
+    expectTypeOf<DataOf<typeof signup>['extras']>().toEqualTypeOf<{ items: string[] }>();
+    expectTypeOf(wizard.get('name')).toEqualTypeOf<{ full: string }>();
+    expectTypeOf(wizard.get('review')).toEqualTypeOf<unknown>();
+    expectTypeOf(wizard.get('name.full')).toEqualTypeOf<unknown>();
+    expectTypeOf(wizard.go)
+      .parameter(0)
+      .toEqualTypeOf<'name' | 'plan' | 'review' | 'extras' | typeof END>();
+
+    // @ts-expect-error not a step of this flow
+    void wizard.go('nope');
+    // @ts-expect-error not the shape `plan` declared
+    wizard.set('plan', { tier: 'gold' });
+    // @ts-expect-error not a step of this flow
+    await wizard.validate('nope');
+
+    wizard.set('name', { full: 'Ada' });
+    wizard.set('name.full', 'Grace');
+    expect(wizard.get('name')).toEqual({ full: 'Grace' });
+    expect(await wizard.go(END)).toMatchObject({ ok: true, to: END });
+  });
+
+  it('is still the untyped Wizard a binding stores', () => {
+    const typed = createWizard({ flow: signup });
+    const untyped: Wizard = typed;
+    expect(untyped.get('name')).toBeUndefined();
+    expectTypeOf(untyped.get('name')).toEqualTypeOf<unknown>();
+    expectTypeOf(untyped.go).parameter(0).toEqualTypeOf<string>();
+  });
+
+  it('accepts a flow that arrived as JSON, with every string a step id', () => {
+    const wizard = createWizard({ flow: JSON.parse(JSON.stringify(signup)) as FlowDefinition });
+    expectTypeOf(wizard.go).parameter(0).toEqualTypeOf<string>();
+    expectTypeOf(wizard.get('anything')).toEqualTypeOf<unknown>();
+  });
+
+  it('stays at inference depth one on a forty-step flow', () => {
+    const wizard = createWizard({ flow: forty });
+    expectTypeOf(wizard.get('s40')).toEqualTypeOf<{ v40: number }>();
+    wizard.set('s01', { v1: 1 });
+    expect(wizard.get('s01')).toEqual({ v1: 1 });
+  });
+});

--- a/packages/core/src/v1/define.ts
+++ b/packages/core/src/v1/define.ts
@@ -34,7 +34,11 @@ export function group<T = unknown>(def: GroupStep): GroupStep & Slice<T> {
 /** The union of step ids in a flow. `go` accepts nothing else. */
 export type StepIdOf<F extends FlowDefinition> = Extract<keyof F['steps'], string>;
 
-/** The data shape a flow writes, one key per step slice. */
+/**
+ * The data shape a flow writes, one key per step. Keyed by step id: a `slice`
+ * override moves the data at runtime but not in the type, because `step<T>()`
+ * has no way to see the literal it was handed once `T` is supplied by hand.
+ */
 export type DataOf<F extends FlowDefinition> = {
   [K in keyof F['steps']]: F['steps'][K] extends Slice<infer T> ? T : unknown;
 };

--- a/packages/core/src/v1/define.ts
+++ b/packages/core/src/v1/define.ts
@@ -31,6 +31,16 @@ export function group<T = unknown>(def: GroupStep): GroupStep & Slice<T> {
   return def;
 }
 
+/**
+ * What `get` and `set` see at a path: the slice a step declared when the path
+ * is that step's id, `unknown` for anything else - a nested field, a key no
+ * step owns. An index into an intersection rather than a conditional type,
+ * because a conditional on `F` makes the compiler treat `Wizard<F>` as
+ * invariant, and a typed wizard could no longer be stored as a plain `Wizard`.
+ */
+export type SliceAt<F extends FlowDefinition, P extends string> = (DataOf<F> &
+  Record<string, unknown>)[P];
+
 /** The union of step ids in a flow. `go` accepts nothing else. */
 export type StepIdOf<F extends FlowDefinition> = Extract<keyof F['steps'], string>;
 

--- a/packages/core/src/v1/expr-builder.test.ts
+++ b/packages/core/src/v1/expr-builder.test.ts
@@ -14,6 +14,9 @@ interface Twin {
   json: Expr;
 }
 
+/** A hand-written node, widened through `unknown`: the key is computed, so the compiler cannot see the operator. */
+const node = (op: string, operand: unknown): Expr => ({ [`$${op}`]: operand }) as unknown as Expr;
+
 const paths = ['data', 'data.a', 'data.b.c', 'ctx.x', 'loop.index', 'loop.item.k'] as const;
 // Round-tripped once: `jsonValue` can yield `-0`, which JSON cannot represent.
 const args = fc.option(
@@ -35,17 +38,20 @@ const twin = fc.letrec<{ expr: Twin }>((tie) => {
   );
   const unary = fc
     .tuple(fc.constantFrom('not', 'empty'), expr)
-    .map(([op, e]): Twin => ({ built: b[op](e.built), json: { [`$${op}`]: e.json } as Expr }));
+    .map(([op, e]): Twin => ({ built: b[op](e.built), json: node(op, e.json) }));
   const nary = fc.tuple(fc.constantFrom('and', 'or'), fc.array(expr, { maxLength: 3 })).map(
     ([op, es]): Twin => ({
       built: b[op](...es.map((e) => e.built)),
-      json: { [`$${op}`]: es.map((e) => e.json) } as Expr,
+      json: node(
+        op,
+        es.map((e) => e.json)
+      ),
     })
   );
   const binary = fc.tuple(fc.constantFrom('eq', 'ne', 'gt', 'gte', 'lt', 'lte'), expr, expr).map(
     ([op, l, r]): Twin => ({
       built: b[op](l.built, r.built),
-      json: { [`$${op}`]: [l.json, r.json] } as Expr,
+      json: node(op, [l.json, r.json]),
     })
   );
   const isIn = fc

--- a/packages/core/src/v1/expr-builder.test.ts
+++ b/packages/core/src/v1/expr-builder.test.ts
@@ -1,0 +1,95 @@
+import fc from 'fast-check';
+import { describe, expect, it } from 'vitest';
+
+import { evaluate, type Expr, type Json, type Registry, type Scope } from './expr';
+import * as b from './expr-builder';
+
+/**
+ * Every node is produced twice: once through the builder and once as the JSON
+ * a person would write by hand. The two trees have to be the same value, and
+ * therefore evaluate the same way — that is the whole contract of the builder.
+ */
+interface Twin {
+  built: Expr;
+  json: Expr;
+}
+
+const paths = ['data', 'data.a', 'data.b.c', 'ctx.x', 'loop.index', 'loop.item.k'] as const;
+// Round-tripped once: `jsonValue` can yield `-0`, which JSON cannot represent.
+const args = fc.option(
+  fc.jsonValue({ maxDepth: 2 }).map((v) => JSON.parse(JSON.stringify(v)) as Json),
+  { nil: undefined }
+);
+
+const twin = fc.letrec<{ expr: Twin }>((tie) => {
+  const expr = tie('expr');
+  const leaf = fc
+    .oneof(fc.constant(null), fc.boolean(), fc.integer(), fc.string())
+    .map((v): Twin => ({ built: v, json: v }));
+  const get = fc.constantFrom(...paths).map((p): Twin => ({ built: b.get(p), json: { $get: p } }));
+  const ref = fc.tuple(fc.constantFrom('len', 'sum'), args).map(
+    ([name, a]): Twin => ({
+      built: b.ref(name, a),
+      json: a === undefined ? { $ref: name } : { $ref: name, args: a },
+    })
+  );
+  const unary = fc
+    .tuple(fc.constantFrom('not', 'empty'), expr)
+    .map(([op, e]): Twin => ({ built: b[op](e.built), json: { [`$${op}`]: e.json } as Expr }));
+  const nary = fc.tuple(fc.constantFrom('and', 'or'), fc.array(expr, { maxLength: 3 })).map(
+    ([op, es]): Twin => ({
+      built: b[op](...es.map((e) => e.built)),
+      json: { [`$${op}`]: es.map((e) => e.json) } as Expr,
+    })
+  );
+  const binary = fc.tuple(fc.constantFrom('eq', 'ne', 'gt', 'gte', 'lt', 'lte'), expr, expr).map(
+    ([op, l, r]): Twin => ({
+      built: b[op](l.built, r.built),
+      json: { [`$${op}`]: [l.json, r.json] } as Expr,
+    })
+  );
+  const isIn = fc
+    .tuple(expr, expr)
+    .map(([l, r]): Twin => ({ built: b.isIn(l.built, r.built), json: { $in: [l.json, r.json] } }));
+  return { expr: fc.oneof({ depthSize: 'small' }, leaf, get, ref, unary, nary, binary, isIn) };
+}).expr;
+
+const scope: Scope = {
+  data: { a: 1, b: { c: 'pro' } },
+  ctx: { x: [1, 2, 3] },
+  loop: { index: 2, item: { k: 'v' } },
+};
+const registry: Registry = {
+  len: (a) => (Array.isArray(a) ? a.length : String(a ?? '').length),
+  sum: (_, s) => (s.ctx.x as number[]).reduce((t, n) => t + n, 0),
+};
+
+describe('expression builder', () => {
+  it('produces the JSON a person would write by hand', () => {
+    fc.assert(
+      fc.property(twin, ({ built, json }) => {
+        expect(built).toEqual(json);
+      })
+    );
+  });
+
+  it('evaluates identically to that JSON and survives serialization', () => {
+    fc.assert(
+      fc.property(twin, ({ built, json }) => {
+        const roundTripped = JSON.parse(JSON.stringify(built)) as Expr;
+        expect(roundTripped).toEqual(built);
+        expect(evaluate(built, scope, registry)).toEqual(evaluate(json, scope, registry));
+      })
+    );
+  });
+
+  it('reads like the predicate it encodes', () => {
+    const when = b.and(b.eq(b.get('data.b.c'), 'pro'), b.not(b.empty(b.get('ctx.x'))));
+    expect(when).toEqual({
+      $and: [{ $eq: [{ $get: 'data.b.c' }, 'pro'] }, { $not: { $empty: { $get: 'ctx.x' } } }],
+    });
+    expect(evaluate(when, scope)).toBe(true);
+    // @ts-expect-error a path needs a root: `plan` is not `data.plan`
+    b.get('plan');
+  });
+});

--- a/packages/core/src/v1/expr-builder.ts
+++ b/packages/core/src/v1/expr-builder.ts
@@ -1,0 +1,42 @@
+import type { Expr, Json } from './expr';
+
+/**
+ * A typed builder for the expression language.
+ *
+ * Every function returns exactly the JSON `evaluate` reads, so
+ * `eq(get('data.plan'), 'pro')` and `{ $eq: [{ $get: 'data.plan' }, 'pro'] }`
+ * are the same value and interchangeable in a flow. The builder exists so the
+ * compiler sees the tree the evaluator will walk: an operand that is not an
+ * expression, a wrong arity, a path with no root — all fail before the flow is
+ * serialized rather than when a step is reached.
+ *
+ * Its own entry, deliberately. A flow that arrives as JSON was authored
+ * elsewhere, and the wizard that runs it pays nothing for the functions that
+ * would have written it.
+ */
+
+/** A `$get` path: one of the three roots, optionally followed by a dotted path. */
+export type Path = 'data' | 'ctx' | 'loop' | `data.${string}` | `ctx.${string}` | `loop.${string}`;
+
+type Pair = readonly [Expr, Expr];
+
+export const get = (path: Path): { $get: string } => ({ $get: path });
+
+/** Names a resolver in the registry. `args` is omitted, not `undefined`, so the JSON round-trips. */
+export const ref = (name: string, args?: Json): { $ref: string; args?: Json } =>
+  args === undefined ? { $ref: name } : { $ref: name, args };
+
+export const not = (e: Expr): { $not: Expr } => ({ $not: e });
+export const and = (...e: readonly Expr[]): { $and: readonly Expr[] } => ({ $and: e });
+export const or = (...e: readonly Expr[]): { $or: readonly Expr[] } => ({ $or: e });
+export const empty = (e: Expr): { $empty: Expr } => ({ $empty: e });
+
+export const eq = (a: Expr, b: Expr): { $eq: Pair } => ({ $eq: [a, b] });
+export const ne = (a: Expr, b: Expr): { $ne: Pair } => ({ $ne: [a, b] });
+export const gt = (a: Expr, b: Expr): { $gt: Pair } => ({ $gt: [a, b] });
+export const gte = (a: Expr, b: Expr): { $gte: Pair } => ({ $gte: [a, b] });
+export const lt = (a: Expr, b: Expr): { $lt: Pair } => ({ $lt: [a, b] });
+export const lte = (a: Expr, b: Expr): { $lte: Pair } => ({ $lte: [a, b] });
+
+/** `$in`: the needle first, then the array or string to look in. Named for the reserved word. */
+export const isIn = (needle: Expr, hay: Expr): { $in: Pair } => ({ $in: [needle, hay] });

--- a/packages/core/src/v1/store.ts
+++ b/packages/core/src/v1/store.ts
@@ -1,5 +1,5 @@
 import { commit, restart } from './commit';
-import { type DataOf, type StepIdOf } from './define';
+import { type SliceAt, type StepIdOf } from './define';
 import { END, type FlowDefinition, type StepDef } from './flow';
 import { runNav, type Hooks, type NavContext, type NavResult } from './navigate';
 import { getPath, setPath } from './path';
@@ -77,11 +77,15 @@ export interface Wizard<F extends FlowDefinition = FlowDefinition> {
   /** Aborts the navigation in flight, if any. */
   cancel: () => void;
 
-  /** A step id reads that step's slice, typed; any other path reads `unknown`. */
-  get<K extends StepIdOf<F>>(path: K): DataOf<F>[K];
-  get(path: string): unknown;
-  set<K extends StepIdOf<F>>(path: K, value: DataOf<F>[K]): void;
-  set(path: string, value: unknown): void;
+  /**
+   * A step id reads that step's slice as `step<T>` declared it - or
+   * `undefined`, before the slice is first written and after `clearOnLeave`
+   * drops it. Any other path reads `unknown`. One signature rather than a
+   * typed overload with an untyped fallback: a fallback is what a wrong value
+   * for a known step would resolve to.
+   */
+  get<P extends string>(path: P): SliceAt<F, P> | undefined;
+  set<P extends string>(path: P, value: SliceAt<F, P>): void;
   patch: (partial: Record<string, unknown>) => void;
   /** Applies several writes and notifies once. */
   batch: (fn: () => void) => void;

--- a/packages/core/src/v1/store.ts
+++ b/packages/core/src/v1/store.ts
@@ -1,4 +1,5 @@
 import { commit, restart } from './commit';
+import { type DataOf, type StepIdOf } from './define';
 import { END, type FlowDefinition, type StepDef } from './flow';
 import { runNav, type Hooks, type NavContext, type NavResult } from './navigate';
 import { getPath, setPath } from './path';
@@ -23,8 +24,8 @@ import type { AsyncRegistry, Json, Scope } from './expr';
 
 export type Snapshot = WizardState & Derived;
 
-export interface WizardOptions {
-  flow: FlowDefinition;
+export interface WizardOptions<F extends FlowDefinition = FlowDefinition> {
+  flow: F;
   /** Named resolvers for everything a flow cannot serialize. */
   registry?: AsyncRegistry;
   plugins?: readonly Hooks[];
@@ -34,7 +35,18 @@ export interface WizardOptions {
   state?: WizardState;
 }
 
-export interface Wizard {
+/**
+ * Typed against its flow. `F` is what `defineFlow` returned, so `go` accepts
+ * only the step ids that exist and `get`/`set` know the slice each `step<T>`
+ * declared. A flow that arrived as JSON is a plain `FlowDefinition`, and the
+ * same methods accept any string.
+ *
+ * The members that name a step are methods rather than function-typed
+ * properties on purpose: a method parameter is checked bivariantly, which is
+ * what lets a `Wizard<typeof signup>` still satisfy the `Wizard` a binding
+ * stores in its context.
+ */
+export interface Wizard<F extends FlowDefinition = FlowDefinition> {
   getState: () => WizardState;
   /** State and derived values in one object, identical between commits. */
   getSnapshot: () => Snapshot;
@@ -58,20 +70,26 @@ export interface Wizard {
   start: () => Promise<NavResult>;
   next: (opts?: { validate?: boolean }) => Promise<NavResult>;
   back: () => Promise<NavResult>;
-  go: (to: string, opts?: { validate?: boolean; force?: boolean }) => Promise<NavResult>;
+  go(
+    to: StepIdOf<F> | typeof END,
+    opts?: { validate?: boolean; force?: boolean }
+  ): Promise<NavResult>;
   /** Aborts the navigation in flight, if any. */
   cancel: () => void;
 
-  get: (path: string) => unknown;
-  set: (path: string, value: unknown) => void;
+  /** A step id reads that step's slice, typed; any other path reads `unknown`. */
+  get<K extends StepIdOf<F>>(path: K): DataOf<F>[K];
+  get(path: string): unknown;
+  set<K extends StepIdOf<F>>(path: K, value: DataOf<F>[K]): void;
+  set(path: string, value: unknown): void;
   patch: (partial: Record<string, unknown>) => void;
   /** Applies several writes and notifies once. */
   batch: (fn: () => void) => void;
   setCtx: (ctx: Record<string, unknown>) => void;
   reset: (data?: Record<string, unknown>) => void;
 
-  validate: (stepId?: string) => Promise<boolean>;
-  setErrors: (stepId: string, errors: Readonly<Record<string, string>> | null) => void;
+  validate(stepId?: StepIdOf<F>): Promise<boolean>;
+  setErrors(stepId: StepIdOf<F>, errors: Readonly<Record<string, string>> | null): void;
 
   /** Replaces steps by id. Refuses a patch that would remove the current step. */
   patchFlow: (patch: Partial<FlowDefinition>) => boolean;
@@ -84,8 +102,9 @@ export interface Wizard {
 
 const strictEquals = <T>(a: T, b: T): boolean => a === b;
 
-export function createWizard(options: WizardOptions): Wizard {
-  let flow = options.flow;
+export function createWizard<F extends FlowDefinition>(options: WizardOptions<F>): Wizard<F> {
+  // Widened on purpose: `patchFlow` replaces it with something that is no longer `F`.
+  let flow: FlowDefinition = options.flow;
   const registry = options.registry;
 
   let state: WizardState = options.state ?? initialState(options.data ?? {}, options.ctx ?? {});
@@ -284,9 +303,11 @@ export function createWizard(options: WizardOptions): Wizard {
     go: (to, opts) => navigate({ type: 'go', to, force: opts?.force }, opts),
     cancel: () => controller?.abort(),
 
-    get: (path) => getPath(state.data, path),
+    // The typed overload's return is the phantom slice type; at runtime it is
+    // whatever sits at the path.
+    get: ((path: string) => getPath(state.data, path)) as Wizard<F>['get'],
 
-    set(path, value) {
+    set(path: string, value: unknown) {
       const data = setPath(state.data as Record<string, unknown>, path, value);
       // A write that changes nothing must not invalidate every memoized
       // selector downstream.

--- a/packages/core/src/v1/tsconfig.json
+++ b/packages/core/src/v1/tsconfig.json
@@ -6,5 +6,9 @@
     // the runtime guards that make server-driven flows safe look redundant.
     "noUncheckedIndexedAccess": true
   },
-  "include": ["."]
+  // Tests included, unlike the package config: `define.test.ts` carries the
+  // type assertions and the forty-step fixture, and a gate that skips them is
+  // no gate.
+  "include": ["."],
+  "exclude": []
 }

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -3,9 +3,9 @@ import { defineConfig } from 'tsup';
 
 export default defineConfig({
   // v1 ships as its own entry so it can be tried from canary without
-  // touching the 0.x surface, and so validate-flow, graph and session stay out
-  // of runtime bundles: a wizard that never draws or replays itself should not
-  // carry the code that would.
+  // touching the 0.x surface, and so validate-flow, graph, session and the
+  // expression builder stay out of runtime bundles: a wizard that never draws,
+  // replays or authors itself should not carry the code that would.
   entry: [
     'src/index.ts',
     'src/v1/index.ts',
@@ -13,6 +13,7 @@ export default defineConfig({
     'src/v1/graph.ts',
     'src/v1/session.ts',
     'src/v1/snapshot.ts',
+    'src/v1/expr-builder.ts',
   ],
   format: ['cjs', 'esm'],
   dts: true,

--- a/packages/react/src/v1/index.tsx
+++ b/packages/react/src/v1/index.tsx
@@ -3,6 +3,7 @@
 import {
   createWizard,
   getPath,
+  type FlowDefinition,
   type Snapshot,
   type Wizard,
   type WizardOptions,
@@ -98,10 +99,11 @@ export function WizardProvider({ wizard, children, ...options }: WizardProviderP
   return createElement(WizardContext.Provider, { value: engine }, children);
 }
 
-export function useWizard(): Wizard {
+/** `useWizard<typeof signup>()` types `go`, `get` and `set` against that flow. */
+export function useWizard<F extends FlowDefinition = FlowDefinition>(): Wizard<F> {
   const wizard = useContext(WizardContext);
   if (!wizard) throw new Error('[wizzard] useWizard must be used inside a WizardProvider');
-  return wizard;
+  return wizard as Wizard<F>;
 }
 
 /**

--- a/packages/vue/src/v1/index.ts
+++ b/packages/vue/src/v1/index.ts
@@ -1,6 +1,7 @@
 import {
   createWizard,
   getPath,
+  type FlowDefinition,
   type Snapshot,
   type Wizard,
   type WizardOptions,
@@ -34,9 +35,11 @@ import {
 
 const KEY: InjectionKey<Wizard> = Symbol('wizzard');
 
-export function provideWizard(source: Wizard | WizardOptions): Wizard {
+export function provideWizard<F extends FlowDefinition>(
+  source: Wizard<F> | WizardOptions<F>
+): Wizard<F> {
   const owned = !('getSnapshot' in source);
-  const wizard = owned ? createWizard(source) : (source as Wizard);
+  const wizard = owned ? createWizard(source) : (source as Wizard<F>);
   provide(KEY, wizard);
   // An engine this call created is this scope's to dispose, or a plugin's
   // teardown never runs. One the caller passed in is theirs.
@@ -55,10 +58,11 @@ export function provideWizard(source: Wizard | WizardOptions): Wizard {
   return wizard;
 }
 
-export function useWizard(): Wizard {
+/** `useWizard<typeof signup>()` types `go`, `get` and `set` against that flow. */
+export function useWizard<F extends FlowDefinition = FlowDefinition>(): Wizard<F> {
   const wizard = inject(KEY, null);
   if (!wizard) throw new Error('[wizzard] useWizard must be used under provideWizard');
-  return wizard;
+  return wizard as Wizard<F>;
 }
 
 /**


### PR DESCRIPTION
Closes wizzard-13 (L2) and lands L2b from the launch plan.

## What changed

- `Wizard<F>` / `WizardOptions<F>` / `createWizard<F>`: `go` takes `StepIdOf<F> | END`, `get` returns `DataOf<F>[K]` for a step id and `unknown` for any other path, `set` checks the slice shape, `validate` and `setErrors` take a step id. Inference depth one; the slice type is the phantom `step<T>` already carried.
- The step-naming members are methods, not function-typed properties, so a typed wizard still satisfies the untyped `Wizard` the bindings store. `useWizard<F>()` in React and Vue, and `provideWizard<F>` in Vue, return `Wizard<F>`.
- `packages/core/src/v1/expr-builder.ts` behind `@wizzard-packages/core/expr`: `get`, `ref`, `not`, `and`, `or`, `empty`, `eq`, `ne`, `gt`, `gte`, `lt`, `lte`, `isIn`. Each returns the JSON `evaluate` reads. `get` requires a `data.` / `ctx.` / `loop.` root.
- Wiring per rule 6: tsup entry, `exports["./expr"]`, `.size-limit.js` line, `AGENTS.md` entry list updated.

## Tests

- `define.test.ts`: typed `get`/`set`/`go`, `@ts-expect-error` on a wrong id and a wrong slice shape, assignability to the untyped `Wizard`, a JSON-sourced flow, and a forty-step fixture (`pnpm type-check` is the gate).
- `expr-builder.test.ts`: fast-check property that every builder tree deep-equals the hand-written JSON, survives `JSON.parse(JSON.stringify())`, and evaluates identically.

## Budgets

New entry `core-v1 expr`: 200 B, measured 147 B. No other budget moved; `core-v1` is unchanged at 4.43 kB.

## Not done, deliberately

- `DataOf` is keyed by step id. A `slice` override moves data at runtime but not in the type, because `step<T>({ slice })` cannot see the literal once `T` is supplied by hand. Documented on the type.
- `get` in the builder checks the root, not the field path against a flow. Flow-aware paths would need a per-flow factory; add when an example needs it.
