### PR TITLE
fix(ci): stop the pre-push hook from running in CI, and measure layout by its fastest run

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,2 +1,12 @@
+# CI is not a laptop. Every pull request already runs build and tests as its own
+# job, and the release job pushes tags from inside a runner - where this hook
+# re-ran the whole suite on a loaded machine and, on 2026-09-08, refused the
+# push after `changeset publish` had already written all ten packages to npm.
+# The registry had the release, the repository had no tags for it, and the job
+# reported failure. A hook that can do that to a release has no business in CI.
+if [ -n "$CI" ]; then
+  exit 0
+fi
+
 pnpm build
 pnpm test:run

--- a/packages/devtools/src/headless/layout.test.ts
+++ b/packages/devtools/src/headless/layout.test.ts
@@ -265,8 +265,13 @@ describe('layoutGraph', () => {
       layoutGraph({ ...graph });
       times.push(performance.now() - started);
     }
-    times.sort((a, b) => a - b);
-    expect(times[1]).toBeLessThan(100);
+    // The fastest run, not the median. Noise on a shared runner only ever adds
+    // time - a scheduler steal inflates a sample and nothing deflates one - so
+    // the minimum is the closest this can get to what the algorithm costs, and
+    // the median is just a sample that happened to be interrupted less. The
+    // median read 452 ms during the 0.5.0 release on a runner that was also
+    // publishing; the same commit measured single digits on the next run.
+    expect(Math.min(...times)).toBeLessThan(100);
   });
 
   it('ratchet: the reference flows draw no more crossings than today', () => {


### PR DESCRIPTION
## What happened

The 0.5.0 release (run 34217478846, commit 11f7858) **published all ten packages to npm and
then reported failure.** Both halves are true and the order matters:

1. `changeset publish` wrote every package to `latest` — core 0.5.0, react 0.5.0, vue 0.2.2,
   devtools 3.0.0, plugins 0.1.1, validate 0.1.1, the four 0.x packages 0.1.5. Verified
   against the registry.
2. `changesets/action` then pushed the version tags.
3. The husky **pre-push** hook fired inside the runner and ran `pnpm build && pnpm test:run` —
   the full suite, on a machine that was busy publishing.
4. Two timing-sensitive tests missed. The push was refused. The step exited non-zero, so the
   `Verify the registry has them` step was skipped.

Net state: npm has the release, the repository has **no tags** for it, and the job says it
failed. Every one of those is misleading on its own.

## The fix

**The hook returns immediately when `CI` is set.** A pre-push hook exists to catch things
before they leave a laptop; in CI it is duplication, since every pull request already runs
build and tests as its own job. What the duplication bought here was a release whose tag push
was hostage to a perf test — after the irreversible half had already happened.

**The layout perf test reads the fastest of its three runs instead of the median.** Noise on a
shared runner only ever adds time; nothing deflates a sample. So the minimum is the closest
three samples get to what the algorithm costs, and the median is just a sample that was
interrupted less. It measured 452 ms during the release and single digits on the next run of
the same commit. The 100 ms budget is unchanged.

## Not in this PR

The `HeroFlow` test that timed out in the same run. It passed twice today on this commit and
has failed only on a runner that was publishing at the same time. Raising its timeout would be
picking a number rather than fixing a cause.

## Follow-up outside this PR

The ten missing tags for the published versions need creating at 11f7858. Re-running the
release workflow will not do it — the versions are already on npm, so changesets finds nothing
to publish and creates no tags.
