### PR TITLE
docs: the 0.x to 1.0 migration guide, and a compat section that is true (D2, D5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,10 +210,11 @@ Node 20.11+, TypeScript 5+, React 18+, Vue 3.3+. ESM and CJS, types for both.
 
 ## Status
 
-v1 is on the `canary` tag while the launch lands: the engine, both bindings and validation are
-done; persistence, devtools and the documentation site are in progress. `docs/designs/v1-launch.md`
-is the plan, and `ROADMAP.md` is where it came from. The 0.x line on `latest` is a different
-library with the same name and is being retired.
+v1 is on the `canary` tag while the launch lands. The engine, both bindings, validation,
+persistence and devtools are done, and the documentation site is up.
+`docs/designs/v1-launch.md` is the plan, and
+`ROADMAP.md` is where it came from. The 0.x line on `latest` is a different library with the
+same name and is being retired — [`docs/MIGRATION.md`](docs/MIGRATION.md) is the way across.
 
 ## License
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -118,15 +118,16 @@ flow generation from a prompt, an MCP server, a CLI, Svelte and Solid bindings.
 
 ## Compatibility
 
-`@wizzard-packages/compat` re-implements the 0.x surface on the new engine, and
-`compileLegacyConfig` maps old configs onto a flow: `condition` → `when`, `canNavigateTo` →
-`guards.enter`, `beforeLeave` → `guards.exit`, `validationAdapter` → the validator registry,
-`component` → the view registry (identity preserved), `persistenceAdapter` → the persist
-plugin, `middlewares` → one plugin each.
+There is no compatibility package. `@wizzard-packages/compat` was planned — a re-implementation
+of the 0.x surface on the new engine, with `compileLegacyConfig` mapping old configs onto a
+flow — and it was cut on 2026-09-03 on the download numbers. Writing a second public API to
+keep alive, so that a handful of installations need not read a page, is the wrong trade at this
+size. [`docs/MIGRATION.md`](docs/MIGRATION.md) replaces it, and carries the mapping the compiler
+would have applied.
 
-Data needs no migration: 0.x stores a flat dot-path object and v1 stores dot-path slices —
-the same shape, with slices as top-level keys.
+Data needs no migration: 0.x stores a flat dot-path object and v1 stores dot-path slices — the
+same shape, with slices as top-level keys.
 
-What deliberately does not carry over is listed in the migration guide, including the
+What deliberately does not carry over is in the migration guide, including the
 `goToStepResult: 'init'` probe protocol, the leaked `errorsMap`, the two-phase render of
 conditional steps, and a handful of 0.x behaviours that were bugs rather than features.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -47,7 +47,6 @@ Dependencies point one way — into core. Core has no runtime dependencies.
 | `@wizzard-packages/validate` | one Standard Schema adapter — Zod, Valibot, ArkType, Effect, Yup                                                    | **317 B**         |
 | `@wizzard-packages/plugins`  | `/persist` in 1.0.0; `/analytics`, `/logger`, `/autosave`, `/url-sync`, `/http-flow` on demand                      | 1.2 kB `/persist` |
 | `@wizzard-packages/devtools` | inspector, flow graph, time travel                                                                                  | —                 |
-| `@wizzard-packages/compat`   | the 0.x API on top of the v1 engine                                                                                 | —                 |
 
 Removed in v1: `middleware` (replaced by plugins), `adapter-zod` and `adapter-yup` (one
 Standard Schema adapter covers four validation libraries), `persistence` (a plugin).
@@ -105,7 +104,7 @@ rewrite, stated as a number.
 shared contract-test package run against both. That suite is what keeps them from drifting
 apart again.
 
-**3 — Periphery.** `validate`, `plugins`, `devtools` with the flow graph, `compat` and the
+**3 — Periphery.** `validate`, `plugins`, `devtools` with the flow graph and the
 migration guide.
 
 **4 — Site and release.** Documentation site with live examples and an interactive flow graph;

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -79,37 +79,39 @@ Every symbol the 0.x packages exported, and what replaces it.
 | `IValidatorAdapter`                                            | none — a validator is a named resolver; see `@wizzard-packages/validate`            |
 | `ValidationResult`                                             | a resolver returns `Record<path, message> \| null`; there is no `isValid` flag      |
 | `ValidationMode`                                               | `FlowDefinition.validate.on`: `'change' \| 'blur' \| 'next' \| 'manual'`            |
-| `IPersistenceAdapter`                                          | none — `persist()` takes a `Storage` directly                                       |
+| `IPersistenceAdapter`                                          | none — `persist()` from `plugins/persist` takes a `Storage`                         |
 | `PersistenceMode`                                              | none — `persist()` writes on every commit, coalesced                                |
 | `StepDirection`                                                | none — an exit guard is an expression and cannot see the direction                  |
 | `WizardAction`, `WizardMiddleware`, `MiddlewareAPI`            | none — there are no actions; a plugin is a `Hooks` object                           |
 | `WizardEventName`, `WizardEventPayloads`, `WizardEventHandler` | none — use `subscribe`, `select`, `watch`, or a plugin hook                         |
 | `IBreadcrumb`, `BreadcrumbStatus`                              | `Breadcrumb`, on `Snapshot.breadcrumbs`                                             |
-| `Path`, `PathValue`                                            | `SliceAt<F, P>` — `wizard.get('name.full')` is typed from the flow                  |
-| `getByPath`, `setByPath`, `toPath`                             | internal to `core/v1`; no longer public                                             |
+| `Path`, `PathValue`                                            | `SliceAt<F, P>` — types a bare step id only; a nested path reads `unknown`          |
+| `getByPath`, `setByPath`                                       | `getPath`, `setPath` from `core/v1` — no default-value argument                     |
+| `toPath`                                                       | none — paths are strings throughout                                                 |
 | `shallowEqual`                                                 | none — `useWizardSelector` takes an equality function                               |
 
 ### `@wizzard-packages/react`
 
-| 0.x export                                                                                                           | v1                                                                           |
-| -------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
-| `WizardProvider`                                                                                                     | `WizardProvider` from `react/v1` — **same name, different props**, see below |
-| `WizardProviderProps`                                                                                                | `WizardProviderProps` — `{ wizard }`, or the options to build one            |
-| `createWizardFactory`                                                                                                | none — there is no factory; `createWizard` takes the flow                    |
-| `createWizardStore`, `createWizardHooks`, `WizardStoreBundle`, `CreateWizardStoreOptions`                            | none — the context-free store path is deleted                                |
-| `useWizard`                                                                                                          | `useWizard()` — returns the engine                                           |
-| `useWizardContext`                                                                                                   | `useWizard()`, or `useOptionalWizard()` outside a provider                   |
-| `useWizardState`                                                                                                     | `useWizardSnapshot()`                                                        |
-| `useWizardActions`, `IWizardActionsTyped`                                                                            | `useNavigation()`, plus `wizard.set` / `patch` / `reset`                     |
-| `useWizardValue`, `useWizardField`                                                                                   | `useField(path)` — one hook, returns `[value, setValue]`                     |
-| `useWizardError`                                                                                                     | `useErrors(stepId?)`                                                         |
-| `useWizardAllErrors`, `useWizardFlatErrors`                                                                          | none — errors are per step; merge them yourself if you need one map          |
-| `useWizardSelector`                                                                                                  | `useWizardSelector(fn, isEqual?)` — **the selector now reads a `Snapshot`**  |
-| `useWizardCurrentStep`, `useWizardSteps`, `useWizardMeta`                                                            | `useStep()` — one hook for all of it                                         |
-| `useWizardStoreState`, `useWizardStoreValue`, `useWizardStoreField`, `useWizardStoreError`, `useWizardStoreSelector` | none — the store-without-provider hooks are deleted                          |
-| `WizardStepRenderer`, `WizardStepRendererProps`                                                                      | none — render on `current`, or name a view with `AtomStep.view`              |
-| `IWizardHandle`                                                                                                      | none                                                                         |
-| re-exports of `WizardStore`, `loggerMiddleware` and the core types                                                   | gone with their packages; import from `core/v1`                              |
+| 0.x export                                                                                                           | v1                                                                                                                     |
+| -------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| `WizardProvider`                                                                                                     | `WizardProvider` from `react/v1` — **same name, different props**, see below                                           |
+| `WizardProviderProps`                                                                                                | `WizardProviderProps` — `{ wizard }`, or the options to build one                                                      |
+| `createWizardFactory`                                                                                                | none — there is no factory; `createWizard` takes the flow                                                              |
+| `createWizardStore`, `createWizardHooks`, `WizardStoreBundle`, `CreateWizardStoreOptions`                            | none — the context-free store path is deleted                                                                          |
+| `useWizard`                                                                                                          | `useWizard()` — returns the engine                                                                                     |
+| `useWizardContext`                                                                                                   | `useWizard()`, or `useOptionalWizard()` outside a provider                                                             |
+| `useWizardState`                                                                                                     | `useWizardSnapshot()`                                                                                                  |
+| `useWizardActions`, `IWizardActionsTyped`                                                                            | `useNavigation()`, plus `wizard.set` / `patch` / `reset`                                                               |
+| `useWizardValue`, `useWizardField`                                                                                   | `useField(path)` — one hook, returns `[value, setValue]`                                                               |
+| `useWizardError`                                                                                                     | `useErrors(stepId?)`                                                                                                   |
+| `useWizardAllErrors`, `useWizardFlatErrors`                                                                          | none — errors are per step; merge them yourself if you need one map                                                    |
+| `useWizardSelector`                                                                                                  | `useWizardSelector(fn, isEqual?)` — **the selector now reads a `Snapshot`**                                            |
+| `useWizardCurrentStep`, `useWizardSteps`                                                                             | `useStep()` — one hook for both                                                                                        |
+| `useWizardMeta`                                                                                                      | `useStep()` for the position and `useNavigation()` for `isBusy`; `isLoading`, `isDirty` and `goToStepResult` have none |
+| `useWizardStoreState`, `useWizardStoreValue`, `useWizardStoreField`, `useWizardStoreError`, `useWizardStoreSelector` | none — the store-without-provider hooks are deleted                                                                    |
+| `WizardStepRenderer`, `WizardStepRendererProps`                                                                      | none — render on `current`, or name a view with `AtomStep.view`                                                        |
+| `IWizardHandle`                                                                                                      | none                                                                                                                   |
+| re-exports of `WizardStore`, `loggerMiddleware` and the core types                                                   | gone with their packages; import from `core/v1`                                                                        |
 
 ### `@wizzard-packages/vue`
 
@@ -137,12 +139,12 @@ One adapter covers Zod, Valibot, ArkType, Effect and Yup, because they all expos
 
 ### `@wizzard-packages/persistence` and `@wizzard-packages/middleware`
 
-| 0.x export            | v1                                                                         |
-| --------------------- | -------------------------------------------------------------------------- |
-| `LocalStorageAdapter` | `persist({ key, storage: localStorage })` from `@wizzard-packages/plugins` |
-| `MemoryAdapter`       | none — pass any object implementing `Storage`, or leave `persist` out      |
-| `loggerMiddleware`    | none in 1.0.0 — a dozen lines against `onCommit` and `onAttempt`           |
-| `devToolsMiddleware`  | `@wizzard-packages/devtools`, a panel rather than a Redux bridge           |
+| 0.x export            | v1                                                                                 |
+| --------------------- | ---------------------------------------------------------------------------------- |
+| `LocalStorageAdapter` | `persist({ key, storage: localStorage })` from `@wizzard-packages/plugins/persist` |
+| `MemoryAdapter`       | none — pass any object implementing `Storage`, or leave `persist` out              |
+| `loggerMiddleware`    | none in 1.0.0 — a dozen lines against `onCommit` and `onAttempt`                   |
+| `devToolsMiddleware`  | `@wizzard-packages/devtools`, a panel rather than a Redux bridge                   |
 
 Both packages are deleted. `store.hydrate()` and `store.save()` go with them: `persist` restores
 before the first render and writes on every commit.
@@ -153,8 +155,9 @@ Each of these was a bug or a leak rather than a feature.
 
 - **`dependsOn` and `clearData`.** React-only in 0.x, never implemented in Vue. Clearing a field
   in one step when a field in another changes is yours now: `wizard.watch(path, fn)` and a `set`
-  in the listener. The nearest built-in, `clearOnLeave`, clears the leaving step's own slice and
-  nothing else.
+  in the listener. `clearOnLeave` is close but not the same thing: it fires when a step is left,
+  not when a value changes. `clearOnLeave: true` drops that step's own slice, and a list of paths
+  drops exactly those, which may live in another slice — but the trigger is still leaving.
 - **`errorsMap`.** A public `Map` mirroring `errors`. `Snapshot.errors` is a plain object.
 - **`goToStepResult: 'init'`.** A sentinel written into state so a caller could re-read it and
   discover that a middleware had intercepted the move. `NavResult` answers directly.
@@ -205,15 +208,26 @@ import { createWizard } from '@wizzard-packages/core/v1';
 
 import { readLegacyWizard } from './from-0x-storage';
 
-const legacy = readLegacyWizard(localStorage);
+// The step ids of your 0.x config, in its order. `hydrate()` read exactly
+// these, in exactly this order, and reproducing that is what keeps a stale key
+// from a deleted step out of the restored data.
+const legacy = readLegacyWizard(localStorage, ['name', 'review']);
 const wizard = createWizard({ flow: signup, data: legacy?.data });
 
 await wizard.start();
-if (legacy?.currentStepId) await wizard.go(legacy.currentStepId, { force: true });
+if (legacy?.currentStepId) {
+  const moved = await wizard.go(legacy.currentStepId, { force: true });
+  if (!moved.ok) {
+    // They stay on the first step, with their answers. Show that rather than
+    // letting it pass: a wizard that silently restarts looks like data loss.
+  }
+}
 ```
 
-`force` is there because the user has already answered the questions guarding the step they were
-on; re-running those guards against restored data would send them back to the beginning.
+`force` waives the navigation policy — `'sequential'` would otherwise refuse a jump to a step
+the restored run has not walked to in this session. It does **not** waive the step's guards or
+its `when`: a step the restored data no longer reaches is still refused, and `go` says so in its
+result. That is the right way round, and it is why the result is worth reading.
 
 ## The root import changes at 1.0.0
 

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -1,0 +1,234 @@
+# Migrating from 0.x to 1.0
+
+0.x and v1 are different libraries with the same name. 0.x gave you a store and a config of
+steps, and left the branching in your components. v1 makes the flow itself a plain JSON object
+and runs it in one engine. Almost nothing is a rename, so almost nothing can be automated.
+
+**There is no codemod, and there is no compatibility package.** `@wizzard-packages/compat` was
+planned and cut on 2026-09-03: it would have re-implemented the 0.x surface on the new engine,
+which means a second public API to keep alive forever. The change is a model change rather than
+a rename, so a codemod would have had to guess at the parts that are genuinely different —
+where a `condition` function becomes a `when` expression, there is no mechanical translation of
+the function body. This page is the whole migration story.
+
+## How many people this is for
+
+A GitHub code search on **2026-09-08** for `@wizzard-packages/` found **157 files**, and all 157
+are in `ZizzX/wizzard-packages` itself. Restricted to `package.json`, the search returns **one
+repository**: this one. No public repository declares a dependency on any
+`@wizzard-packages/*` package.
+
+npm reports 1 296 downloads of `@wizzard-packages/core` in the month to 2026-09-06 (react 926,
+vue 830), which with zero visible dependents is what mirrors and registry crawlers look like
+rather than applications. Both numbers are here because the decision to cut the compatibility
+package rested on them, and a reader deserves to check the reasoning rather than take it.
+
+If you are the exception — a private repository the search cannot see — the table below is
+complete, and an issue naming what you are on gets a real answer.
+
+## The seven moves
+
+Everything else follows from these.
+
+**1. A steps array becomes a keyed record and an order.** 0.x had `config.steps: IStepConfig[]`,
+where a step's identity was its position and its `id`. v1 has `steps: Record<string, StepDef>`
+plus `order: string[]`. A patch can name one step without counting indexes, and a flow can be
+reordered without touching a step.
+
+**2. Functions in the config become expressions in JSON.** `condition(data, meta)` becomes
+`when: { $not: { $empty: { $get: 'data.plan' } } }`. This is the change everything else rests
+on: a flow with a function in it cannot be sent from a server, stored, diffed or drawn. Anything
+that genuinely needs to run code is a **named** entry in the registry you pass to
+`createWizard`, so the flow holds the name and your application holds the function.
+
+**3. Navigation returns a result instead of a boolean.** `goToStep` resolved to `true` or
+`false`, and to find out why it refused you dispatched a sentinel action and re-read the store.
+`next()`, `back()` and `go()` resolve to a `NavResult` —
+`{ ok: false, reason: 'blocked', by: 'age-check' }` — and there is nothing to probe.
+
+**4. There is one navigation implementation.** 0.x had three, in the store, the React context
+and the Vue composable, and they disagreed. v1 has one pipeline in the engine, and a shared
+contract suite runs against both bindings.
+
+**5. Sets become arrays.** `visitedSteps`, `completedSteps`, `busySteps` and `dirtyFields` were
+`Set`s, which do not survive `JSON.stringify`. They are `readonly string[]` now, which is what
+makes a session serializable at all.
+
+**6. Middleware becomes lifecycle hooks.** There is no `dispatch` and no action object left to
+intercept. A plugin is `{ init, onCommit, beforeNavigate, afterNavigate, onAttempt, loadStep }`.
+
+**7. Derived state stops being stored.** `activeSteps`, `progress` and `breadcrumbs` were written
+into state by the framework layer. They are computed by a memoized selector now, so they cannot
+go stale and are not part of what gets persisted.
+
+## Every 0.x export
+
+Every symbol the 0.x packages exported, and what replaces it.
+
+### `@wizzard-packages/core`
+
+| 0.x export                                                     | v1                                                                                  |
+| -------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
+| `WizardStore`                                                  | `createWizard(options)` in `core/v1`                                                |
+| `IWizardStore`                                                 | `Wizard<F>`                                                                         |
+| `IWizardState`                                                 | `WizardState`, with the derived values in `Snapshot`                                |
+| `IWizardActions`                                               | methods on `Wizard`: `next`, `back`, `go`, `set`, `patch`, `reset`                  |
+| `IWizardConfig`                                                | `FlowDefinition`                                                                    |
+| `IStepConfig`                                                  | `StepDef` — an `AtomStep` or a `GroupStep`                                          |
+| `IWizardContext`                                               | none — a binding exposes the `Snapshot` and the engine, not a merged context object |
+| `IValidatorAdapter`                                            | none — a validator is a named resolver; see `@wizzard-packages/validate`            |
+| `ValidationResult`                                             | a resolver returns `Record<path, message> \| null`; there is no `isValid` flag      |
+| `ValidationMode`                                               | `FlowDefinition.validate.on`: `'change' \| 'blur' \| 'next' \| 'manual'`            |
+| `IPersistenceAdapter`                                          | none — `persist()` takes a `Storage` directly                                       |
+| `PersistenceMode`                                              | none — `persist()` writes on every commit, coalesced                                |
+| `StepDirection`                                                | none — an exit guard is an expression and cannot see the direction                  |
+| `WizardAction`, `WizardMiddleware`, `MiddlewareAPI`            | none — there are no actions; a plugin is a `Hooks` object                           |
+| `WizardEventName`, `WizardEventPayloads`, `WizardEventHandler` | none — use `subscribe`, `select`, `watch`, or a plugin hook                         |
+| `IBreadcrumb`, `BreadcrumbStatus`                              | `Breadcrumb`, on `Snapshot.breadcrumbs`                                             |
+| `Path`, `PathValue`                                            | `SliceAt<F, P>` — `wizard.get('name.full')` is typed from the flow                  |
+| `getByPath`, `setByPath`, `toPath`                             | internal to `core/v1`; no longer public                                             |
+| `shallowEqual`                                                 | none — `useWizardSelector` takes an equality function                               |
+
+### `@wizzard-packages/react`
+
+| 0.x export                                                                                                           | v1                                                                           |
+| -------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
+| `WizardProvider`                                                                                                     | `WizardProvider` from `react/v1` — **same name, different props**, see below |
+| `WizardProviderProps`                                                                                                | `WizardProviderProps` — `{ wizard }`, or the options to build one            |
+| `createWizardFactory`                                                                                                | none — there is no factory; `createWizard` takes the flow                    |
+| `createWizardStore`, `createWizardHooks`, `WizardStoreBundle`, `CreateWizardStoreOptions`                            | none — the context-free store path is deleted                                |
+| `useWizard`                                                                                                          | `useWizard()` — returns the engine                                           |
+| `useWizardContext`                                                                                                   | `useWizard()`, or `useOptionalWizard()` outside a provider                   |
+| `useWizardState`                                                                                                     | `useWizardSnapshot()`                                                        |
+| `useWizardActions`, `IWizardActionsTyped`                                                                            | `useNavigation()`, plus `wizard.set` / `patch` / `reset`                     |
+| `useWizardValue`, `useWizardField`                                                                                   | `useField(path)` — one hook, returns `[value, setValue]`                     |
+| `useWizardError`                                                                                                     | `useErrors(stepId?)`                                                         |
+| `useWizardAllErrors`, `useWizardFlatErrors`                                                                          | none — errors are per step; merge them yourself if you need one map          |
+| `useWizardSelector`                                                                                                  | `useWizardSelector(fn, isEqual?)` — **the selector now reads a `Snapshot`**  |
+| `useWizardCurrentStep`, `useWizardSteps`, `useWizardMeta`                                                            | `useStep()` — one hook for all of it                                         |
+| `useWizardStoreState`, `useWizardStoreValue`, `useWizardStoreField`, `useWizardStoreError`, `useWizardStoreSelector` | none — the store-without-provider hooks are deleted                          |
+| `WizardStepRenderer`, `WizardStepRendererProps`                                                                      | none — render on `current`, or name a view with `AtomStep.view`              |
+| `IWizardHandle`                                                                                                      | none                                                                         |
+| re-exports of `WizardStore`, `loggerMiddleware` and the core types                                                   | gone with their packages; import from `core/v1`                              |
+
+### `@wizzard-packages/vue`
+
+| 0.x export                         | v1                                                                     |
+| ---------------------------------- | ---------------------------------------------------------------------- |
+| `useProvideWizard`                 | `provideWizard(source)` — renamed                                      |
+| `WIZARD_STORE_KEY`                 | none — the injection key is private                                    |
+| `useWizardStore`                   | `useWizard()`                                                          |
+| `useWizardState`                   | `useWizardSnapshot()`                                                  |
+| `useWizardValue`, `useWizardField` | `useField(path)` — a `WritableComputedRef`, for `v-model`              |
+| `useWizardActions`                 | `useNavigation()`                                                      |
+| `useWizardError`                   | `useErrors(stepId?)` — **scoped to one step**; 0.x searched every step |
+| `useWizardSelector`                | `useWizardSelector(fn)` — returns a `ComputedRef`                      |
+| `createWizardFactory`              | none                                                                   |
+
+### The adapter packages
+
+| 0.x export                                                    | v1                                                    |
+| ------------------------------------------------------------- | ----------------------------------------------------- |
+| `ZodAdapter`, `ZodLikeSchema` (`adapter-zod`)                 | `schema(zodSchema)` from `@wizzard-packages/validate` |
+| `YupAdapter`, `YupLikeSchema`, `YupLikeError` (`adapter-yup`) | `schema(yupSchema)` — Yup 1.5+ speaks Standard Schema |
+
+One adapter covers Zod, Valibot, ArkType, Effect and Yup, because they all expose the same
+`~standard` property. Both 0.x packages are deleted.
+
+### `@wizzard-packages/persistence` and `@wizzard-packages/middleware`
+
+| 0.x export            | v1                                                                         |
+| --------------------- | -------------------------------------------------------------------------- |
+| `LocalStorageAdapter` | `persist({ key, storage: localStorage })` from `@wizzard-packages/plugins` |
+| `MemoryAdapter`       | none — pass any object implementing `Storage`, or leave `persist` out      |
+| `loggerMiddleware`    | none in 1.0.0 — a dozen lines against `onCommit` and `onAttempt`           |
+| `devToolsMiddleware`  | `@wizzard-packages/devtools`, a panel rather than a Redux bridge           |
+
+Both packages are deleted. `store.hydrate()` and `store.save()` go with them: `persist` restores
+before the first render and writes on every commit.
+
+## What does not carry over
+
+Each of these was a bug or a leak rather than a feature.
+
+- **`dependsOn` and `clearData`.** React-only in 0.x, never implemented in Vue. Clearing a field
+  in one step when a field in another changes is yours now: `wizard.watch(path, fn)` and a `set`
+  in the listener. The nearest built-in, `clearOnLeave`, clears the leaving step's own slice and
+  nothing else.
+- **`errorsMap`.** A public `Map` mirroring `errors`. `Snapshot.errors` is a plain object.
+- **`goToStepResult: 'init'`.** A sentinel written into state so a caller could re-read it and
+  discover that a middleware had intercepted the move. `NavResult` answers directly.
+- **The two-phase render of conditional steps.** 0.x seeded `activeSteps` with the unconditional
+  steps and corrected itself a tick later, so a conditional step flashed. In v1 `active` is right
+  on the first read whenever no condition needs an async resolver.
+- **Per-step navigation veto.** `canNavigateTo` was an arbitrary function on a step that could
+  override the navigation mode entirely. `policy` is flow-level, and anything beyond an
+  expression belongs in a plugin's `beforeNavigate`, which is wizard-wide.
+- **Direction-aware exit guards.** `beforeLeave(data, direction)` could allow leaving forward and
+  refuse leaving backward. `guards.exit` is an expression and does not see the direction.
+
+## Same name, different behaviour
+
+Three things survive by name and will not tell you they changed.
+
+**`WizardProvider`** exists in both. 0.x took `config`, `initialData` and `initialStepId` and
+dispatched an `INIT` synchronously; v1 takes a `flow` (or a `wizard`) and starts in a layout
+effect that never runs on the server. TypeScript catches the props — a copied JSX block will look
+right and be wrong.
+
+**`useWizardSelector`** exists in both, and this one the compiler will not always catch. The
+selector argument changed from `IWizardState` to `Snapshot`, and two names changed meaning with
+it: `activeSteps` was an array of step **objects**, `active` is an array of step **id strings**.
+A selector reading `.length` keeps compiling and starts answering a different question.
+
+**`errors`** is the one place where the name and the shape both hold:
+`Record<stepId, Record<path, message>>` in 0.x and in v1.
+
+## Your stored data
+
+The values need no migration. Both versions address data by dot path, and a 0.x step id is a v1
+slice key, so `name.full` means the same thing in both.
+
+The envelope around them does not carry. 0.x wrote one storage key per step —
+`wizard_<stepId>`, each holding a timestamped copy of the whole data object — plus a
+`wizard___wizzard_meta__` key with the position. `persist()` writes one key holding a whole
+`Snapshot`. **A v1 wizard pointed at 0.x storage finds no key it recognises and starts empty,
+without an error.** If your users have wizards in progress, read the old keys once before the new
+build takes over.
+
+[`examples/migration/from-0x-storage.ts`](../examples/migration/from-0x-storage.ts) is that read,
+and [its test](../examples/migration/from-0x-storage.test.ts) runs a real 0.x storage dump
+through it and into a v1 wizard. Copy the file; it is not shipped as a package.
+
+```ts
+import { createWizard } from '@wizzard-packages/core/v1';
+
+import { readLegacyWizard } from './from-0x-storage';
+
+const legacy = readLegacyWizard(localStorage);
+const wizard = createWizard({ flow: signup, data: legacy?.data });
+
+await wizard.start();
+if (legacy?.currentStepId) await wizard.go(legacy.currentStepId, { force: true });
+```
+
+`force` is there because the user has already answered the questions guarding the step they were
+on; re-running those guards against restored data would send them back to the beginning.
+
+## The root import changes at 1.0.0
+
+Today `@wizzard-packages/core` resolves `.` to 0.x and `/v1` to the new engine, which is why
+every example here imports `/v1`. At 1.0.0 the root export becomes v1. **This is a breaking
+change to code that never named a version**: an untouched 0.x application that upgrades across
+it gets the new engine from an import it did not edit.
+
+Pin `0.x` on the `latest` tag until you have worked through this page, then move to `/v1`
+imports, then upgrade. The `/v1` path keeps working after the flip.
+
+## Where to go next
+
+The [documentation site](https://zizzx.github.io/wizzard-packages/docs/start/) teaches v1 from
+nothing, which for most 0.x applications is faster than translating a config field by field.
+[The flow](https://zizzx.github.io/wizzard-packages/docs/flow/) and
+[Expressions](https://zizzx.github.io/wizzard-packages/docs/expressions/) cover what used to be
+functions in your config.

--- a/examples/migration/from-0x-storage.test.ts
+++ b/examples/migration/from-0x-storage.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest';
+
+import { createWizard, defineFlow, step } from '../../packages/core/src/v1/index';
+
+import { readLegacyWizard, type ReadableStorage } from './from-0x-storage';
+
+/** A `Storage` that holds what a 0.x wizard actually left behind. */
+function storage(entries: Record<string, string>): ReadableStorage {
+  const keys = Object.keys(entries);
+  return {
+    length: keys.length,
+    key: (i) => keys[i] ?? null,
+    getItem: (k) => entries[k] ?? null,
+  };
+}
+
+const wrap = (data: unknown, timestamp: number): string => JSON.stringify({ timestamp, data });
+
+/**
+ * What 0.x wrote for a two-step wizard the user had filled in and walked into
+ * the second step: one key per step, each a full copy of the data, and a meta
+ * key with the position.
+ */
+const legacyDump = {
+  wizard_name: wrap({ name: { full: 'Ada Lovelace' } }, 1_000),
+  wizard_review: wrap({ name: { full: 'Ada Lovelace' }, review: { agreed: true } }, 2_000),
+  wizard___wizzard_meta__: wrap(
+    {
+      currentStepId: 'review',
+      visited: ['name', 'review'],
+      completed: ['name'],
+      history: ['name'],
+    },
+    2_000
+  ),
+};
+
+const signup = defineFlow({
+  id: 'signup',
+  order: ['name', 'review'],
+  steps: {
+    name: step<{ full: string }>({ label: 'Your name' }),
+    review: step<{ agreed: boolean }>({ label: 'Review' }),
+  },
+});
+
+describe('reading a 0.x wizard out of storage', () => {
+  it('takes the newest data across the step keys, the way 0.x hydrate did', () => {
+    const legacy = readLegacyWizard(storage(legacyDump));
+
+    expect(legacy).not.toBeNull();
+    expect(legacy?.data).toEqual({
+      name: { full: 'Ada Lovelace' },
+      review: { agreed: true },
+    });
+    expect(legacy?.currentStepId).toBe('review');
+    expect(legacy?.visited).toEqual(['name', 'review']);
+  });
+
+  it('carries the values into a v1 wizard, addressed by the same paths', async () => {
+    const legacy = readLegacyWizard(storage(legacyDump));
+    const wizard = createWizard({ flow: signup, data: legacy?.data });
+
+    await wizard.start();
+    if (legacy?.currentStepId) await wizard.go(legacy.currentStepId, { force: true });
+
+    // The whole claim of the migration guide, in one assertion: a dot path that
+    // addressed a value in 0.x addresses the same value in v1.
+    expect(wizard.get('name.full')).toBe('Ada Lovelace');
+    expect(wizard.getSnapshot().current).toBe('review');
+  });
+
+  it('returns null when there is nothing to carry, rather than an empty wizard', () => {
+    expect(readLegacyWizard(storage({}))).toBeNull();
+    expect(readLegacyWizard(storage({ other_thing: '{}' }))).toBeNull();
+  });
+
+  it('survives a key that is not JSON, which 0.x also ignored', () => {
+    const legacy = readLegacyWizard(
+      storage({ wizard_name: 'not json{', wizard_review: wrap({ a: 1 }, 5) })
+    );
+
+    expect(legacy?.data).toEqual({ a: 1 });
+  });
+
+  it('prefers a value stored without a timestamp over no value at all', () => {
+    // An adapter without `getStepWithMeta` stored the bare object; 0.x read it
+    // back as timestamp 0. It is still the only data there is.
+    const legacy = readLegacyWizard(storage({ wizard_name: JSON.stringify({ name: 'bare' }) }));
+
+    expect(legacy?.data).toEqual({ name: 'bare' });
+  });
+});

--- a/examples/migration/from-0x-storage.test.ts
+++ b/examples/migration/from-0x-storage.test.ts
@@ -52,7 +52,6 @@ describe('reading a 0.x wizard out of storage', () => {
       review: { agreed: true },
     });
     expect(legacy?.currentStepId).toBe('review');
-    expect(legacy?.visited).toEqual(['name', 'review']);
   });
 
   it('carries the values into a v1 wizard, addressed by the same paths', async () => {

--- a/examples/migration/from-0x-storage.test.ts
+++ b/examples/migration/from-0x-storage.test.ts
@@ -5,16 +5,14 @@ import { createWizard, defineFlow, step } from '../../packages/core/src/v1/index
 import { readLegacyWizard, type ReadableStorage } from './from-0x-storage';
 
 /** A `Storage` that holds what a 0.x wizard actually left behind. */
-function storage(entries: Record<string, string>): ReadableStorage {
-  const keys = Object.keys(entries);
-  return {
-    length: keys.length,
-    key: (i) => keys[i] ?? null,
-    getItem: (k) => entries[k] ?? null,
-  };
-}
+const storage = (entries: Record<string, string>): ReadableStorage => ({
+  getItem: (k) => entries[k] ?? null,
+});
 
 const wrap = (data: unknown, timestamp: number): string => JSON.stringify({ timestamp, data });
+
+/** The step ids of the 0.x config, in its order — what `hydrate()` walked. */
+const STEPS = ['name', 'review'];
 
 /**
  * What 0.x wrote for a two-step wizard the user had filled in and walked into
@@ -46,7 +44,7 @@ const signup = defineFlow({
 
 describe('reading a 0.x wizard out of storage', () => {
   it('takes the newest data across the step keys, the way 0.x hydrate did', () => {
-    const legacy = readLegacyWizard(storage(legacyDump));
+    const legacy = readLegacyWizard(storage(legacyDump), STEPS);
 
     expect(legacy).not.toBeNull();
     expect(legacy?.data).toEqual({
@@ -58,11 +56,17 @@ describe('reading a 0.x wizard out of storage', () => {
   });
 
   it('carries the values into a v1 wizard, addressed by the same paths', async () => {
-    const legacy = readLegacyWizard(storage(legacyDump));
+    const legacy = readLegacyWizard(storage(legacyDump), STEPS);
     const wizard = createWizard({ flow: signup, data: legacy?.data });
 
     await wizard.start();
-    if (legacy?.currentStepId) await wizard.go(legacy.currentStepId, { force: true });
+    if (legacy?.currentStepId) {
+      const moved = await wizard.go(legacy.currentStepId, { force: true });
+      // The restore can be refused — a guard on the step the user was standing
+      // on is re-evaluated here. Failing loudly beats landing them on step one
+      // with their answers apparently intact.
+      expect(moved.ok).toBe(true);
+    }
 
     // The whole claim of the migration guide, in one assertion: a dot path that
     // addressed a value in 0.x addresses the same value in v1.
@@ -70,14 +74,42 @@ describe('reading a 0.x wizard out of storage', () => {
     expect(wizard.getSnapshot().current).toBe('review');
   });
 
+  it('breaks a timestamp tie towards the later step, as 0.x did', () => {
+    // 0.x compared with `>=` while walking the config in order, so on a tie the
+    // step further down the config won. Two writes inside one millisecond is
+    // not a hypothetical on a fast machine.
+    const tie = {
+      wizard_name: wrap({ who: 'first' }, 5_000),
+      wizard_review: wrap({ who: 'second' }, 5_000),
+    };
+
+    expect(readLegacyWizard(storage(tie), ['name', 'review'])?.data).toEqual({ who: 'second' });
+    // The same two keys, read against a config in the other order, answer the
+    // other way. Which is why the ids are a parameter and not a prefix scan.
+    expect(readLegacyWizard(storage(tie), ['review', 'name'])?.data).toEqual({ who: 'first' });
+  });
+
+  it('ignores a key left behind by a step the config no longer has', () => {
+    // A step removed from the config in a later 0.x release leaves its key in
+    // localStorage forever. `hydrate()` never read it, however fresh it was,
+    // and a migration that does would restore data the application had dropped.
+    const withOrphan = {
+      wizard_name: wrap({ who: 'live' }, 1_000),
+      wizard_deleted_step: wrap({ who: 'orphan' }, 9_999),
+    };
+
+    expect(readLegacyWizard(storage(withOrphan), ['name'])?.data).toEqual({ who: 'live' });
+  });
+
   it('returns null when there is nothing to carry, rather than an empty wizard', () => {
-    expect(readLegacyWizard(storage({}))).toBeNull();
-    expect(readLegacyWizard(storage({ other_thing: '{}' }))).toBeNull();
+    expect(readLegacyWizard(storage({}), STEPS)).toBeNull();
+    expect(readLegacyWizard(storage({ other_thing: '{}' }), STEPS)).toBeNull();
   });
 
   it('survives a key that is not JSON, which 0.x also ignored', () => {
     const legacy = readLegacyWizard(
-      storage({ wizard_name: 'not json{', wizard_review: wrap({ a: 1 }, 5) })
+      storage({ wizard_name: 'not json{', wizard_review: wrap({ a: 1 }, 5) }),
+      STEPS
     );
 
     expect(legacy?.data).toEqual({ a: 1 });
@@ -86,7 +118,10 @@ describe('reading a 0.x wizard out of storage', () => {
   it('prefers a value stored without a timestamp over no value at all', () => {
     // An adapter without `getStepWithMeta` stored the bare object; 0.x read it
     // back as timestamp 0. It is still the only data there is.
-    const legacy = readLegacyWizard(storage({ wizard_name: JSON.stringify({ name: 'bare' }) }));
+    const legacy = readLegacyWizard(
+      storage({ wizard_name: JSON.stringify({ name: 'bare' }) }),
+      STEPS
+    );
 
     expect(legacy?.data).toEqual({ name: 'bare' });
   });

--- a/examples/migration/from-0x-storage.ts
+++ b/examples/migration/from-0x-storage.ts
@@ -28,10 +28,17 @@ export interface LegacyWizard {
   data: Record<string, unknown>;
   /** Where the user was, when the meta key recorded it. */
   currentStepId?: string;
-  /** Steps 0.x had marked visited, for a flow whose policy reads them. */
-  visited: string[];
-  completed: string[];
 }
+
+/*
+ * The meta key also held `visited`, `completed` and `history`, and none of them
+ * are returned: `createWizard` takes `data`, `ctx` and a whole `WizardState`,
+ * and there is nothing in between to hand a list of visited steps to. Building
+ * a `WizardState` by hand to carry them would be a bigger and more fragile
+ * thing than this file should be. `go(..., { force: true })` below is the
+ * cheaper answer to the one problem they would have solved - a `'visited'` or
+ * `'sequential'` policy refusing to put the person back where they were.
+ */
 
 const META = '__wizzard_meta__';
 
@@ -100,13 +107,8 @@ export function readLegacyWizard(
 
   if (data === null && meta === null) return null;
 
-  const strings = (value: unknown): string[] =>
-    Array.isArray(value) ? value.filter((v): v is string => typeof v === 'string') : [];
-
   return {
     data: data ?? {},
     ...(typeof meta?.currentStepId === 'string' ? { currentStepId: meta.currentStepId } : {}),
-    visited: strings(meta?.visited),
-    completed: strings(meta?.completed),
   };
 }

--- a/examples/migration/from-0x-storage.ts
+++ b/examples/migration/from-0x-storage.ts
@@ -10,14 +10,16 @@
  * whole `Snapshot`. So a v1 wizard pointed at 0.x storage restores nothing: it
  * finds no key it recognises and starts empty, silently.
  *
- * Twenty lines, run once, and then the old keys can be dropped. This is not
+ * Thirty lines, run once, and then the old keys can be dropped. This is not
  * shipped as a package - it is here, tested, so it can be copied.
+ *
+ * It reads the step ids it is given rather than scanning the prefix, because
+ * that is what `WizardStore.hydrate()` did, and the difference is not cosmetic:
+ * see the note on `stepIds` below.
  */
 
-/** The parts of `Storage` this needs. A plain object works in a test. */
+/** The one part of `Storage` this needs. A plain object works in a test. */
 export interface ReadableStorage {
-  readonly length: number;
-  key(index: number): string | null;
   getItem(key: string): string | null;
 }
 
@@ -60,6 +62,16 @@ const isRecord = (value: unknown): value is Record<string, unknown> =>
  */
 export function readLegacyWizard(
   storage: ReadableStorage,
+  /**
+   * The step ids of the 0.x config, in its order. Required, and not discovered
+   * by scanning the prefix, because `hydrate()` read exactly these and in
+   * exactly this order. Two things follow from that, and both change which
+   * answers survive: a key left behind by a step the config no longer listed
+   * was never read, however fresh it was; and `>=` means that when two steps
+   * carry the same timestamp - one tick of a fast machine - the later step in
+   * the config wins. Scanning the prefix instead reproduces neither.
+   */
+  stepIds: readonly string[],
   prefix = 'wizard_'
 ): LegacyWizard | null {
   let data: Record<string, unknown> | null = null;
@@ -67,20 +79,12 @@ export function readLegacyWizard(
   // adapter without `getStepWithMeta`, and that value still has to win over
   // nothing at all.
   let newest = -1;
-  let meta: Record<string, unknown> | null = null;
 
-  for (let i = 0; i < storage.length; i += 1) {
-    const key = storage.key(i);
-    if (key === null || !key.startsWith(prefix)) continue;
-    const raw = storage.getItem(key);
+  for (const stepId of stepIds) {
+    const raw = storage.getItem(prefix + stepId);
     if (raw === null) continue;
     const entry = unwrap(raw);
     if (entry === null) continue;
-
-    if (key === prefix + META) {
-      if (isRecord(entry.data)) meta = entry.data;
-      continue;
-    }
     // Latest wins across steps, the rule 0.x's `hydrate()` used: every step key
     // held the whole data object, so the newest one is the whole truth and the
     // others are stale copies of it.
@@ -89,6 +93,10 @@ export function readLegacyWizard(
       data = entry.data;
     }
   }
+
+  const rawMeta = storage.getItem(prefix + META);
+  const metaEntry = rawMeta === null ? null : unwrap(rawMeta);
+  const meta = metaEntry !== null && isRecord(metaEntry.data) ? metaEntry.data : null;
 
   if (data === null && meta === null) return null;
 

--- a/examples/migration/from-0x-storage.ts
+++ b/examples/migration/from-0x-storage.ts
@@ -1,0 +1,104 @@
+/**
+ * Reading a 0.x wizard out of storage, so a v1 wizard can start where the user
+ * left off.
+ *
+ * The data object itself needs no migration - both versions address values by
+ * dot path, and a 0.x step id is a v1 slice key. What does not carry is the
+ * envelope around it. 0.x wrote one key per step, `wizard_<stepId>`, each
+ * holding a timestamped copy of the whole data object, plus a
+ * `wizard___wizzard_meta__` key with the position. v1 writes one key holding a
+ * whole `Snapshot`. So a v1 wizard pointed at 0.x storage restores nothing: it
+ * finds no key it recognises and starts empty, silently.
+ *
+ * Twenty lines, run once, and then the old keys can be dropped. This is not
+ * shipped as a package - it is here, tested, so it can be copied.
+ */
+
+/** The parts of `Storage` this needs. A plain object works in a test. */
+export interface ReadableStorage {
+  readonly length: number;
+  key(index: number): string | null;
+  getItem(key: string): string | null;
+}
+
+export interface LegacyWizard {
+  /** The newest data object across every step key, by the same rule 0.x used. */
+  data: Record<string, unknown>;
+  /** Where the user was, when the meta key recorded it. */
+  currentStepId?: string;
+  /** Steps 0.x had marked visited, for a flow whose policy reads them. */
+  visited: string[];
+  completed: string[];
+}
+
+const META = '__wizzard_meta__';
+
+/** 0.x wrapped every value it stored, but tolerated a bare one on read. */
+function unwrap(raw: string): { data: unknown; timestamp: number } | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    // A key written by something else, or half-written by a killed tab. The
+    // 0.x reader swallowed this too, and a migration is the wrong place to
+    // start throwing at data that was already being ignored.
+    return null;
+  }
+  if (parsed !== null && typeof parsed === 'object' && 'data' in parsed && 'timestamp' in parsed) {
+    const { data, timestamp } = parsed as { data: unknown; timestamp: unknown };
+    return { data, timestamp: typeof timestamp === 'number' ? timestamp : 0 };
+  }
+  return { data: parsed, timestamp: 0 };
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  value !== null && typeof value === 'object' && !Array.isArray(value);
+
+/**
+ * Returns what a v1 wizard needs, or `null` when there is no 0.x state to
+ * carry - which is the common case, and must not be confused with an empty one.
+ */
+export function readLegacyWizard(
+  storage: ReadableStorage,
+  prefix = 'wizard_'
+): LegacyWizard | null {
+  let data: Record<string, unknown> | null = null;
+  // `-1` and not `0`: 0.x stored `timestamp: 0` for a value written by an
+  // adapter without `getStepWithMeta`, and that value still has to win over
+  // nothing at all.
+  let newest = -1;
+  let meta: Record<string, unknown> | null = null;
+
+  for (let i = 0; i < storage.length; i += 1) {
+    const key = storage.key(i);
+    if (key === null || !key.startsWith(prefix)) continue;
+    const raw = storage.getItem(key);
+    if (raw === null) continue;
+    const entry = unwrap(raw);
+    if (entry === null) continue;
+
+    if (key === prefix + META) {
+      if (isRecord(entry.data)) meta = entry.data;
+      continue;
+    }
+    // Latest wins across steps, the rule 0.x's `hydrate()` used: every step key
+    // held the whole data object, so the newest one is the whole truth and the
+    // others are stale copies of it.
+    if (entry.timestamp >= newest && isRecord(entry.data)) {
+      newest = entry.timestamp;
+      data = entry.data;
+    }
+  }
+
+  if (data === null && meta === null) return null;
+
+  const strings = (value: unknown): string[] =>
+    Array.isArray(value) ? value.filter((v): v is string => typeof v === 'string') : [];
+
+  return {
+    data: data ?? {},
+    ...(typeof meta?.currentStepId === 'string' ? { currentStepId: meta.currentStepId } : {}),
+    visited: strings(meta?.visited),
+    completed: strings(meta?.completed),
+  };
+}


### PR DESCRIPTION
## What

`docs/MIGRATION.md`, which did not exist, and the `## Compatibility` section of `ROADMAP.md`,
which was describing `@wizzard-packages/compat` as a live plan five days after it was cut. A
reader of the roadmap was being told a compatibility package would carry them across. Nothing
was going to.

## The guide

A row for every one of the **88 symbols** the seven 0.x packages exported, grouped by package,
each mapped to its v1 equivalent or marked as having none. That is D2's acceptance criterion —
"every deleted export has a row" — and the reason it is worth the length is that most rows say
*none*: this is not a rename.

Ahead of the table, the seven conceptual moves that explain why. Functions in the config became
JSON expressions; three navigation implementations became one; `Set`s became arrays so a session
can serialize; middleware became lifecycle hooks; derived state stopped being stored.

It says plainly that there is no codemod and why — no transform rewrites the body of a
`condition` function into a `when` expression — and documents the root-export flip at 1.0.0 as
the breaking change it is.

## Two claims checked rather than asserted

**The dependent count.** A GitHub code search, dated in the file, finds 157 files mentioning
`@wizzard-packages/` — all 157 in this repository. Zero public repositories declare a dependency
on any of the packages. The compat package was cut on download numbers; downloads with no
dependents are crawlers, and this is the check that was missing from that decision.

**The stored data.** "Data needs no migration" was true about the values and false about
everything around them:

| | 0.x | v1 |
| --- | --- | --- |
| keys | one per step, `wizard_<stepId>`, plus `wizard___wizzard_meta__` | one, holding a `Snapshot` |
| payload | `{ timestamp, data }` — a full copy of the data per step | the whole serialized state |
| result of pointing v1 at 0.x storage | — | starts empty, no error |

So there is a migration, it is small, and it was undocumented. `examples/migration/from-0x-storage.ts`
reads the old keys by the same latest-wins rule `WizardStore.hydrate()` used; its test drives a
real 0.x storage dump through it and into a running v1 wizard, asserting that `name.full`
addresses the same value on both sides. Five tests.

Deliberately not shipped as a package. It is twenty lines to copy, and a compatibility surface
is the thing this release is removing.

## Also

The README status line claimed persistence, devtools and the documentation site were still in
progress. All three are in `main` — persistence as `packages/plugins/src/persist.ts`, devtools
across three merged PRs, the site as c0761d2. Rewritten so it does not enumerate what remains
and go stale again, and it now links the migration guide.

## Checks

`prettier --check`, `eslint`, and `vitest run examples/migration/` — 5 passed. No source
changed, so no changeset.
