### PR TITLE
docs(packages): rewrite the core, react and vue READMEs on v1 (D4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,8 +166,8 @@ navigation epoch, so a slow validator that resolves after you pressed Back canno
 Navigation returns a result — `{ ok: false, reason: 'blocked', by: 'age-check' }` — never a
 bare boolean.
 
-**One engine, two bindings.** `@wizzard-packages/react` is 906 B and `@wizzard-packages/vue`
-is 646 B, against 8.43 kB and 5.07 kB for their 0.x equivalents. Nothing was optimised to get
+**One engine, two bindings.** `@wizzard-packages/react` is 1.04 kB and `@wizzard-packages/vue`
+is 732 B, against 8.48 kB and 5.07 kB for their 0.x equivalents. Nothing was optimised to get
 there: the logic moved into the engine. A shared contract suite runs against both, which is
 what stops them drifting apart.
 
@@ -195,9 +195,9 @@ definition that comes from somewhere other than your bundle. When a `useReducer`
 
 | Package                        | What it is                                                 | gzip    |
 | ------------------------------ | ---------------------------------------------------------- | ------- |
-| `@wizzard-packages/core`       | the engine: flow types, expressions, navigation, selectors | 3.92 kB |
-| `@wizzard-packages/react`      | provider and hooks                                         | 927 B   |
-| `@wizzard-packages/vue`        | `provideWizard` and the same composables                   | 660 B   |
+| `@wizzard-packages/core`       | the engine: flow types, expressions, navigation, selectors | 5.13 kB |
+| `@wizzard-packages/react`      | provider and hooks                                         | 1.04 kB |
+| `@wizzard-packages/vue`        | `provideWizard` and the same composables                   | 732 B   |
 | `@wizzard-packages/validate`   | one adapter for Zod, Valibot, ArkType, Effect and Yup      | 317 B   |
 | `@wizzard-packages/core/graph` | a flow as `{ nodes, edges }`, for drawing it               | 754 B   |
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -4,64 +4,106 @@
 ![downloads](https://img.shields.io/npm/dm/@wizzard-packages/core)
 ![license](https://img.shields.io/npm/l/@wizzard-packages/core)
 
-Framework-agnostic wizard engine: state, actions, and types. Use this package to build your own UI layer or plug it into another framework.
-
-## Why core
-
-- Headless state store and typed actions
-- Works in any UI (React, Vue, custom, CLI)
-- Small surface area with predictable behavior
+The engine. A flow is a plain JSON object — no functions, no classes, no `Set`s — and this
+package is what walks it: expressions, guards, validation, navigation and the state that
+comes out. It has no framework in it, so React and Vue are thin bindings over one engine
+rather than two implementations of the same rules.
 
 ## Install
 
 ```bash
-pnpm add @wizzard-packages/core
+pnpm add @wizzard-packages/core@canary
 ```
 
-## Quickstart
+## A flow
 
+`defineFlow` and `step` are the typed way to write that JSON. They add no runtime behaviour —
+`defineFlow` returns its argument — but they carry the shape of each step's data into
+`wizard.get` and `wizard.set`.
+
+<!-- example:quickstart-flow -->
+
+<!-- prettier-ignore -->
 ```ts
-import { WizardStore, type IWizardConfig } from '@wizzard-packages/core';
+import { defineFlow, step } from '@wizzard-packages/core/v1';
 
-type Data = { name: string };
-
-type StepId = 'name' | 'review';
-
-const config: IWizardConfig<Data, StepId> = {
-  steps: [
-    { id: 'name', label: 'Name', component: null },
-    { id: 'review', label: 'Review', component: null },
-  ],
-};
-
-const store = new WizardStore<Data, StepId>({ name: '' });
-
-store.dispatch({
-  type: 'INIT',
-  payload: { data: { name: '' }, config },
+/**
+ * The smallest flow that is still a wizard: two steps, one field, and a value
+ * that has to survive going back.
+ *
+ * A flow is data. This object is JSON — no functions, no classes — so the same
+ * definition can come from a file, from a backend, or from a generator, and one
+ * engine runs all three.
+ */
+export const signup = defineFlow({
+  id: 'signup',
+  order: ['name', 'review'],
+  steps: {
+    name: step<{ full: string }>({ label: 'Your name' }),
+    review: step({ label: 'Review' }),
+  },
 });
 ```
 
-## Utilities
+<!-- /example -->
+
+## Running it
 
 ```ts
-import { getByPath, setByPath } from '@wizzard-packages/core';
+import { createWizard } from '@wizzard-packages/core/v1';
 
-const data = { user: { name: 'Ada' } };
-const name = getByPath(data, 'user.name');
-const next = setByPath(data, 'user.name', 'Grace');
+import { signup } from './flow';
+
+const wizard = createWizard({ flow: signup });
+
+await wizard.start(); // enters the first reachable step
+wizard.set('name.full', 'Ada');
+const result = await wizard.next();
+// { ok: true } — or { ok: false, reason: 'blocked', by: 'age-check' }
 ```
 
-## Related packages
+Navigation returns a result, never a bare boolean, because "it did not move" and "why it did
+not move" are different questions and the second one is what you render. `subscribe`,
+`select` and `watch` are the three ways to hear about a change: everything, one derived
+value, or one data path.
 
-- @wizzard-packages/react - React provider + hooks on top of core
-- @wizzard-packages/persistence - save/load wizard state
-- @wizzard-packages/middleware - logger and devtools middleware
-- @wizzard-packages/adapter-zod - validation with Zod
-- @wizzard-packages/adapter-yup - validation with Yup
-- @wizzard-packages/devtools - DevTools UI (React)
+Anything a flow cannot serialize — a validator, a predicate, an async guard — is a **named**
+entry in `registry`, so `JSON.stringify(flow)` always round-trips.
 
-## Links
+## Entries
 
-- Repo: https://github.com/ZizzX/wizzard-packages
-- Docs UI: https://zizzx.github.io/wizzard-packages/
+Separate entry points because they are separate budgets. A wizard that never draws itself
+does not carry the code that would.
+
+| Entry            | What it is                                             |
+| ---------------- | ------------------------------------------------------ |
+| `/v1`            | the engine: types, expressions, navigation, selectors  |
+| `/graph`         | a flow as `{ nodes, edges }`, for drawing it           |
+| `/groups`        | traversal for repeated sub-flows                       |
+| `/session`       | serialize and resume a run                             |
+| `/snapshot`      | record and replay                                      |
+| `/expr`          | a builder for expressions, if you dislike writing JSON |
+| `/validate-flow` | checks a flow definition, for tooling and tests        |
+
+`.size-limit.js` holds the budget for each, with the measurement that set it.
+
+## Documentation
+
+The guides live on the site: [Getting started](https://zizzx.github.io/wizzard-packages/docs/start/),
+[The flow](https://zizzx.github.io/wizzard-packages/docs/flow/),
+[Expressions](https://zizzx.github.io/wizzard-packages/docs/expressions/),
+[Navigation](https://zizzx.github.io/wizzard-packages/docs/navigation/).
+
+Bindings: [`@wizzard-packages/react`](https://www.npmjs.com/package/@wizzard-packages/react),
+[`@wizzard-packages/vue`](https://www.npmjs.com/package/@wizzard-packages/vue). Validation:
+[`@wizzard-packages/validate`](https://www.npmjs.com/package/@wizzard-packages/validate).
+
+## Upgrading from 0.x
+
+0.x was a different library with the same name: `new WizardStore(...)`, a config of steps, and
+the branching in your components. v1 is on the `canary` tag while the launch lands. The
+0.x line on `latest` is being retired.
+
+## License
+
+MIT

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -75,15 +75,15 @@ entry in `registry`, so `JSON.stringify(flow)` always round-trips.
 Separate entry points because they are separate budgets. A wizard that never draws itself
 does not carry the code that would.
 
-| Entry            | What it is                                             |
-| ---------------- | ------------------------------------------------------ |
-| `/v1`            | the engine: types, expressions, navigation, selectors  |
-| `/graph`         | a flow as `{ nodes, edges }`, for drawing it           |
-| `/groups`        | traversal for repeated sub-flows                       |
-| `/session`       | serialize and resume a run                             |
-| `/snapshot`      | record and replay                                      |
-| `/expr`          | a builder for expressions, if you dislike writing JSON |
-| `/validate-flow` | checks a flow definition, for tooling and tests        |
+| Entry            | What it is                                                     |
+| ---------------- | -------------------------------------------------------------- |
+| `/v1`            | the engine: types, expressions, navigation, selectors          |
+| `/graph`         | a flow as `{ nodes, edges }`, for drawing it                   |
+| `/groups`        | traversal for repeated sub-flows                               |
+| `/session`       | a recorded run, and the check that a replay matches it         |
+| `/snapshot`      | serialize a run, and refuse stored JSON that cannot be trusted |
+| `/expr`          | a builder for expressions, if you dislike writing JSON         |
+| `/validate-flow` | checks a flow definition, for tooling and tests                |
 
 `.size-limit.js` holds the budget for each, with the measurement that set it.
 

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -4,350 +4,111 @@
 ![downloads](https://img.shields.io/npm/dm/@wizzard-packages/react)
 ![license](https://img.shields.io/npm/l/@wizzard-packages/react)
 
-React bindings for Wizzard Stepper: provider, hooks, and typed factory built on top of @wizzard-packages/core.
+The React binding for [`@wizzard-packages/core`](https://www.npmjs.com/package/@wizzard-packages/core).
+It bridges the engine into React and does nothing else: navigation, guards and validation are
+the engine's, so this package is a provider and six hooks. That is why it is 1.04 kB gzipped
+against 8.48 kB for its 0.x equivalent — nothing was optimised, the logic moved.
 
 ## Install
 
 ```bash
-pnpm add @wizzard-packages/react
+pnpm add @wizzard-packages/core@canary @wizzard-packages/react@canary
 ```
 
-Optional add-ons:
+React 18 or newer. The provider subscribes through `useSyncExternalStore`, so concurrent
+rendering and StrictMode's double mount are handled by the store rather than by an effect.
 
-```bash
-pnpm add @wizzard-packages/persistence @wizzard-packages/middleware
-pnpm add @wizzard-packages/adapter-zod zod
-pnpm add @wizzard-packages/adapter-yup yup
-```
+## Use
 
-## Quickstart
+Wrap the wizard, then read it. `WizardProvider` takes either a `wizard` you built with
+`createWizard` or the options to build one — passing `flow` alone is the common case, and the
+provider owns and destroys that instance.
 
+<!-- example:quickstart-react -->
+
+<!-- prettier-ignore -->
 ```tsx
-import { createWizardFactory } from '@wizzard-packages/react';
+import { WizardProvider, useField, useNavigation, useStep } from '@wizzard-packages/react/v1';
 
-type Data = { name: string };
-
-type StepId = 'name' | 'review';
-
-const { WizardProvider, createStep, useWizardActions, useWizardState } = createWizardFactory<
-  Data,
-  StepId
->();
-
-const steps = [
-  createStep({ id: 'name', label: 'Name', component: NameStep }),
-  createStep({ id: 'review', label: 'Review', component: ReviewStep }),
-];
+import { signup } from './flow';
 
 export function App() {
   return (
-    <WizardProvider config={{ steps }} initialData={{ name: '' }} initialStepId="name">
-      <WizardUI />
+    <WizardProvider flow={signup}>
+      <Wizard />
     </WizardProvider>
   );
 }
 
-function WizardUI() {
-  const { goToNextStep } = useWizardActions();
-  const { currentStepId } = useWizardState();
-
-  return <button onClick={goToNextStep}>Next ({currentStepId})</button>;
-}
-```
-
-## 🎨 UI Integrations (Shadcn, Mantine, MUI)
-
-Since `@wizzard-packages/react` is headless, you are expected to bring your own UI components. We provide "Connector" examples that demonstrate how to bind popular design systems to the wizard engine using the Factory Pattern.
-
-- **[Shadcn/UI Connector Example](../../examples/shadcn-ui-connector)**: Demonstrates how to create a `createShadcnWizard` factory that generates strongly-typed `WizardField`, `WizardStep`, and `WizardStepper` components pre-styled with Tailwind and Shadcn.
-
-## Best practices (DX)
-
-- Memoize `steps` and `config` (`useMemo`) to avoid unnecessary recalculations.
-- Prefer granular hooks (`useWizardValue`, `useWizardSelector`, `useWizardMeta`) over `useWizardContext` for performance.
-- For form fields, use `useWizardField(path)` to get `[value, setValue]` without extra boilerplate.
-- SSR is supported via `useSyncExternalStore`. Avoid persistence adapters that touch `window` during module init.
-
-## Context-free store (without Provider)
-
-If you need store access without React Context (common in large codebases), the API surface is the same.
-You get the same `actions` as `useWizardActions`, and the hooks mirror `useWizardState`,
-`useWizardValue`, and `useWizardSelector`.
-
-```tsx
-import { createWizardStore, createWizardHooks } from '@wizzard-packages/react';
-
-type Data = { name: string };
-type StepId = 'name' | 'review';
-
-const steps = [
-  { id: 'name', label: 'Name', component: NameStep },
-  { id: 'review', label: 'Review', component: ReviewStep },
-];
-
-const { store, actions } = createWizardStore<Data, StepId>({
-  config: { steps },
-  initialData: { name: '' },
-  initialStepId: 'name',
-});
-
-const { useWizardState, useWizardValue, useWizardField } = createWizardHooks(store, actions);
-
-function WizardUI() {
-  const state = useWizardState();
-  const name = useWizardValue('name');
-  const [nameField, setNameField] = useWizardField('name');
+export function Wizard() {
+  const { current, isLast } = useStep();
+  const { next, back, canBack } = useNavigation();
+  const [full, setFull] = useField<string>('name.full');
 
   return (
-    <button onClick={actions.goToNextStep}>
-      Next ({state.currentStepId}) {name} {nameField}
-    </button>
+    <form onSubmit={(e) => e.preventDefault()}>
+      {current === 'name' && (
+        <label>
+          Your name
+          <input value={full ?? ''} onChange={(e) => setFull(e.target.value)} />
+        </label>
+      )}
+      {current === 'review' && <p>Hello, {full || 'stranger'}.</p>}
+
+      <button type="button" onClick={() => back()} disabled={!canBack}>
+        Back
+      </button>
+      <button type="button" onClick={() => next()} disabled={isLast}>
+        Next
+      </button>
+    </form>
   );
 }
 ```
 
-### Example: selector + derived UI
+<!-- /example -->
 
-```tsx
-const { useWizardSelector } = createWizardHooks(store, actions);
+That file and the flow it imports are `examples/quickstart`, which CI runs — this block is
+generated from them, so what you paste is what is tested.
 
-function Progress() {
-  const { progress, isBusy } = useWizardSelector((s) => ({
-    progress: s.progress,
-    isBusy: s.isBusy,
-  }));
+## Hooks
 
-  return (
-    <div>
-      Progress: {progress}% {isBusy ? '...' : ''}
-    </div>
-  );
-}
-```
+| Hook                    | Returns                                                                             |
+| ----------------------- | ----------------------------------------------------------------------------------- |
+| `useStep()`             | `current`, `isFirst`, `isLast`, `progress` and the rest of the step's derived state |
+| `useNavigation()`       | `next`, `back`, `go`, `canBack`, `canNext`, `isNavigating`                          |
+| `useField<T>(path)`     | `[value, setValue]`, addressing the same paths the flow does                        |
+| `useErrors(stepId?)`    | the error map for a step, or for the current one                                    |
+| `useWizardSelector(fn)` | one derived value, re-rendering only when it changes                                |
+| `useWizard()`           | the engine itself, for anything the hooks above do not cover                        |
 
-### Example: actions outside React (service layer)
+`useOptionalWizard()` returns `null` outside a provider instead of throwing, which is what a
+component rendered both inside and outside a wizard needs.
 
-```ts
-// services/wizardActions.ts
-export const wizard = createWizardStore<Data, StepId>({
-  config: { steps },
-  initialData: { name: '' },
-  initialStepId: 'name',
-});
+Navigation is async and returns a result, not a boolean: `await next()` gives
+`{ ok: false, reason: 'blocked', by: 'age-check' }` when a guard refuses. Every `await` inside
+the engine re-checks a navigation epoch, so a validator that resolves after the user pressed
+Back cannot move them.
 
-export const wizardActions = wizard.actions;
-```
+## Documentation
 
-```tsx
-import { wizardActions } from './services/wizardActions';
+[Getting started](https://zizzx.github.io/wizzard-packages/docs/start/) ·
+[The flow](https://zizzx.github.io/wizzard-packages/docs/flow/) ·
+[Navigation](https://zizzx.github.io/wizzard-packages/docs/navigation/) ·
+[Validation](https://zizzx.github.io/wizzard-packages/docs/validation/) ·
+[Persistence](https://zizzx.github.io/wizzard-packages/docs/persistence/)
 
-function Footer() {
-  return (
-    <>
-      <button onClick={wizardActions.goToPrevStep}>Back</button>
-      <button onClick={wizardActions.goToNextStep}>Next</button>
-    </>
-  );
-}
-```
+The same hooks, under the same names, are in
+[`@wizzard-packages/vue`](https://www.npmjs.com/package/@wizzard-packages/vue). A shared
+contract suite runs against both, which is what stops them drifting apart.
 
-### Example: multiple stores (independent wizards)
+## Upgrading from 0.x
 
-```tsx
-const wizardA = createWizardStore<DataA, StepIdA>({ config: { steps: stepsA } });
-const wizardB = createWizardStore<DataB, StepIdB>({ config: { steps: stepsB } });
+0.x was a different library with the same name: `createWizardFactory`, a store per wizard, and
+the branching in your components. Both lines export a `WizardProvider` with different props,
+so check the import path — v1 is `@wizzard-packages/react/v1`. v1 is on the `canary` tag while
+the launch lands; the 0.x line on `latest` is being retired.
 
-const hooksA = createWizardHooks(wizardA.store);
-const hooksB = createWizardHooks(wizardB.store);
+## License
 
-function DualWizard() {
-  const stepA = hooksA.useWizardState().currentStepId;
-  const stepB = hooksB.useWizardState().currentStepId;
-
-  return (
-    <div>
-      <div>Wizard A: {stepA}</div>
-      <div>Wizard B: {stepB}</div>
-    </div>
-  );
-}
-```
-
-### Example: SSR-friendly initialization
-
-```tsx
-// create store outside render to keep it stable across SSR/CSR.
-const wizard = createWizardStore<Data, StepId>({
-  config: { steps },
-  initialData: { name: '' },
-  initialStepId: 'name',
-});
-
-const hooks = createWizardHooks(wizard.store);
-
-function WizardApp() {
-  const { currentStepId } = hooks.useWizardState();
-  return <div>Current step: {currentStepId}</div>;
-}
-```
-
-### Example: integration with external state manager
-
-```ts
-// Example using a simple external event bus pattern.
-type Listener = () => void;
-const listeners = new Set<Listener>();
-
-wizard.store.subscribe(() => {
-  listeners.forEach((listener) => listener());
-});
-
-export const wizardStateStore = {
-  subscribe(listener: Listener) {
-    listeners.add(listener);
-    return () => listeners.delete(listener);
-  },
-  getSnapshot() {
-    return wizard.store.getSnapshot();
-  },
-};
-```
-
-```tsx
-import { useSyncExternalStore } from 'react';
-
-function WizardBadge() {
-  const snapshot = useSyncExternalStore(
-    wizardStateStore.subscribe,
-    wizardStateStore.getSnapshot,
-    wizardStateStore.getSnapshot
-  );
-
-  return <span>{snapshot.currentStepId}</span>;
-}
-```
-
-### Example: Zustand integration
-
-```ts
-import { create } from 'zustand';
-import { shallow } from 'zustand/shallow';
-
-type WizardSnapshot = ReturnType<typeof wizard.store.getSnapshot>;
-
-export const useWizardSnapshot = create<{ snapshot: WizardSnapshot }>(() => ({
-  snapshot: wizard.store.getSnapshot(),
-}));
-
-wizard.store.subscribe(() => {
-  useWizardSnapshot.setState({ snapshot: wizard.store.getSnapshot() });
-});
-```
-
-```tsx
-function WizardStatus() {
-  const { currentStepId, progress } = useWizardSnapshot(
-    (s) => ({
-      currentStepId: s.snapshot.currentStepId,
-      progress: s.snapshot.progress,
-    }),
-    shallow
-  );
-
-  return (
-    <div>
-      Step: {currentStepId} ({progress}%)
-    </div>
-  );
-}
-```
-
-### Example: Redux integration
-
-```ts
-// Store current snapshot in Redux when the wizard updates.
-import { createSlice, configureStore } from '@reduxjs/toolkit';
-import { createSelector } from '@reduxjs/toolkit';
-
-const wizardSlice = createSlice({
-  name: 'wizard',
-  initialState: { snapshot: wizard.store.getSnapshot() },
-  reducers: {
-    setSnapshot(state, action) {
-      state.snapshot = action.payload;
-    },
-  },
-});
-
-export const { setSnapshot } = wizardSlice.actions;
-export const store = configureStore({ reducer: { wizard: wizardSlice.reducer } });
-
-wizard.store.subscribe(() => {
-  store.dispatch(setSnapshot(wizard.store.getSnapshot()));
-});
-
-export const selectWizardSnapshot = (state) => state.wizard.snapshot;
-export const selectWizardProgress = createSelector([selectWizardSnapshot], (snapshot) => ({
-  currentStepId: snapshot.currentStepId,
-  progress: snapshot.progress,
-  isBusy: snapshot.isBusy,
-}));
-```
-
-```tsx
-import { useSelector } from 'react-redux';
-
-function WizardReduxStatus() {
-  const { currentStepId, progress, isBusy } = useSelector(selectWizardProgress);
-  return (
-    <div>
-      Step: {currentStepId} ({progress}%) {isBusy ? '...' : ''}
-    </div>
-  );
-}
-```
-
-### Example: memoized config + middleware pipeline
-
-```tsx
-import { useMemo } from 'react';
-import { loggerMiddleware } from '@wizzard-packages/middleware';
-
-function WizardRoot() {
-  const steps = useMemo(
-    () => [
-      { id: 'name', label: 'Name', component: NameStep },
-      { id: 'review', label: 'Review', component: ReviewStep },
-    ],
-    []
-  );
-
-  const config = useMemo(
-    () => ({
-      steps,
-      middlewares: [loggerMiddleware],
-      validationMode: 'onChange',
-      validationDebounceTime: 250,
-    }),
-    [steps]
-  );
-
-  return (
-    <WizardProvider config={config} initialData={{ name: '' }} initialStepId="name">
-      <WizardUI />
-    </WizardProvider>
-  );
-}
-```
-
-## How it fits
-
-- Core engine: @wizzard-packages/core
-- Optional persistence: @wizzard-packages/persistence
-- Optional middleware: @wizzard-packages/middleware
-- Optional validation: @wizzard-packages/adapter-zod or @wizzard-packages/adapter-yup
-
-## Links
-
-- Repo: https://github.com/ZizzX/wizzard-packages
-- Docs UI: https://zizzx.github.io/wizzard-packages/
+MIT

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -6,7 +6,7 @@
 
 The React binding for [`@wizzard-packages/core`](https://www.npmjs.com/package/@wizzard-packages/core).
 It bridges the engine into React and does nothing else: navigation, guards and validation are
-the engine's, so this package is a provider and six hooks. That is why it is 1.04 kB gzipped
+the engine's, so this package is a provider and eight hooks. That is why it is 1.04 kB gzipped
 against 8.48 kB for its 0.x equivalent — nothing was optimised, the logic moved.
 
 ## Install
@@ -76,7 +76,7 @@ generated from them, so what you paste is what is tested.
 | Hook                    | Returns                                                                             |
 | ----------------------- | ----------------------------------------------------------------------------------- |
 | `useStep()`             | `current`, `isFirst`, `isLast`, `progress` and the rest of the step's derived state |
-| `useNavigation()`       | `next`, `back`, `go`, `canBack`, `canNext`, `isNavigating`                          |
+| `useNavigation()`       | `next`, `back`, `go`, `cancel`, `canBack`, `isBusy`, `isLast`                       |
 | `useField<T>(path)`     | `[value, setValue]`, addressing the same paths the flow does                        |
 | `useErrors(stepId?)`    | the error map for a step, or for the current one                                    |
 | `useWizardSelector(fn)` | one derived value, re-rendering only when it changes                                |

--- a/packages/vue/README.md
+++ b/packages/vue/README.md
@@ -6,7 +6,7 @@
 
 The Vue binding for [`@wizzard-packages/core`](https://www.npmjs.com/package/@wizzard-packages/core).
 It bridges the engine into Vue and does nothing else: navigation, guards and validation are the
-engine's, so this package is one `provide` and six composables. That is why it is 732 B gzipped
+engine's, so this package is one `provide` and eight composables. That is why it is 732 B gzipped
 against 5.07 kB for its 0.x equivalent — nothing was optimised, the logic moved.
 
 ## Install
@@ -76,7 +76,7 @@ generated from them, so what you paste is what is tested.
 | Composable              | Returns                                                                                      |
 | ----------------------- | -------------------------------------------------------------------------------------------- |
 | `useStep()`             | `current`, `isFirst`, `isLast`, `progress`, `breadcrumbs` and the rest, each a `ComputedRef` |
-| `useNavigation()`       | `next`, `back`, `go`, `canBack`, `canNext`, `isNavigating`                                   |
+| `useNavigation()`       | `next`, `back`, `go`, `cancel`, `canBack`, `isBusy`, `isLast`                                |
 | `useField<T>(path)`     | a `WritableComputedRef`, usable directly with `v-model`                                      |
 | `useErrors(stepId?)`    | the error map for a step, or for the current one                                             |
 | `useWizardSelector(fn)` | one derived value as a `ComputedRef`                                                         |

--- a/packages/vue/README.md
+++ b/packages/vue/README.md
@@ -1,822 +1,117 @@
-# @wizzard-packages/vue 🧙‍♂️
+# @wizzard-packages/vue
 
 ![npm](https://img.shields.io/npm/v/@wizzard-packages/vue)
 ![downloads](https://img.shields.io/npm/dm/@wizzard-packages/vue)
 ![license](https://img.shields.io/npm/l/@wizzard-packages/vue)
 
-Vue 3 Composition API bindings for **Wizzard Stepper**.  
-Build flexible, headless, and strictly typed multi-step wizards with Vue 3.
+The Vue binding for [`@wizzard-packages/core`](https://www.npmjs.com/package/@wizzard-packages/core).
+It bridges the engine into Vue and does nothing else: navigation, guards and validation are the
+engine's, so this package is one `provide` and six composables. That is why it is 732 B gzipped
+against 5.07 kB for its 0.x equivalent — nothing was optimised, the logic moved.
 
-## ✨ Features
-
-- 🟢 **Vue 3 Native**: Built with Composition API and fine-grained reactivity.
-- 🏗 **Headless**: Total control over your UI/components.
-- 🧪 **Strictly Typed**: Full TypeScript support with the Factory Pattern.
-- ⚡ **Atomic Updates**: Components re-render only when the specific data they use changes.
-- 🔌 **Core Powered**: Uses the same battle-tested engine as `@wizzard-packages/react`.
-- 🔄 **Feature Parity**: All React adapter features available in Vue (validation, guards, persistence, middleware).
-
-## 📦 Installation
+## Install
 
 ```bash
-pnpm add @wizzard-packages/vue @wizzard-packages/core
-# or
-npm install @wizzard-packages/vue @wizzard-packages/core
+pnpm add @wizzard-packages/core@canary @wizzard-packages/vue@canary
 ```
 
-Optional add-ons:
+Vue 3.3 or newer. Reactivity rides on snapshot identity: the engine returns the same object
+until a commit, so a `shallowRef` holding it invalidates exactly once per commit and every
+`computed` derived from it caches for free.
 
-```bash
-pnpm add @wizzard-packages/persistence @wizzard-packages/middleware
-pnpm add @wizzard-packages/adapter-zod zod
-pnpm add @wizzard-packages/adapter-yup yup
-```
+## Use
 
-## 🚀 Quick Start
-
-### 1. Define your Schema and Factory
-
-Create a typed wizard instance for your data schema.
-
-```typescript
-// wizard.ts
-import { createWizardFactory } from '@wizzard-packages/vue';
-
-export interface MySchema {
-  user: {
-    name: string;
-    email: string;
-  };
-  plan: 'basic' | 'pro';
-}
-
-export type StepId = 'info' | 'plan' | 'review';
-
-export const {
-  useProvideWizard,
-  useWizardActions,
-  useWizardValue,
-  useWizardState,
-  useWizardField,
-  useWizardSelector,
-  useWizardError,
-} = createWizardFactory<MySchema>();
-```
-
-### 2. Provide the Wizard in a Parent Component
+`provideWizard` goes in a parent, because `inject` reads the parent chain — the component that
+provides the wizard is not the one that uses it. Pass a flow and the scope owns and destroys
+the engine, or pass a `Wizard` you built yourself and it stays yours.
 
 ```vue
 <script setup lang="ts">
-import { useProvideWizard } from './wizard';
-import type { IWizardConfig } from '@wizzard-packages/core';
+import { provideWizard } from '@wizzard-packages/vue/v1';
 
-const config: IWizardConfig<'info' | 'plan' | 'review', any> = {
-  steps: [
-    { id: 'info', label: 'Personal Info' },
-    { id: 'plan', label: 'Select Plan' },
-    { id: 'review', label: 'Review' },
-  ],
-};
+import { signup } from './flow';
+import Wizard from './Wizard.vue';
 
-useProvideWizard({
-  config,
-  initialData: {
-    user: { name: '', email: '' },
-    plan: 'basic',
-  },
-});
+provideWizard({ flow: signup });
 </script>
 
 <template>
-  <div class="wizard-container">
-    <StepRenderer />
-    <NavigationControls />
-  </div>
+  <Wizard />
 </template>
 ```
 
-### 3. Consume State in Child Components
+<!-- example:quickstart-vue -->
 
-#### Reading and Writing Values (`useWizardField`)
-
+<!-- prettier-ignore -->
 ```vue
 <script setup lang="ts">
-import { useWizardField } from './wizard';
+import { useField, useNavigation, useStep } from '@wizzard-packages/vue/v1';
 
-// Reactive [ref, setter]
-const [name, setName] = useWizardField('user.name');
-const [email, setEmail] = useWizardField('user.email');
+const { current, isLast } = useStep();
+const { next, back, canBack } = useNavigation();
+const full = useField<string>('name.full');
 </script>
 
 <template>
-  <div>
-    <input
-      :value="name"
-      @input="(e) => setName((e.target as HTMLInputElement).value)"
-      placeholder="Enter name"
-    />
-    <input
-      :value="email"
-      @input="(e) => setEmail((e.target as HTMLInputElement).value)"
-      placeholder="Enter email"
-      type="email"
-    />
-  </div>
-</template>
-```
-
-#### Navigation Actions (`useWizardActions`)
-
-```vue
-<script setup lang="ts">
-import { useWizardActions, useWizardState } from './wizard';
-
-const state = useWizardState();
-const { nextStep, prevStep, goToStep } = useWizardActions();
-</script>
-
-<template>
-  <div class="navigation">
-    <button @click="prevStep" :disabled="state.isFirstStep">Back</button>
-    <span>Step {{ state.currentStepIndex + 1 }} of {{ state.totalSteps }}</span>
-    <button @click="nextStep" :disabled="state.isLastStep">Next</button>
-  </div>
-</template>
-```
-
-## 🛠 API Reference
-
-### `createWizardFactory<TSchema>()`
-
-Returns a set of typed hooks for your schema:
-
-#### `useProvideWizard(options)`
-
-Initializes and provides the wizard store to the component tree.
-
-```typescript
-interface IWizardProviderOptions<StepId, TSchema> {
-  config: IWizardConfig<StepId, TSchema>;
-  initialData?: TSchema;
-  initialStepId?: StepId;
-}
-
-useProvideWizard({
-  config: {
-    steps: [
-      { id: 'step1', label: 'Step 1' },
-      { id: 'step2', label: 'Step 2' },
-    ],
-    validationMode: 'onChange', // 'onChange' | 'onBlur' | 'onSubmit'
-    validationDebounceTime: 300,
-  },
-  initialData: { name: '' },
-  initialStepId: 'step1',
-});
-```
-
-#### `useWizardState()`
-
-Returns a reactive computed ref with the complete wizard state:
-
-```typescript
-const state = useWizardState();
-
-// Available properties:
-state.currentStepId; // Current step ID
-state.currentStepIndex; // Current step index (0-based)
-state.totalSteps; // Total number of active steps
-state.isFirstStep; // Boolean: is first step
-state.isLastStep; // Boolean: is last step
-state.canGoNext; // Boolean: can navigate forward
-state.canGoPrev; // Boolean: can navigate backward
-state.visitedSteps; // Set of visited step IDs
-state.completedSteps; // Set of completed step IDs
-state.errorSteps; // Set of steps with errors
-state.progress; // Progress percentage (0-100)
-state.isBusy; // Boolean: async operation in progress
-state.data; // Current wizard data
-state.activeSteps; // Array of currently active steps
-```
-
-#### `useWizardValue(path, defaultValue?)`
-
-Returns a reactive ref for a specific path in the wizard data:
-
-```typescript
-const name = useWizardValue('user.name');
-const email = useWizardValue('user.email', 'default@example.com');
-
-// Automatically updates when the value changes
-console.log(name.value); // 'John'
-```
-
-#### `useWizardField(path, defaultValue?)`
-
-Returns `[ref, setter]` tuple for a specific field:
-
-```typescript
-const [name, setName] = useWizardField('user.name');
-const [age, setAge] = useWizardField('user.age', 18);
-
-// Use in template
-<input :value="name" @input="e => setName(e.target.value)" />
-
-// Or with v-model workaround
-const nameModel = computed({
-  get: () => name.value,
-  set: (val) => setName(val)
-});
-
-<input v-model="nameModel" />
-```
-
-#### `useWizardActions()`
-
-Returns navigation and data manipulation methods:
-
-```typescript
-const actions = useWizardActions();
-
-// Navigation
-actions.nextStep(); // Go to next step
-actions.prevStep(); // Go to previous step
-actions.goToStep('stepId'); // Go to specific step
-actions.goToStepIndex(2); // Go to step by index
-
-// Data manipulation
-actions.setData('user.name', 'John'); // Set single value
-actions.updateData({
-  // Update multiple values
-  user: { name: 'John', email: 'john@example.com' },
-});
-actions.getData('user.name'); // Get value by path
-actions.getData('user.name', 'Default'); // With default value
-
-// Validation
-actions.validateStep('stepId'); // Validate specific step
-actions.validateAll(); // Validate all steps
-
-// Error management
-actions.setErrors({
-  // Set errors for a step
-  stepId: {
-    fieldName: 'Error message',
-  },
-});
-
-// Reset
-actions.reset(); // Reset to initial state
-actions.reset({ name: 'New' }); // Reset with new data
-```
-
-#### `useWizardSelector(selector)`
-
-Returns a reactive computed value derived from wizard state:
-
-```typescript
-const progress = useWizardSelector((state) => state.progress);
-const isValid = useWizardSelector((state) => state.errorSteps.size === 0);
-
-// Complex derived state
-const wizardStatus = useWizardSelector((state) => ({
-  step: state.currentStepId,
-  progress: state.progress,
-  canProceed: state.canGoNext && !state.isBusy,
-  hasErrors: state.errorSteps.size > 0,
-}));
-```
-
-#### `useWizardError(path)`
-
-Returns a reactive ref with the error message for a specific field:
-
-```typescript
-const nameError = useWizardError('user.name');
-const emailError = useWizardError('user.email');
-
-// Use in template
-<div v-if="nameError" class="error">{{ nameError }}</div>
-```
-
-## 📚 Advanced Examples
-
-### Example 1: Step Guards (beforeLeave)
-
-Prevent navigation until validation passes:
-
-```typescript
-const config: IWizardConfig<StepId, MySchema> = {
-  steps: [
-    {
-      id: 'info',
-      label: 'Personal Info',
-      beforeLeave: async (data) => {
-        if (!data.user.name) {
-          return { canLeave: false, error: 'Name is required' };
-        }
-        if (!data.user.email.includes('@')) {
-          return { canLeave: false, error: 'Valid email required' };
-        }
-        return { canLeave: true };
-      },
-    },
-    { id: 'review', label: 'Review' },
-  ],
-};
-```
-
-### Example 2: Conditional Steps (isVisible)
-
-Show/hide steps based on data:
-
-```typescript
-const config: IWizardConfig<StepId, MySchema> = {
-  steps: [
-    { id: 'plan', label: 'Select Plan' },
-    {
-      id: 'payment',
-      label: 'Payment',
-      isVisible: (data) => data.plan === 'pro', // Only show for pro plan
-    },
-    { id: 'review', label: 'Review' },
-  ],
-};
-```
-
-### Example 3: Async Step Conditions
-
-Dynamic step visibility with async checks:
-
-```typescript
-const config: IWizardConfig<StepId, MySchema> = {
-  steps: [
-    { id: 'account', label: 'Account' },
-    {
-      id: 'premium',
-      label: 'Premium Features',
-      isVisible: async (data) => {
-        const hasAccess = await checkPremiumAccess(data.user.id);
-        return hasAccess;
-      },
-    },
-  ],
-};
-```
-
-### Example 4: Zod Validation
-
-Integrate with Zod for schema validation:
-
-```vue
-<script setup lang="ts">
-import { z } from 'zod';
-import { ZodAdapter } from '@wizzard-packages/adapter-zod';
-import { useProvideWizard } from './wizard';
-
-const userSchema = z.object({
-  name: z.string().min(2, 'Name must be at least 2 characters'),
-  email: z.string().email('Invalid email address'),
-  age: z.number().min(18, 'Must be 18 or older'),
-});
-
-const config = {
-  steps: [
-    {
-      id: 'info',
-      label: 'Info',
-      validate: ZodAdapter(userSchema),
-    },
-  ],
-};
-
-useProvideWizard({ config, initialData: { name: '', email: '', age: 0 } });
-</script>
-```
-
-### Example 5: LocalStorage Persistence
-
-Persist wizard state across sessions:
-
-```typescript
-import { LocalStorageAdapter } from '@wizzard-packages/persistence';
-
-const config = {
-  steps: [
-    { id: 'step1', label: 'Step 1' },
-    { id: 'step2', label: 'Step 2' },
-  ],
-  persistence: LocalStorageAdapter('my-wizard-state'),
-};
-
-useProvideWizard({ config, initialData: {} });
-```
-
-### Example 6: Middleware (Logger)
-
-Add logging middleware for debugging:
-
-```typescript
-import { loggerMiddleware } from '@wizzard-packages/middleware';
-
-const config = {
-  steps: [{ id: 'step1', label: 'Step 1' }],
-  middlewares: [loggerMiddleware],
-};
-
-useProvideWizard({ config, initialData: {} });
-```
-
-### Example 7: Progress Indicator Component
-
-```vue
-<script setup lang="ts">
-import { useWizardState } from './wizard';
-
-const state = useWizardState();
-</script>
-
-<template>
-  <div class="progress-bar">
-    <div class="progress-fill" :style="{ width: `${state.progress}%` }" />
-  </div>
-  <div class="progress-text">
-    {{ state.progress }}% Complete ({{ state.currentStepIndex + 1 }} / {{ state.totalSteps }})
-  </div>
-</template>
-
-<style scoped>
-.progress-bar {
-  width: 100%;
-  height: 8px;
-  background: #e0e0e0;
-  border-radius: 4px;
-  overflow: hidden;
-}
-
-.progress-fill {
-  height: 100%;
-  background: linear-gradient(90deg, #4caf50, #8bc34a);
-  transition: width 0.3s ease;
-}
-</style>
-```
-
-### Example 8: Step Breadcrumbs
-
-```vue
-<script setup lang="ts">
-import { useWizardState, useWizardActions } from './wizard';
-
-const state = useWizardState();
-const { goToStep } = useWizardActions();
-
-const canNavigateToStep = (stepId: string) => {
-  return state.visitedSteps.has(stepId) || state.completedSteps.has(stepId);
-};
-</script>
-
-<template>
-  <div class="breadcrumbs">
-    <div
-      v-for="(step, index) in state.activeSteps"
-      :key="step.id"
-      class="breadcrumb"
-      :class="{
-        active: step.id === state.currentStepId,
-        completed: state.completedSteps.has(step.id),
-        error: state.errorSteps.has(step.id),
-      }"
-      @click="canNavigateToStep(step.id) && goToStep(step.id)"
-    >
-      <span class="number">{{ index + 1 }}</span>
-      <span class="label">{{ step.label }}</span>
-    </div>
-  </div>
-</template>
-```
-
-### Example 9: Form with Validation Errors
-
-```vue
-<script setup lang="ts">
-import { useWizardField, useWizardError, useWizardActions } from './wizard';
-
-const [name, setName] = useWizardField('user.name');
-const [email, setEmail] = useWizardField('user.email');
-
-const nameError = useWizardError('user.name');
-const emailError = useWizardError('user.email');
-
-const { validateStep, nextStep } = useWizardActions();
-
-const handleSubmit = async () => {
-  const result = await validateStep('info');
-  if (result.isValid) {
-    await nextStep();
-  }
-};
-</script>
-
-<template>
-  <form @submit.prevent="handleSubmit">
-    <div class="field">
-      <label>Name</label>
-      <input
-        :value="name"
-        @input="(e) => setName((e.target as HTMLInputElement).value)"
-        :class="{ error: nameError }"
-      />
-      <span v-if="nameError" class="error-message">{{ nameError }}</span>
-    </div>
-
-    <div class="field">
-      <label>Email</label>
-      <input
-        type="email"
-        :value="email"
-        @input="(e) => setEmail((e.target as HTMLInputElement).value)"
-        :class="{ error: emailError }"
-      />
-      <span v-if="emailError" class="error-message">{{ emailError }}</span>
-    </div>
-
-    <button type="submit">Continue</button>
+  <form @submit.prevent>
+    <label v-if="current === 'name'">
+      Your name
+      <input v-model="full" />
+    </label>
+    <p v-else-if="current === 'review'">Hello, {{ full || 'stranger' }}.</p>
+
+    <button type="button" :disabled="!canBack" @click="back()">Back</button>
+    <button type="button" :disabled="isLast" @click="next()">Next</button>
   </form>
 </template>
 ```
 
-### Example 10: Computed v-model Wrapper
+<!-- /example -->
 
-For easier v-model integration:
+That file and the flow it imports are `examples/quickstart`, which CI runs — this block is
+generated from them, so what you paste is what is tested.
 
-```vue
-<script setup lang="ts">
-import { computed } from 'vue';
-import { useWizardField } from './wizard';
+## Composables
 
-const [nameRef, setName] = useWizardField('user.name');
-const [emailRef, setEmail] = useWizardField('user.email');
+| Composable              | Returns                                                                                      |
+| ----------------------- | -------------------------------------------------------------------------------------------- |
+| `useStep()`             | `current`, `isFirst`, `isLast`, `progress`, `breadcrumbs` and the rest, each a `ComputedRef` |
+| `useNavigation()`       | `next`, `back`, `go`, `canBack`, `canNext`, `isNavigating`                                   |
+| `useField<T>(path)`     | a `WritableComputedRef`, usable directly with `v-model`                                      |
+| `useErrors(stepId?)`    | the error map for a step, or for the current one                                             |
+| `useWizardSelector(fn)` | one derived value as a `ComputedRef`                                                         |
+| `useWizard()`           | the engine itself, for anything the composables above do not cover                           |
 
-// Create computed properties for v-model
-const name = computed({
-  get: () => nameRef.value,
-  set: (val) => setName(val),
-});
+`useOptionalWizard()` returns `null` outside a provider instead of throwing, which is what a
+component rendered both inside and outside a wizard needs.
 
-const email = computed({
-  get: () => emailRef.value,
-  set: (val) => setEmail(val),
-});
-</script>
+Navigation is async and returns a result, not a boolean: `await next()` gives
+`{ ok: false, reason: 'blocked', by: 'age-check' }` when a guard refuses. Every `await` inside
+the engine re-checks a navigation epoch, so a validator that resolves after the user pressed
+Back cannot move them.
 
-<template>
-  <div>
-    <input v-model="name" placeholder="Name" />
-    <input v-model="email" type="email" placeholder="Email" />
-  </div>
-</template>
-```
+On the server `onMounted` never runs, so a wizard rendered by SSR navigates nowhere and hydrates
+into its first step on the client.
 
-### Example 11: Complex Selector with Performance
+## Documentation
 
-```vue
-<script setup lang="ts">
-import { useWizardSelector } from './wizard';
+[Getting started](https://zizzx.github.io/wizzard-packages/docs/start/) ·
+[The flow](https://zizzx.github.io/wizzard-packages/docs/flow/) ·
+[Navigation](https://zizzx.github.io/wizzard-packages/docs/navigation/) ·
+[Validation](https://zizzx.github.io/wizzard-packages/docs/validation/) ·
+[Persistence](https://zizzx.github.io/wizzard-packages/docs/persistence/)
 
-// Only re-renders when these specific values change
-const wizardMeta = useWizardSelector((state) => ({
-  currentStep: state.activeSteps.find((s) => s.id === state.currentStepId),
-  isLastAndValid: state.isLastStep && state.errorSteps.size === 0,
-  completionRate: (state.completedSteps.size / state.totalSteps) * 100,
-}));
-</script>
+The same names, as hooks, are in
+[`@wizzard-packages/react`](https://www.npmjs.com/package/@wizzard-packages/react). A shared
+contract suite runs against both, which is what stops them drifting apart.
 
-<template>
-  <div class="wizard-meta">
-    <h2>{{ wizardMeta.currentStep?.label }}</h2>
-    <p v-if="wizardMeta.isLastAndValid">Ready to submit!</p>
-    <p>{{ wizardMeta.completionRate.toFixed(0) }}% of steps completed</p>
-  </div>
-</template>
-```
+## Upgrading from 0.x
 
-### Example 12: Dynamic Step Configuration
+0.x was a different library with the same name: `createWizardFactory<TSchema>()`,
+`useProvideWizard`, `useWizardState`, `useWizardActions`. In v1 the names are shorter and the
+import path carries the version — `@wizzard-packages/vue/v1`. v1 is on the `canary` tag while
+the launch lands; the 0.x line on `latest` is being retired.
 
-```vue
-<script setup lang="ts">
-import { ref, computed } from 'vue';
-import { useProvideWizard } from './wizard';
-import type { IStepConfig } from '@wizzard-packages/core';
+## License
 
-const userType = ref<'personal' | 'business'>('personal');
-
-const steps = computed(() => {
-  const baseSteps: IStepConfig<string, any>[] = [{ id: 'type', label: 'Account Type' }];
-
-  if (userType.value === 'business') {
-    baseSteps.push({ id: 'company', label: 'Company Info' }, { id: 'tax', label: 'Tax Details' });
-  } else {
-    baseSteps.push({ id: 'personal', label: 'Personal Info' });
-  }
-
-  baseSteps.push({ id: 'review', label: 'Review' });
-
-  return baseSteps;
-});
-
-const config = computed(() => ({
-  steps: steps.value,
-}));
-
-useProvideWizard({
-  config: config.value,
-  initialData: { type: userType.value },
-});
-</script>
-```
-
-## 🎯 Best Practices
-
-### 1. Memoize Configuration
-
-Use `computed` for step configuration to avoid unnecessary recalculations:
-
-```typescript
-const config = computed(() => ({
-  steps: [{ id: 'step1', label: 'Step 1' }],
-  middlewares: [loggerMiddleware],
-  validationMode: 'onChange',
-}));
-```
-
-### 2. Granular Subscriptions
-
-Prefer specific hooks over full state for better performance:
-
-```typescript
-// ✅ Good: Only re-renders when 'user.name' changes
-const name = useWizardValue('user.name');
-
-// ❌ Avoid: Re-renders on any state change
-const state = useWizardState();
-const name = state.data.user.name;
-```
-
-### 3. Use Selectors for Derived State
-
-Create computed values with `useWizardSelector`:
-
-```typescript
-// Only re-computes when progress or isBusy changes
-const status = useWizardSelector((state) => ({
-  progress: state.progress,
-  loading: state.isBusy,
-}));
-```
-
-### 4. Validation Timing
-
-Choose appropriate validation mode:
-
-- `onChange`: Real-time validation (best UX, more API calls)
-- `onBlur`: Validate on field blur (balanced)
-- `onSubmit`: Validate on step navigation (least intrusive)
-
-### 5. Error Handling
-
-Always handle async errors in guards and validation:
-
-```typescript
-{
-  id: 'step1',
-  beforeLeave: async (data) => {
-    try {
-      await validateAPI(data);
-      return { canLeave: true };
-    } catch (error) {
-      return {
-        canLeave: false,
-        error: error.message || 'Validation failed'
-      };
-    }
-  }
-}
-```
-
-## 🔌 Integration with Vue Router
-
-```vue
-<script setup lang="ts">
-import { watch } from 'vue';
-import { useRoute, useRouter } from 'vue-router';
-import { useWizardActions, useWizardState } from './wizard';
-
-const route = useRoute();
-const router = useRouter();
-const { goToStep } = useWizardActions();
-const state = useWizardState();
-
-// Sync wizard step with route
-watch(
-  () => route.params.step,
-  (stepId) => {
-    if (stepId && stepId !== state.currentStepId) {
-      goToStep(stepId as string);
-    }
-  }
-);
-
-// Sync route with wizard step
-watch(
-  () => state.currentStepId,
-  (stepId) => {
-    if (route.params.step !== stepId) {
-      router.push({ params: { step: stepId } });
-    }
-  }
-);
-</script>
-```
-
-## 🧪 Testing
-
-```typescript
-import { mount } from '@vue/test-utils';
-import { useProvideWizard, useWizardState } from './wizard';
-
-describe('Wizard', () => {
-  it('navigates between steps', async () => {
-    const wrapper = mount({
-      setup() {
-        useProvideWizard({
-          config: {
-            steps: [
-              { id: 'step1', label: 'Step 1' },
-              { id: 'step2', label: 'Step 2' },
-            ],
-          },
-          initialData: {},
-        });
-
-        const state = useWizardState();
-        const { nextStep } = useWizardActions();
-
-        return { state, nextStep };
-      },
-      template: '<div>{{ state.currentStepId }}</div>',
-    });
-
-    expect(wrapper.text()).toBe('step1');
-
-    await wrapper.vm.nextStep();
-    await wrapper.vm.$nextTick();
-
-    expect(wrapper.text()).toBe('step2');
-  });
-});
-```
-
-## 🌐 SSR Support
-
-The Vue adapter is SSR-friendly and works with Nuxt 3:
-
-```typescript
-// Avoid persistence adapters that access `window` during module initialization
-// Use lazy initialization instead:
-
-const config = computed(() => ({
-  steps: [...],
-  persistence: typeof window !== 'undefined'
-    ? LocalStorageAdapter('key')
-    : undefined
-}));
-```
-
-## 📦 Package Structure
-
-- **ESM**: `dist/index.js` (tree-shakeable)
-- **CJS**: `dist/index.cjs` (Node.js compatibility)
-- **Types**: `dist/index.d.ts` (TypeScript definitions)
-
-## 🔗 How It Fits
-
-- **Core engine**: `@wizzard-packages/core` (shared with React)
-- **Optional persistence**: `@wizzard-packages/persistence`
-- **Optional middleware**: `@wizzard-packages/middleware`
-- **Optional validation**: `@wizzard-packages/adapter-zod` or `@wizzard-packages/adapter-yup`
-
-## 📖 Links
-
-- **Repository**: https://github.com/ZizzX/wizzard-packages
-- **Documentation**: https://zizzx.github.io/wizzard-packages/
-- **Issues**: https://github.com/ZizzX/wizzard-packages/issues
-- **Changelog**: [CHANGELOG.md](./CHANGELOG.md)
-
-## 📄 License
-
-MIT © [ZizzX](https://github.com/ZizzX)
-
----
-
-**Made with ❤️ for the Vue community**
+MIT

--- a/packages/vue/README.md
+++ b/packages/vue/README.md
@@ -76,9 +76,9 @@ generated from them, so what you paste is what is tested.
 | Composable              | Returns                                                                                      |
 | ----------------------- | -------------------------------------------------------------------------------------------- |
 | `useStep()`             | `current`, `isFirst`, `isLast`, `progress`, `breadcrumbs` and the rest, each a `ComputedRef` |
-| `useNavigation()`       | `next`, `back`, `go`, `cancel`, `canBack`, `isBusy`, `isLast`                                |
+| `useNavigation()`       | `next`, `back`, `go`, `cancel`, and `canBack`, `isBusy`, `isLast` as `ComputedRef`s          |
 | `useField<T>(path)`     | a `WritableComputedRef`, usable directly with `v-model`                                      |
-| `useErrors(stepId?)`    | the error map for a step, or for the current one                                             |
+| `useErrors(stepId?)`    | a `ComputedRef` of the error map for a step, or for the current one                          |
 | `useWizardSelector(fn)` | one derived value as a `ComputedRef`                                                         |
 | `useWizard()`           | the engine itself, for anything the composables above do not cover                           |
 

--- a/scripts/embed-examples.mjs
+++ b/scripts/embed-examples.mjs
@@ -36,7 +36,19 @@ const SNIPPETS = {
   'quickstart-devtools': { file: 'examples/quickstart/src/Devtools.tsx', lang: 'tsx' },
 };
 
-const DOCUMENTS = ['README.md', 'packages/devtools/README.md'];
+/**
+ * Every document with markers in it. A package README embeds the same snippet
+ * the root README does on purpose: npm shows the package README and nothing
+ * else, so the quickstart a reader arrives at there has to be the tested one
+ * rather than a copy that drifts.
+ */
+const DOCUMENTS = [
+  'README.md',
+  'packages/core/README.md',
+  'packages/react/README.md',
+  'packages/vue/README.md',
+  'packages/devtools/README.md',
+];
 
 const check = process.argv.includes('--check');
 /** Line endings differ between a Windows checkout and CI; the content does not. */


### PR DESCRIPTION
## What

`packages/{core,react,vue}/README.md` rewritten against v1. These three were the last
getting-started path in the repository still teaching the retired 0.x class API, and they are
the ones with the most traffic: npm renders a package README and nothing else, so a reader who
arrives from `npm i` never sees the root README or the site.

| Package | Before | After |
| --- | --- | --- |
| `core` | `new WizardStore(...)`, `IWizardConfig` | `defineFlow`, `createWizard`, the `/v1` entries |
| `react` | `createWizardFactory`, 353 lines of store recipes | `WizardProvider` and the six hooks |
| `vue` | `createWizardFactory<TSchema>()`, 822 lines, zero `/v1` | `provideWizard` and the six composables |

Net −890 lines. They are short on purpose: the guides live on the site now, and a package
README owes a reader what the package is, the smallest thing that works, and where the rest
is. Restating the site in three more places is how the two of them drift.

## Examples stay tested

`scripts/embed-examples.mjs` now carries the three package documents alongside the root and
devtools READMEs, so the quickstart blocks are generated from `examples/quickstart` and CI
fails when they drift. Same guarantee the root README already had, extended to the surface
where a stale snippet is least visible to us and most visible to a stranger.

## Sizes corrected

The root README published measurements from 2026-08-30 and the engine has grown since. Taken
from `size-limit` today:

| | README said | measures |
| --- | --- | --- |
| `core` | 3.92 kB | 5.13 kB |
| `react` | 927 B | 1.04 kB |
| `vue` | 660 B | 732 B |
| 0.x `react` | 8.43 kB | 8.48 kB |

`validate` (317 B) and `core/graph` (754 B) were already right. The "one engine, two bindings"
argument reads the same at 1.04 kB against 8.48 kB; publishing a wrong number for it would
not.

## Not in this PR

The 0.x-only package READMEs — `middleware`, `persistence`, `adapter-zod`, `adapter-yup` — are
untouched. They are deleted with their packages in L8, and rewriting a document scheduled for
deletion is work with a known expiry date.

## Checks

`prettier --check`, `eslint scripts/embed-examples.mjs`, `node scripts/embed-examples.mjs
--check`. No source changed, so no changeset: the READMEs travel with the next release either
way.
