### PR TITLE
docs: the automated review does not run on every push

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,8 +85,10 @@ problems that are returned:
 Single-clause messages are the thing this replaces: `unknown resolver: x` names the symptom
 and leaves the reader to find the cause.
 
-**The automated review is a second gate.** A review runs on every PR and on every push to
-one. Its comments are only reachable through the API - `gh api
+**The automated review is a second gate.** A review runs when a PR is opened, when a draft
+is marked ready, and when it is asked for by comment - not on every push, so a branch that
+was reviewed and then pushed to has not been reviewed again. Its comments are only reachable
+through the API - `gh api
 repos/ZizzX/wizzard-packages/pulls/<n>/comments`, not `gh pr view`. Read it before merging
 and answer every finding: fix it, or say why it is wrong with the evidence. It has been
 right far more often than not, and it has also blamed the wrong file, so verify each one


### PR DESCRIPTION
AGENTS.md told a reader the automated review "runs on every PR and on every push to one". It does not: it runs when a PR is opened, when a draft is marked ready, and when it is asked for by comment.

The difference matters at exactly the moment it is read. A branch that was reviewed, then had four rounds of fixes pushed to it, has been reviewed once - and the old wording says it has been reviewed five times. Noticed while working PR #50, where the gate had to be substituted for an unrelated reason.

Docs only; no code touched.