### PR TITLE
feat(site): the onboarding reference application, live on both bindings (S3)

### DIFF
--- a/e2e/tests/site/examples-onboarding.spec.ts
+++ b/e2e/tests/site/examples-onboarding.spec.ts
@@ -1,0 +1,186 @@
+import AxeBuilder from '@axe-core/playwright';
+
+import type { Page } from '@playwright/test';
+
+import { expect, test } from '../../fixtures/base';
+
+/**
+ * R-A, in a browser, on both bindings.
+ *
+ * The unit suite already drives the application. What a browser adds is the
+ * three things a page can get wrong on its own: what it draws before anything
+ * hydrates, what it can be operated with instead of a mouse, and which runtime
+ * it actually downloaded.
+ */
+// Relative, so the repository's base path stays on the URL: a leading slash
+// would replace it and every page here would be a 404.
+const REACT = 'examples/onboarding/';
+const VUE = 'examples/onboarding/vue/';
+
+/** Walks Tab until the named field has focus, then types into it. */
+async function tabTo(page: Page, id: string): Promise<void> {
+  for (let i = 0; i < 20; i++) {
+    if (await page.locator(`#${id}`).evaluate((el) => el === document.activeElement)) return;
+    await page.keyboard.press('Tab');
+  }
+  throw new Error(`never reached #${id} with the keyboard`);
+}
+
+/** Every script the page fetched, concatenated. */
+function collectScripts(page: Page): { text: () => Promise<string> } {
+  const bodies: Promise<string>[] = [];
+  page.on('response', (response) => {
+    if (response.url().endsWith('.js')) bodies.push(response.text().catch(() => ''));
+  });
+  return { text: async () => (await Promise.all(bodies)).join('') };
+}
+
+test.describe('R-A onboarding', () => {
+  test('draws the first step before it hydrates, with the controls disabled', async ({
+    page,
+    browser,
+  }) => {
+    const context = await browser.newContext({ javaScriptEnabled: false });
+    const still = await context.newPage();
+    await still.goto(REACT);
+
+    // The step is drawn, not a spinner, and the buttons say they are not ready.
+    await expect(still.getByRole('heading', { name: 'Your details' })).toBeVisible();
+    await expect(still.getByLabel('Email')).toBeVisible();
+    await expect(still.getByRole('button', { name: 'Next' })).toBeDisabled();
+    await expect(still.getByRole('status')).toHaveText('Starting.');
+    // And the source is there without any JavaScript at all.
+    await expect(still.getByText('defineFlow', { exact: false }).first()).toBeVisible();
+    await context.close();
+
+    await page.goto(REACT);
+    await expect(page.getByRole('button', { name: 'Next' })).toBeEnabled();
+  });
+
+  test('routes a business payer through Company and submits neither the code nor the branch', async ({
+    page,
+  }) => {
+    await page.goto(REACT);
+    await expect(page.getByRole('button', { name: 'Next' })).toBeEnabled();
+
+    await page.getByLabel('Email').fill('ada@example.com');
+    await page.getByRole('button', { name: 'Business' }).click();
+    await page.getByRole('button', { name: 'Next' }).click();
+
+    await expect(page.getByRole('heading', { name: 'Verify your email' })).toBeVisible();
+    await page.getByLabel('Six-digit code').fill('123456');
+    await page.getByRole('button', { name: 'Next' }).click();
+
+    await expect(page.getByRole('heading', { name: 'Company details' })).toBeVisible();
+    await page.getByLabel('Company name').fill('Acme');
+    await page.getByLabel('VAT number').fill('GB123');
+    await page.getByRole('button', { name: 'Next' }).click();
+
+    await expect(page.getByRole('heading', { name: 'Payment' })).toBeVisible();
+    await page.getByLabel('Card number').fill('4242424242424242');
+    await page.getByRole('button', { name: 'Next' }).click();
+
+    await expect(page.getByRole('heading', { name: 'Review' })).toBeVisible();
+    const body = await page.locator('.app-data').innerText();
+    expect(body).toContain('"company"');
+    // The one-time code was dropped the moment the step was left.
+    expect(body).not.toContain('"verify"');
+    expect(body).not.toContain('123456');
+  });
+
+  test('can be walked without a mouse, and says where it went', async ({ page }) => {
+    await page.goto(REACT);
+    await expect(page.getByRole('button', { name: 'Next' })).toBeEnabled();
+
+    await tabTo(page, 'email');
+    await page.keyboard.type('ada@example.com');
+
+    await page.keyboard.press('Tab');
+    await page.keyboard.press('Tab');
+    // The second segmented button is Business; Enter presses it.
+    await page.keyboard.press('Enter');
+    await expect(page.getByRole('button', { name: 'Business' })).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    );
+
+    await page.keyboard.press('Tab');
+    await page.keyboard.press('Enter');
+
+    await expect(page.getByRole('heading', { name: 'Verify your email' })).toBeVisible();
+    // Focus went with the flow, and the live region said so.
+    await expect(page.getByRole('heading', { name: 'Verify your email' })).toBeFocused();
+    await expect(page.getByRole('status')).toHaveText('Verify your email. Step 2 of 5.');
+  });
+
+  test('refuses the first move and names the field', async ({ page }) => {
+    await page.goto(REACT);
+    await expect(page.getByRole('button', { name: 'Next' })).toBeEnabled();
+
+    await page.getByRole('button', { name: 'Next' }).click();
+    await expect(page.getByRole('heading', { name: 'Your details' })).toBeVisible();
+    await expect(page.getByLabel('Email')).toHaveAttribute('aria-invalid', 'true');
+    await expect(page.getByRole('status')).toContainText('Enter your email address.');
+  });
+
+  test('the Vue page runs the same flow', async ({ page }) => {
+    await page.goto(VUE);
+    await expect(page.getByRole('button', { name: 'Next' })).toBeEnabled();
+
+    await page.getByLabel('Email').fill('ada@example.com');
+    await page.getByRole('button', { name: 'Business' }).click();
+    await page.getByRole('button', { name: 'Next' }).click();
+
+    await expect(page.getByRole('heading', { name: 'Verify your email' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Verify your email' })).toBeFocused();
+    await expect(page.locator('.app-state')).toContainText(
+      'details → verify → company → payment → review'
+    );
+  });
+
+  test('each page downloads one runtime and not the other', async ({ page }) => {
+    const react = collectScripts(page);
+    await page.goto(REACT);
+    await expect(page.getByRole('button', { name: 'Next' })).toBeEnabled();
+    const reactScripts = await react.text();
+    expect(reactScripts).toContain('__reactContainer$');
+    expect(reactScripts).not.toContain('__vue_app__');
+
+    const vue = collectScripts(page);
+    await page.goto(VUE);
+    await expect(page.getByRole('button', { name: 'Next' })).toBeEnabled();
+    const vueScripts = await vue.text();
+    expect(vueScripts).toContain('__vue_app__');
+    expect(vueScripts).not.toContain('__reactContainer$');
+  });
+
+  test('the framework toggle is a link, and the index remembers the answer', async ({ page }) => {
+    await page.goto(REACT);
+    await page.getByRole('link', { name: 'Vue' }).click();
+    await expect(page).toHaveURL(/\/examples\/onboarding\/vue\/$/);
+    await expect(page.getByRole('link', { name: 'Vue' })).toHaveAttribute('aria-current', 'page');
+
+    // The index links where the visitor last was, without changing what any
+    // page renders.
+    await page.goto('examples/');
+    await expect(page.locator('a[data-example="onboarding"]')).toHaveAttribute(
+      'href',
+      /\/examples\/onboarding\/vue\/$/
+    );
+  });
+
+  for (const [name, path] of [
+    ['React', REACT],
+    ['Vue', VUE],
+  ] as const) {
+    test(`the ${name} page has no accessibility violations`, async ({ page }) => {
+      await page.goto(path);
+      await expect(page.getByRole('button', { name: 'Next' })).toBeEnabled();
+
+      const results = await new AxeBuilder({ page })
+        .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'])
+        .analyze();
+      expect(results.violations).toEqual([]);
+    });
+  }
+});

--- a/examples/reference/package.json
+++ b/examples/reference/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@examples/reference",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "description": "The reference applications of the 1.0 release. One flow definition per application, rendered by both bindings, run on the site and asserted by the end-to-end suite.",
+  "scripts": {
+    "type-check": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@wizzard-packages/core": "workspace:*",
+    "@wizzard-packages/react": "workspace:*",
+    "@wizzard-packages/vue": "workspace:*",
+    "react": "^19.2.0",
+    "react-dom": "^19.2.0",
+    "vue": "^3.5.13"
+  },
+  "devDependencies": {
+    "@testing-library/react": "^16.3.1",
+    "@types/react": "^19.2.7",
+    "@types/react-dom": "^19.2.3",
+    "@vue/test-utils": "^2.4.6",
+    "typescript": "^5.9.3"
+  }
+}

--- a/examples/reference/src/onboarding/App.tsx
+++ b/examples/reference/src/onboarding/App.tsx
@@ -70,6 +70,11 @@ function Onboarding(): ReactNode {
 
   // Focus follows the flow, but only once the visitor has moved: taking focus on
   // the first paint would drag a reader who was still reading the page above.
+  //
+  // The step id is the only dependency, and the count is read off the engine
+  // inside: `active` is rebuilt on every commit, so depending on it would make
+  // a keystroke look like a step change and pull focus out of the field being
+  // typed into.
   const moved = useRef(false);
   useEffect(() => {
     if (current === null) return;
@@ -78,14 +83,18 @@ function Onboarding(): ReactNode {
       return;
     }
     heading.current?.focus();
-    const at = active.indexOf(current) + 1;
-    setAnnouncement(`${LABELS[current] ?? current}. Step ${at} of ${active.length}.`);
-  }, [current, active]);
+    const { active: route } = wizard.getSnapshot();
+    const at = route.indexOf(current) + 1;
+    setAnnouncement(`${LABELS[current] ?? current}. Step ${at} of ${route.length}.`);
+  }, [current, wizard]);
 
   async function onNext(): Promise<void> {
     if (ended) {
       setEnded(false);
       setAnnouncement('');
+      // `reset` keeps `ctx` - it is the host's, not the run's - so the fast
+      // path has to be put back by hand, or starting again silently takes it.
+      wizard.setCtx({ returning: false });
       wizard.reset();
       await wizard.start();
       return;

--- a/examples/reference/src/onboarding/App.tsx
+++ b/examples/reference/src/onboarding/App.tsx
@@ -1,0 +1,349 @@
+import {
+  WizardProvider,
+  useErrors,
+  useField,
+  useNavigation,
+  useStep,
+  useWizard,
+  useWizardSelector,
+} from '@wizzard-packages/react/v1';
+import { useEffect, useRef, useState, type ReactNode } from 'react';
+
+import { onboarding } from './flow';
+import { registry } from './registry';
+
+/**
+ * R-A on the React binding.
+ *
+ * The rendering knows the fields and nothing else. It never asks "is this a
+ * business payer" to decide what comes next - it asks the engine which step is
+ * current and draws that one. Adding a branch is an edit to `flow.ts`.
+ *
+ * Accessibility is by hand here, deliberately: the bindings supply no ARIA in
+ * 1.0, so this file is what that contract will be written from. Visible labels,
+ * one polite live region for validation and step changes, and focus moved to
+ * the heading of the step the visitor just arrived at.
+ */
+export default function OnboardingApp(): ReactNode {
+  return (
+    <WizardProvider flow={onboarding} registry={registry} ctx={{ returning: false }}>
+      <Onboarding />
+    </WizardProvider>
+  );
+}
+
+const LABELS: Record<string, string> = {
+  details: 'Your details',
+  verify: 'Verify your email',
+  company: 'Company details',
+  payment: 'Payment',
+  review: 'Review',
+};
+
+function Onboarding(): ReactNode {
+  const wizard = useWizard();
+  const { current, active, isLast } = useStep();
+  const { back, canBack, isBusy } = useNavigation();
+  const errors = useErrors();
+
+  const [email, setEmail] = useField<string>('details.email');
+  const [payer, setPayer] = useField<string>('details.payer');
+  const [code, setCode] = useField<string>('verify.code');
+  const [company, setCompany] = useField<string>('company.name');
+  const [vat, setVat] = useField<string>('company.vat');
+  const [card, setCard] = useField<string>('payment.card');
+
+  const returning = useWizardSelector((s) => s.ctx['returning'] === true);
+  const completed = useWizardSelector((s) => s.completed);
+  const dirty = useWizardSelector((s) => s.dirty);
+  const data = useWizardSelector((s) => s.data);
+
+  const [announcement, setAnnouncement] = useState('');
+  const [ended, setEnded] = useState(false);
+  const heading = useRef<HTMLHeadingElement>(null);
+
+  // Before `start` has run - on the server, and for the first paint - there is
+  // no current step, so the form draws the step the flow is about to enter and
+  // says so, instead of a spinner over an empty box.
+  const standing = current ?? active[0] ?? 'details';
+  const starting = current === null;
+
+  // Focus follows the flow, but only once the visitor has moved: taking focus on
+  // the first paint would drag a reader who was still reading the page above.
+  const moved = useRef(false);
+  useEffect(() => {
+    if (current === null) return;
+    if (!moved.current) {
+      moved.current = true;
+      return;
+    }
+    heading.current?.focus();
+    const at = active.indexOf(current) + 1;
+    setAnnouncement(`${LABELS[current] ?? current}. Step ${at} of ${active.length}.`);
+  }, [current, active]);
+
+  async function onNext(): Promise<void> {
+    if (ended) {
+      setEnded(false);
+      setAnnouncement('');
+      wizard.reset();
+      await wizard.start();
+      return;
+    }
+    const result = await wizard.next();
+    if (result.ok) {
+      if (result.to === '@end') {
+        setEnded(true);
+        setAnnouncement('Onboarding complete.');
+      }
+      return;
+    }
+    // A refusal is the one thing the live region must carry: the fields below
+    // show it too, but a screen reader is not looking at them.
+    const fields = Object.values(result.errors ?? {});
+    setAnnouncement(
+      fields.length === 0 ? `That move was refused: ${result.reason}.` : fields.join(' ')
+    );
+  }
+
+  if (ended) {
+    return (
+      <div className="app">
+        <h2 ref={heading} tabIndex={-1}>
+          Done
+        </h2>
+        <p>The submission is what the flow collected, and nothing else.</p>
+        <pre className="app-data">{JSON.stringify(submission(data, active), null, 2)}</pre>
+        <div className="actions">
+          <button
+            className="button button-accent"
+            type="button"
+            onClick={() => {
+              void onNext();
+            }}
+          >
+            Start again
+          </button>
+        </div>
+        <Live text={announcement} />
+      </div>
+    );
+  }
+
+  return (
+    <form
+      className="app"
+      onSubmit={(event) => {
+        event.preventDefault();
+        void onNext();
+      }}
+    >
+      <h2 ref={heading} tabIndex={-1}>
+        {LABELS[standing] ?? standing}
+      </h2>
+
+      {standing === 'details' && (
+        <>
+          <Field
+            id="email"
+            label="Email"
+            type="email"
+            autoComplete="email"
+            value={email}
+            onChange={setEmail}
+            error={errors['email']}
+          />
+          <fieldset className="field">
+            <legend className="field-label">Who is paying</legend>
+            <div className="segmented">
+              {(['personal', 'business'] as const).map((choice) => (
+                <button
+                  key={choice}
+                  type="button"
+                  aria-pressed={payer === choice}
+                  onClick={() => {
+                    setPayer(choice);
+                  }}
+                >
+                  {choice === 'personal' ? 'Personal' : 'Business'}
+                </button>
+              ))}
+            </div>
+            {errors['payer'] !== undefined && <p className="field-error">{errors['payer']}</p>}
+          </fieldset>
+        </>
+      )}
+
+      {standing === 'verify' && (
+        <>
+          <Field
+            id="code"
+            label="Six-digit code"
+            inputMode="numeric"
+            autoComplete="one-time-code"
+            hint="Any six digits will do here."
+            value={code}
+            onChange={setCode}
+            error={errors['code']}
+          />
+          <label className="check">
+            <input
+              type="checkbox"
+              checked={returning}
+              onChange={(e) => {
+                wizard.setCtx({ returning: e.target.checked });
+              }}
+            />
+            I already have an account
+          </label>
+        </>
+      )}
+
+      {standing === 'company' && (
+        <>
+          <Field
+            id="company-name"
+            label="Company name"
+            value={company}
+            onChange={setCompany}
+            error={errors['name']}
+          />
+          <Field id="vat" label="VAT number" value={vat} onChange={setVat} error={errors['vat']} />
+        </>
+      )}
+
+      {standing === 'payment' && (
+        <Field
+          id="card"
+          label="Card number"
+          inputMode="numeric"
+          autoComplete="cc-number"
+          hint="Sixteen digits, spaces allowed."
+          value={card}
+          onChange={setCard}
+          error={errors['card']}
+        />
+      )}
+
+      {standing === 'review' && (
+        <>
+          <p>This is what the flow will submit.</p>
+          <pre className="app-data">{JSON.stringify(submission(data, active), null, 2)}</pre>
+        </>
+      )}
+
+      <div className="actions">
+        <button className="button button-accent" type="submit" disabled={starting || isBusy}>
+          {isLast ? 'Submit' : 'Next'}
+        </button>
+        <button
+          className="button button-secondary"
+          type="button"
+          disabled={starting || !canBack || isBusy}
+          onClick={() => {
+            void back();
+          }}
+        >
+          Back
+        </button>
+      </div>
+
+      <dl className="app-state">
+        <dt>route</dt>
+        <dd>{active.join(' → ')}</dd>
+        <dt>completed</dt>
+        <dd>{completed.length === 0 ? 'none' : completed.join(', ')}</dd>
+        <dt>edited</dt>
+        <dd>{dirty.length === 0 ? 'none' : dirty.join(', ')}</dd>
+      </dl>
+
+      <Live text={starting ? 'Starting.' : announcement} />
+    </form>
+  );
+}
+
+/**
+ * What the flow submits: the slices of the steps that are on the route.
+ *
+ * A branch the visitor walked away from keeps its answers - the engine clears
+ * nothing when a `when` goes false, so going back to it finds them still there -
+ * and it is the application that decides those answers are not part of this
+ * submission. `verify` is missing for the other reason: `clearOnLeave` dropped
+ * it the moment the step was left.
+ */
+function submission(
+  data: Readonly<Record<string, unknown>>,
+  active: readonly string[]
+): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const id of active) {
+    if (data[id] !== undefined) out[id] = data[id];
+  }
+  return out;
+}
+
+/**
+ * A labelled text field.
+ *
+ * The label is a `for`/`id` pair rather than a wrapper, and the hint and the
+ * error are named by `aria-describedby`: that keeps the accessible name of the
+ * input to the label alone, while a screen reader still reads the refusal with
+ * the field it belongs to. Wrapping all four in one `<label>` would fold the
+ * error message into the name, and the field would announce itself differently
+ * before and after a refusal.
+ */
+function Field(props: {
+  id: string;
+  label: string;
+  value: string | undefined;
+  onChange: (value: string) => void;
+  type?: string;
+  inputMode?: 'numeric';
+  autoComplete?: string;
+  hint?: string;
+  error?: string | undefined;
+}): ReactNode {
+  const described = [
+    props.hint === undefined ? null : `${props.id}-hint`,
+    props.error === undefined ? null : `${props.id}-error`,
+  ].filter((id): id is string => id !== null);
+
+  return (
+    <div className="field">
+      <label className="field-label" htmlFor={props.id}>
+        {props.label}
+      </label>
+      <input
+        id={props.id}
+        type={props.type ?? 'text'}
+        inputMode={props.inputMode}
+        autoComplete={props.autoComplete}
+        value={props.value ?? ''}
+        aria-invalid={props.error === undefined ? undefined : true}
+        aria-describedby={described.length === 0 ? undefined : described.join(' ')}
+        onChange={(e) => {
+          props.onChange(e.target.value);
+        }}
+      />
+      {props.hint !== undefined && (
+        <span className="field-hint" id={`${props.id}-hint`}>
+          {props.hint}
+        </span>
+      )}
+      {props.error !== undefined && (
+        <span className="field-error" id={`${props.id}-error`}>
+          {props.error}
+        </span>
+      )}
+    </div>
+  );
+}
+
+/** One polite region for the whole application, so two announcements queue. */
+function Live(props: { text: string }): ReactNode {
+  return (
+    <p className="app-live" role="status" aria-live="polite">
+      {props.text}
+    </p>
+  );
+}

--- a/examples/reference/src/onboarding/App.vue
+++ b/examples/reference/src/onboarding/App.vue
@@ -1,0 +1,16 @@
+<script setup lang="ts">
+import { provideWizard } from '@wizzard-packages/vue/v1';
+
+import Onboarding from './Onboarding.vue';
+import { onboarding } from './flow';
+import { registry } from './registry';
+
+// The wizard is provided here and consumed by the child. Vue's `inject` reads
+// the parent chain, so the component that provides cannot also use the
+// composables - which is the whole reason this file is two lines and a child.
+provideWizard({ flow: onboarding, registry, ctx: { returning: false } });
+</script>
+
+<template>
+  <Onboarding />
+</template>

--- a/examples/reference/src/onboarding/Onboarding.vue
+++ b/examples/reference/src/onboarding/Onboarding.vue
@@ -90,6 +90,9 @@ async function onNext(): Promise<void> {
   if (ended.value) {
     ended.value = false;
     announcement.value = '';
+    // `reset` keeps `ctx` - it is the host's, not the run's - so the fast path
+    // has to be put back by hand, or starting again silently takes it.
+    wizard.setCtx({ returning: false });
     wizard.reset();
     await wizard.start();
     return;

--- a/examples/reference/src/onboarding/Onboarding.vue
+++ b/examples/reference/src/onboarding/Onboarding.vue
@@ -1,0 +1,260 @@
+<script setup lang="ts">
+import {
+  useErrors,
+  useField,
+  useNavigation,
+  useStep,
+  useWizard,
+  useWizardSelector,
+} from '@wizzard-packages/vue/v1';
+import { computed, ref, useTemplateRef, watch } from 'vue';
+
+/**
+ * R-A on the Vue binding.
+ *
+ * The same application as `App.tsx`, step for step and message for message: the
+ * two files exist so that a reader can put them side by side and see that the
+ * engine, the route and the validation are the same object, and only the
+ * rendering differs.
+ *
+ * Accessibility is by hand for the same reason it is in the React file - the
+ * bindings supply no ARIA in 1.0, and these two are what that contract will be
+ * written from.
+ */
+const LABELS: Record<string, string> = {
+  details: 'Your details',
+  verify: 'Verify your email',
+  company: 'Company details',
+  payment: 'Payment',
+  review: 'Review',
+};
+
+const wizard = useWizard();
+const { current, active, isLast } = useStep();
+const { back, canBack, isBusy } = useNavigation();
+const errors = useErrors();
+
+const email = useField<string>('details.email');
+const payer = useField<string>('details.payer');
+const code = useField<string>('verify.code');
+const company = useField<string>('company.name');
+const vat = useField<string>('company.vat');
+const card = useField<string>('payment.card');
+
+const returning = useWizardSelector((s) => s.ctx['returning'] === true);
+const completed = useWizardSelector((s) => s.completed);
+const dirty = useWizardSelector((s) => s.dirty);
+const data = useWizardSelector((s) => s.data);
+
+const announcement = ref('');
+const ended = ref(false);
+const heading = useTemplateRef<HTMLHeadingElement>('heading');
+
+// Before `start` has run - on the server, and for the first paint - there is no
+// current step, so the form draws the step the flow is about to enter and says
+// so, instead of a spinner over an empty box.
+const standing = computed(() => current.value ?? active.value[0] ?? 'details');
+const starting = computed(() => current.value === null);
+
+/**
+ * What the flow submits: the slices of the steps that are on the route.
+ *
+ * A branch the visitor walked away from keeps its answers - the engine clears
+ * nothing when a `when` goes false - and it is the application that decides
+ * those answers are not part of this submission. `verify` is missing for the
+ * other reason: `clearOnLeave` dropped it the moment the step was left.
+ */
+const submission = computed(() => {
+  const out: Record<string, unknown> = {};
+  for (const id of active.value) {
+    if (data.value[id] !== undefined) out[id] = data.value[id];
+  }
+  return out;
+});
+
+// Focus follows the flow, but only once the visitor has moved: taking focus on
+// the first paint would drag a reader who was still reading the page above.
+let moved = false;
+watch(current, (to) => {
+  if (to === null) return;
+  if (!moved) {
+    moved = true;
+    return;
+  }
+  heading.value?.focus();
+  const at = active.value.indexOf(to) + 1;
+  announcement.value = `${LABELS[to] ?? to}. Step ${at} of ${active.value.length}.`;
+});
+
+async function onNext(): Promise<void> {
+  if (ended.value) {
+    ended.value = false;
+    announcement.value = '';
+    wizard.reset();
+    await wizard.start();
+    return;
+  }
+  const result = await wizard.next();
+  if (result.ok) {
+    if (result.to === '@end') {
+      ended.value = true;
+      announcement.value = 'Onboarding complete.';
+    }
+    return;
+  }
+  // A refusal is the one thing the live region must carry: the fields below
+  // show it too, but a screen reader is not looking at them.
+  const fields = Object.values(result.errors ?? {});
+  announcement.value =
+    fields.length === 0 ? `That move was refused: ${result.reason}.` : fields.join(' ');
+}
+</script>
+
+<template>
+  <div v-if="ended" class="app">
+    <h2 ref="heading" tabindex="-1">Done</h2>
+    <p>The submission is what the flow collected, and nothing else.</p>
+    <pre class="app-data">{{ JSON.stringify(submission, null, 2) }}</pre>
+    <div class="actions">
+      <button class="button button-accent" type="button" @click="onNext()">Start again</button>
+    </div>
+    <p class="app-live" role="status" aria-live="polite">{{ announcement }}</p>
+  </div>
+
+  <form v-else class="app" @submit.prevent="onNext()">
+    <h2 ref="heading" tabindex="-1">{{ LABELS[standing] ?? standing }}</h2>
+
+    <template v-if="standing === 'details'">
+      <!--
+        The label is a `for`/`id` pair rather than a wrapper, and the hint and
+        the error are named by `aria-describedby`: that keeps the accessible
+        name of the input to the label alone, while a screen reader still reads
+        the refusal with the field it belongs to.
+      -->
+      <div class="field">
+        <label class="field-label" for="email">Email</label>
+        <input
+          id="email"
+          v-model="email"
+          type="email"
+          autocomplete="email"
+          :aria-invalid="errors['email'] ? true : undefined"
+          :aria-describedby="errors['email'] ? 'email-error' : undefined"
+        />
+        <span v-if="errors['email']" id="email-error" class="field-error">
+          {{ errors['email'] }}
+        </span>
+      </div>
+      <fieldset class="field">
+        <legend class="field-label">Who is paying</legend>
+        <div class="segmented">
+          <button
+            v-for="choice in ['personal', 'business']"
+            :key="choice"
+            type="button"
+            :aria-pressed="payer === choice"
+            @click="payer = choice"
+          >
+            {{ choice === 'personal' ? 'Personal' : 'Business' }}
+          </button>
+        </div>
+        <p v-if="errors['payer']" class="field-error">{{ errors['payer'] }}</p>
+      </fieldset>
+    </template>
+
+    <template v-else-if="standing === 'verify'">
+      <div class="field">
+        <label class="field-label" for="code">Six-digit code</label>
+        <input
+          id="code"
+          v-model="code"
+          inputmode="numeric"
+          autocomplete="one-time-code"
+          :aria-invalid="errors['code'] ? true : undefined"
+          :aria-describedby="errors['code'] ? 'code-hint code-error' : 'code-hint'"
+        />
+        <span id="code-hint" class="field-hint">Any six digits will do here.</span>
+        <span v-if="errors['code']" id="code-error" class="field-error">{{ errors['code'] }}</span>
+      </div>
+      <label class="check">
+        <input
+          type="checkbox"
+          :checked="returning"
+          @change="wizard.setCtx({ returning: ($event.target as HTMLInputElement).checked })"
+        />
+        I already have an account
+      </label>
+    </template>
+
+    <template v-else-if="standing === 'company'">
+      <div class="field">
+        <label class="field-label" for="company-name">Company name</label>
+        <input
+          id="company-name"
+          v-model="company"
+          :aria-invalid="errors['name'] ? true : undefined"
+          :aria-describedby="errors['name'] ? 'company-name-error' : undefined"
+        />
+        <span v-if="errors['name']" id="company-name-error" class="field-error">
+          {{ errors['name'] }}
+        </span>
+      </div>
+      <div class="field">
+        <label class="field-label" for="vat">VAT number</label>
+        <input
+          id="vat"
+          v-model="vat"
+          :aria-invalid="errors['vat'] ? true : undefined"
+          :aria-describedby="errors['vat'] ? 'vat-error' : undefined"
+        />
+        <span v-if="errors['vat']" id="vat-error" class="field-error">{{ errors['vat'] }}</span>
+      </div>
+    </template>
+
+    <div v-else-if="standing === 'payment'" class="field">
+      <label class="field-label" for="card">Card number</label>
+      <input
+        id="card"
+        v-model="card"
+        inputmode="numeric"
+        autocomplete="cc-number"
+        :aria-invalid="errors['card'] ? true : undefined"
+        :aria-describedby="errors['card'] ? 'card-hint card-error' : 'card-hint'"
+      />
+      <span id="card-hint" class="field-hint">Sixteen digits, spaces allowed.</span>
+      <span v-if="errors['card']" id="card-error" class="field-error">{{ errors['card'] }}</span>
+    </div>
+
+    <template v-else-if="standing === 'review'">
+      <p>This is what the flow will submit.</p>
+      <pre class="app-data">{{ JSON.stringify(submission, null, 2) }}</pre>
+    </template>
+
+    <div class="actions">
+      <button class="button button-accent" type="submit" :disabled="starting || isBusy">
+        {{ isLast ? 'Submit' : 'Next' }}
+      </button>
+      <button
+        class="button button-secondary"
+        type="button"
+        :disabled="starting || !canBack || isBusy"
+        @click="back()"
+      >
+        Back
+      </button>
+    </div>
+
+    <dl class="app-state">
+      <dt>route</dt>
+      <dd>{{ active.join(' → ') }}</dd>
+      <dt>completed</dt>
+      <dd>{{ completed.length === 0 ? 'none' : completed.join(', ') }}</dd>
+      <dt>edited</dt>
+      <dd>{{ dirty.length === 0 ? 'none' : dirty.join(', ') }}</dd>
+    </dl>
+
+    <p class="app-live" role="status" aria-live="polite">
+      {{ starting ? 'Starting.' : announcement }}
+    </p>
+  </form>
+</template>

--- a/examples/reference/src/onboarding/flow.ts
+++ b/examples/reference/src/onboarding/flow.ts
@@ -1,0 +1,56 @@
+import { defineFlow, step } from '@wizzard-packages/core/v1';
+import { eq, get } from '@wizzard-packages/core/expr';
+
+/**
+ * R-A: onboarding with a conditional branch and backtracking.
+ *
+ * The whole route lives in this object. Nothing below it decides where the
+ * visitor goes next, which is the point: the rendering is a switch over
+ * `current`, and it stays a switch when a fourth step is added here.
+ */
+export const onboarding = defineFlow({
+  id: 'onboarding',
+  version: 1,
+  order: ['details', 'verify', 'company', 'payment', 'review'],
+  steps: {
+    details: step<{ email: string; payer: 'personal' | 'business' }>({
+      label: 'Details',
+      validate: { $ref: 'details' },
+    }),
+
+    verify: step<{ code: string }>({
+      label: 'Verify',
+      validate: { $ref: 'verify' },
+      // The code is a credential, not an answer. `true` drops the whole slice
+      // whichever way the step is left, so it is never in the object the last
+      // step submits and never sits in storage waiting to be restored.
+      clearOnLeave: true,
+      // A visitor who already has an account skips ahead. `company` and
+      // `payment` stay reachable — they are jumped over, not excluded — so the
+      // jump has to be an explicit target rather than a `when`.
+      //
+      // The list is exhaustive on purpose: a target list where nothing matches
+      // ends the flow, so the ordinary route is spelled out after the fast
+      // path. `company` is tried first and skipped when its own `when` is
+      // false, which lands a personal payer on `payment`.
+      on: { next: [{ to: 'review', when: get('ctx.returning') }, 'company', 'payment'] },
+    }),
+
+    company: step<{ name: string; vat: string }>({
+      label: 'Company',
+      // Reachability, not navigation: a step whose `when` is false is off the
+      // route, so it is skipped forwards and backwards and drawn as a step this
+      // visitor will not see.
+      when: eq(get('data.details.payer'), 'business'),
+      validate: { $ref: 'company' },
+    }),
+
+    payment: step<{ card: string }>({
+      label: 'Payment',
+      validate: { $ref: 'payment' },
+    }),
+
+    review: step({ label: 'Review' }),
+  },
+  policy: 'free',
+});

--- a/examples/reference/src/onboarding/onboarding.test.tsx
+++ b/examples/reference/src/onboarding/onboarding.test.tsx
@@ -1,0 +1,168 @@
+import { render, screen } from '@testing-library/react';
+import { flushPromises, mount } from '@vue/test-utils';
+import { act } from 'react';
+import { describe, expect, it } from 'vitest';
+
+import AppVue from './App.vue';
+import OnboardingApp from './App';
+
+/**
+ * R-A, driven the way a person drives it.
+ *
+ * What is asserted here is the behaviour the release claims: a branch that
+ * appears and disappears with the data, a back stack that crosses it, a
+ * credential that is never part of the submission, and a fast path written as
+ * an explicit target list. Both bindings run the same flow file, so one that
+ * drifts from the other fails here rather than on the site.
+ */
+const type = async (input: HTMLElement, value: string): Promise<void> => {
+  const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')?.set as (
+    this: HTMLInputElement,
+    v: string
+  ) => void;
+  await act(async () => {
+    setter.call(input as HTMLInputElement, value);
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+  });
+};
+
+const click = async (name: string): Promise<void> => {
+  await act(async () => {
+    screen.getByRole('button', { name }).dispatchEvent(new MouseEvent('click', { bubbles: true }));
+  });
+};
+
+const heading = (): string => screen.getByRole('heading').textContent ?? '';
+const field = (label: string): HTMLInputElement => screen.getByLabelText(label) as HTMLInputElement;
+const route = (): string => screen.getByText('route').nextElementSibling?.textContent ?? '';
+const submitted = (): unknown => JSON.parse(screen.getByText(/^\{/).textContent ?? '{}');
+
+/** Fills the step on screen and moves on. */
+const fill = async (label: string, value: string): Promise<void> => {
+  await type(screen.getByLabelText(label), value);
+};
+
+describe('R-A onboarding, React', () => {
+  it('refuses the first move and says why', async () => {
+    render(<OnboardingApp />);
+    await act(async () => {});
+
+    await click('Next');
+    expect(heading()).toBe('Your details');
+    expect(screen.getByText('Enter your email address.')).toBeTruthy();
+    expect(field('Email').getAttribute('aria-invalid')).toBe('true');
+    // The refusal reaches a screen reader too, not only the field.
+    expect(screen.getByRole('status').textContent).toContain('Enter your email address.');
+  });
+
+  it('routes a business payer through Company and submits neither the code nor the branch it left', async () => {
+    render(<OnboardingApp />);
+    await act(async () => {});
+
+    await fill('Email', 'ada@example.com');
+    await click('Business');
+    await click('Next');
+    expect(heading()).toBe('Verify your email');
+
+    await fill('Six-digit code', '123456');
+    await click('Next');
+    expect(heading()).toBe('Company details');
+
+    await fill('Company name', 'Acme');
+    await fill('VAT number', 'GB123');
+    await click('Next');
+    expect(heading()).toBe('Payment');
+
+    await fill('Card number', '4242 4242 4242 4242');
+    await click('Next');
+    expect(heading()).toBe('Review');
+
+    const body = submitted() as Record<string, unknown>;
+    expect(Object.keys(body)).toEqual(['details', 'company', 'payment']);
+    // `clearOnLeave: true` dropped the code the moment the step was left.
+    expect(body['verify']).toBeUndefined();
+  });
+
+  it('walks back across the branch and drops it when the payer changes', async () => {
+    render(<OnboardingApp />);
+    await act(async () => {});
+
+    await fill('Email', 'ada@example.com');
+    await click('Business');
+    await click('Next');
+    await fill('Six-digit code', '123456');
+    await click('Next');
+    await fill('Company name', 'Acme');
+    await fill('VAT number', 'GB123');
+    await click('Next');
+    expect(heading()).toBe('Payment');
+
+    // Back crosses the branch step, then the step whose data was cleared.
+    await click('Back');
+    expect(heading()).toBe('Company details');
+    // The answers survived: nothing is cleared by going back to a step.
+    expect(field('Company name').value).toBe('Acme');
+
+    await click('Back');
+    expect(heading()).toBe('Verify your email');
+    // The code did not survive - it is the one field the flow forgets.
+    expect(field('Six-digit code').value).toBe('');
+
+    await click('Back');
+    expect(heading()).toBe('Your details');
+    await click('Personal');
+    expect(route()).toBe('details → verify → payment → review');
+
+    await click('Next');
+    await fill('Six-digit code', '654321');
+    await click('Next');
+    // Company is off the route, so `next` from verify falls through to payment.
+    expect(heading()).toBe('Payment');
+  });
+
+  it('takes the fast path when the visitor says they already have an account', async () => {
+    render(<OnboardingApp />);
+    await act(async () => {});
+
+    await fill('Email', 'ada@example.com');
+    await click('Business');
+    await click('Next');
+    await fill('Six-digit code', '123456');
+
+    await act(async () => {
+      screen
+        .getByLabelText('I already have an account')
+        .dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    await click('Next');
+    // An explicit target beats the order: Company and Payment are still on the
+    // route, and the flow jumped over both.
+    expect(heading()).toBe('Review');
+    expect(route()).toContain('company');
+  });
+});
+
+describe('R-A onboarding, Vue', () => {
+  it('draws the same route and drops the same branch', async () => {
+    const app = mount(AppVue, { attachTo: document.createElement('div') });
+    await flushPromises();
+
+    await app.get('#email').setValue('ada@example.com');
+    await app.findAll('.segmented button')[1]!.trigger('click');
+    // The form is submitted, not the button clicked: jsdom does not run the
+    // submission algorithm for a synthetic click on a submit button.
+    await app.get('form').trigger('submit');
+    await flushPromises();
+    expect(app.get('h2').text()).toBe('Verify your email');
+    // Focus followed the flow, and the live region said where it went.
+    expect(app.get('[role="status"]').text()).toBe('Verify your email. Step 2 of 5.');
+
+    await app.get('#code').setValue('123456');
+    await app.get('form').trigger('submit');
+    await flushPromises();
+    expect(app.get('h2').text()).toBe('Company details');
+
+    expect(app.get('dl').text()).toContain('details → verify → company → payment → review');
+    app.unmount();
+  });
+});

--- a/examples/reference/src/onboarding/onboarding.test.tsx
+++ b/examples/reference/src/onboarding/onboarding.test.tsx
@@ -166,3 +166,38 @@ describe('R-A onboarding, Vue', () => {
     app.unmount();
   });
 });
+
+describe('R-A onboarding, starting again', () => {
+  it('starts again without the fast path it finished on', async () => {
+    render(<OnboardingApp />);
+    await act(async () => {});
+
+    const fastPath = async (): Promise<void> => {
+      await fill('Email', 'ada@example.com');
+      await click('Business');
+      await click('Next');
+      await fill('Six-digit code', '123456');
+    };
+
+    await fastPath();
+    await act(async () => {
+      screen
+        .getByLabelText('I already have an account')
+        .dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    await click('Next');
+    expect(heading()).toBe('Review');
+    await click('Submit');
+    expect(heading()).toBe('Done');
+
+    await click('Start again');
+    expect(heading()).toBe('Your details');
+    await fastPath();
+    // `reset` keeps `ctx`, so the application has to put the fast path back.
+    expect((screen.getByLabelText('I already have an account') as HTMLInputElement).checked).toBe(
+      false
+    );
+    await click('Next');
+    expect(heading()).toBe('Company details');
+  });
+});

--- a/examples/reference/src/onboarding/registry.ts
+++ b/examples/reference/src/onboarding/registry.ts
@@ -1,0 +1,51 @@
+import type { AsyncRegistry, Scope } from '@wizzard-packages/core/v1';
+
+/**
+ * What the flow could not serialize. Each `$ref` in `flow.ts` is a key here,
+ * and a validator answers with the field errors it found or `null`.
+ *
+ * They are ordinary functions of the data: no component, no engine, nothing to
+ * mock. That is what makes the same four testable without a browser.
+ */
+type Fields = Record<string, string> | null;
+
+const slice = (scope: Scope, id: string): Record<string, unknown> =>
+  (scope.data[id] as Record<string, unknown> | undefined) ?? {};
+
+const EMAIL = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+export const registry: AsyncRegistry = {
+  details: (_args, scope): Fields => {
+    const { email, payer } = slice(scope, 'details');
+    const errors: Record<string, string> = {};
+    if (typeof email !== 'string' || email === '') errors['email'] = 'Enter your email address.';
+    else if (!EMAIL.test(email)) errors['email'] = 'That does not look like an email address.';
+    if (payer !== 'personal' && payer !== 'business') errors['payer'] = 'Choose who is paying.';
+    return Object.keys(errors).length === 0 ? null : errors;
+  },
+
+  verify: (_args, scope): Fields => {
+    const { code } = slice(scope, 'verify');
+    // Six digits, and in a real application a call to the service that sent
+    // them. The example keeps it local so the page works offline.
+    if (typeof code !== 'string' || !/^\d{6}$/.test(code)) {
+      return { code: 'The code is six digits.' };
+    }
+    return null;
+  },
+
+  company: (_args, scope): Fields => {
+    const { name, vat } = slice(scope, 'company');
+    const errors: Record<string, string> = {};
+    if (typeof name !== 'string' || name.trim() === '') errors['name'] = 'Enter the company name.';
+    if (typeof vat !== 'string' || vat.trim() === '') errors['vat'] = 'Enter the VAT number.';
+    return Object.keys(errors).length === 0 ? null : errors;
+  },
+
+  payment: (_args, scope): Fields => {
+    const { card } = slice(scope, 'payment');
+    const digits = typeof card === 'string' ? card.replace(/\s/g, '') : '';
+    if (!/^\d{16}$/.test(digits)) return { card: 'A card number is sixteen digits.' };
+    return null;
+  },
+};

--- a/examples/reference/src/vue-shim.d.ts
+++ b/examples/reference/src/vue-shim.d.ts
@@ -1,0 +1,7 @@
+// Single-file components are compiled by the bundler, not by tsc; this is the
+// shim every Vue-in-TypeScript project carries so an import of one type-checks.
+declare module '*.vue' {
+  import type { DefineComponent } from 'vue';
+  const component: DefineComponent<Record<string, never>, Record<string, never>, unknown>;
+  export default component;
+}

--- a/examples/reference/tsconfig.json
+++ b/examples/reference/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "noEmit": true,
+    "types": ["vitest/globals"]
+  },
+  "include": ["src"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -324,6 +324,43 @@ importers:
         specifier: ^5.9.3
         version: 5.9.3
 
+  examples/reference:
+    dependencies:
+      '@wizzard-packages/core':
+        specifier: workspace:*
+        version: link:../../packages/core
+      '@wizzard-packages/react':
+        specifier: workspace:*
+        version: link:../../packages/react
+      '@wizzard-packages/vue':
+        specifier: workspace:*
+        version: link:../../packages/vue
+      react:
+        specifier: ^19.2.0
+        version: 19.2.3
+      react-dom:
+        specifier: ^19.2.0
+        version: 19.2.3(react@19.2.3)
+      vue:
+        specifier: ^3.5.13
+        version: 3.5.27(typescript@5.9.3)
+    devDependencies:
+      '@testing-library/react':
+        specifier: ^16.3.1
+        version: 16.3.1(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@types/react':
+        specifier: ^19.2.7
+        version: 19.2.7
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.7)
+      '@vue/test-utils':
+        specifier: ^2.4.6
+        version: 2.4.6
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+
   examples/shadcn-ui-connector:
     dependencies:
       '@wizzard-packages/adapter-zod':
@@ -731,6 +768,9 @@ importers:
 
   site:
     dependencies:
+      '@examples/reference':
+        specifier: workspace:*
+        version: link:../examples/reference
       '@fontsource-variable/inter-tight':
         specifier: ^5.3.0
         version: 5.3.0

--- a/site/package.json
+++ b/site/package.json
@@ -14,6 +14,7 @@
     "type-check": "astro check"
   },
   "dependencies": {
+    "@examples/reference": "workspace:*",
     "@fontsource-variable/inter-tight": "^5.3.0",
     "@fontsource-variable/jetbrains-mono": "^5.3.0",
     "@wizzard-packages/core": "workspace:^",

--- a/site/src/components/ExampleShell.astro
+++ b/site/src/components/ExampleShell.astro
@@ -1,0 +1,98 @@
+---
+import Page from '../layouts/Page.astro';
+
+/**
+ * The page around a reference application: the claim, the framework toggle, the
+ * running application, and the source it is running.
+ *
+ * The source blocks are `?raw` imports of the very files the island mounts, so
+ * a code block cannot drift from the code beside it - there is one file, read
+ * twice. That is why nothing here checks them against each other.
+ *
+ * They are plain `<pre>`, not Shiki: Starlight owns the highlighter for the
+ * whole build and its bundle carries only the themes it needs, so a `<Code>`
+ * outside it fails at build time. A page whose subject is that the flow is
+ * readable data can afford to print it in one colour.
+ *
+ * The toggle is a link. A route change is what keeps a remembered preference
+ * away from the rendering: each page mounts one runtime, decided by its URL and
+ * by nothing a browser stored.
+ */
+interface Source {
+  name: string;
+  lang: 'ts' | 'tsx' | 'vue';
+  code: string;
+  note: string;
+}
+
+interface Props {
+  slug: string;
+  ref: string;
+  heading: string;
+  lede: string;
+  framework: 'react' | 'vue';
+  sources: Source[];
+}
+
+const { slug, ref, heading, lede, framework, sources } = Astro.props;
+const base = import.meta.env.BASE_URL.replace(/\/$/, '');
+const here = `${base}/examples/${slug}`;
+---
+
+<Page
+  title={`${heading} - wizzard`}
+  description={lede}
+  current="examples"
+>
+  <section class="hero hero-tight">
+    <p class="example-ref">{ref}</p>
+    <h1>{heading}</h1>
+    <p class="lede">{lede}</p>
+
+    <nav class="framework" aria-label="Rendering">
+      <a href={`${here}/`} aria-current={framework === 'react' ? 'page' : undefined}>React</a>
+      <a href={`${here}/vue/`} aria-current={framework === 'vue' ? 'page' : undefined}>Vue</a>
+    </nav>
+    <p class="framework-note">
+      This page ships the {framework === 'react' ? 'React' : 'Vue'} binding and only that one.
+      React is what the server renders when no framework is named, so the choice is a link rather
+      than a switch: nothing a browser remembered can disagree with what arrived.
+    </p>
+
+    <div class="example-stage">
+      <slot />
+    </div>
+  </section>
+
+  <section class="example-source">
+    <h2>The source it is running</h2>
+    <p class="lede">
+      These blocks are the files the application above imports, read at build time. There is no
+      copy of them to fall out of date.
+    </p>
+
+    {
+      sources.map((source) => (
+        <article>
+          <h3>{source.name}</h3>
+          <p>{source.note}</p>
+          <pre class="code-block" data-lang={source.lang}><code>{source.code}</code></pre>
+        </article>
+      ))
+    }
+  </section>
+</Page>
+
+<script>
+  // Remember the framework this page rendered, so the index links here next
+  // time. Written on arrival rather than on a click: the visitor may have
+  // reached the page from anywhere.
+  try {
+    localStorage.setItem(
+      'wizzard:framework',
+      document.location.pathname.replace(/\/$/, '').endsWith('/vue') ? 'vue' : 'react'
+    );
+  } catch {
+    // A browser that refuses storage simply does not remember.
+  }
+</script>

--- a/site/src/components/StageBoundary.tsx
+++ b/site/src/components/StageBoundary.tsx
@@ -19,6 +19,11 @@ interface Props {
   children: ReactNode;
   /** Changing this clears the failure, so the next paste draws again. */
   resetKey?: unknown;
+  /**
+   * Offered when the caller can put the island back on its feet - an example
+   * that can be mounted again, as opposed to a paste the reader has to fix.
+   */
+  onRestart?: () => void;
 }
 
 interface State {
@@ -48,14 +53,34 @@ export class StageBoundary extends Component<Props, State> {
     const { message } = this.state;
     if (message === null) return this.props.children;
 
+    const { onRestart } = this.props;
     return (
       <div className="stage-failed" role="alert">
-        <p>This flow could not be drawn.</p>
+        <p>{onRestart === undefined ? 'This flow could not be drawn.' : 'This example stopped.'}</p>
         <p className="stage-failed-why">{message}</p>
-        <p>
-          The flow itself is unharmed — paste a different one, or reload to go back to the example.
-          If it is a flow you can share, an issue with it attached is worth opening.
-        </p>
+        {onRestart === undefined ? (
+          <p>
+            The flow itself is unharmed — paste a different one, or reload to go back to the
+            example. If it is a flow you can share, an issue with it attached is worth opening.
+          </p>
+        ) : (
+          <p>
+            The page around it is fine, and so is the flow definition below. Start the example
+            again, or open an issue with what you had typed.
+          </p>
+        )}
+        {onRestart !== undefined && (
+          <button
+            className="button button-secondary"
+            type="button"
+            onClick={() => {
+              this.setState({ message: null });
+              onRestart();
+            }}
+          >
+            Restart example
+          </button>
+        )}
       </div>
     );
   }

--- a/site/src/islands/OnboardingReact.tsx
+++ b/site/src/islands/OnboardingReact.tsx
@@ -1,0 +1,26 @@
+import OnboardingApp from '@examples/reference/src/onboarding/App';
+import { useState, type ReactNode } from 'react';
+
+import { StageBoundary } from '../components/StageBoundary';
+
+/**
+ * R-A, mounted. The site owns the net; the example owns the application.
+ *
+ * The boundary and the remount key live here rather than in the example,
+ * because a reader copying `App.tsx` into their own project is copying an
+ * application, not a page that has to survive a stranger's browser.
+ */
+export default function OnboardingReact(): ReactNode {
+  const [attempt, setAttempt] = useState(0);
+
+  return (
+    <StageBoundary
+      resetKey={attempt}
+      onRestart={() => {
+        setAttempt((n) => n + 1);
+      }}
+    >
+      <OnboardingApp key={attempt} />
+    </StageBoundary>
+  );
+}

--- a/site/src/islands/OnboardingVue.vue
+++ b/site/src/islands/OnboardingVue.vue
@@ -1,0 +1,42 @@
+<script setup lang="ts">
+import App from '@examples/reference/src/onboarding/App.vue';
+import { onErrorCaptured, ref } from 'vue';
+
+/**
+ * R-A on the Vue binding, mounted. The counterpart of `OnboardingReact.tsx`:
+ * the site owns the net, the example owns the application.
+ *
+ * `onErrorCaptured` returning false stops the error propagating to the app
+ * root, which is Vue's equivalent of React's error boundary. Bumping `attempt`
+ * remounts the child, which is what starting the example again means.
+ */
+const failure = ref<string | null>(null);
+const attempt = ref(0);
+
+onErrorCaptured((error) => {
+  failure.value = error instanceof Error ? error.message : String(error);
+  console.error('[example] the application stopped', error);
+  return false;
+});
+
+function restart(): void {
+  failure.value = null;
+  attempt.value += 1;
+}
+</script>
+
+<template>
+  <div v-if="failure !== null" class="stage-failed" role="alert">
+    <p>This example stopped.</p>
+    <p class="stage-failed-why">
+      {{ failure }}
+    </p>
+    <p>
+      The page around it is fine, and so is the flow definition below. Start the example again, or
+      open an issue with what you had typed.
+    </p>
+    <button class="button button-secondary" type="button" @click="restart">Restart example</button>
+  </div>
+
+  <App v-else :key="attempt" />
+</template>

--- a/site/src/layouts/Page.astro
+++ b/site/src/layouts/Page.astro
@@ -1,0 +1,68 @@
+---
+import '@fontsource-variable/inter-tight';
+import '@fontsource-variable/jetbrains-mono';
+import '../styles/tokens.css';
+import '../styles/site.css';
+
+/**
+ * The chrome every hand-written page wears: the document head, the top bar and
+ * the footer. Starlight owns its own; this is for the pages outside it.
+ *
+ * It exists because the examples added six routes to a site that had two, and
+ * a navigation entry that appears on four pages out of six is how a link ends
+ * up dead on the two nobody edited.
+ */
+interface Props {
+  title: string;
+  description: string;
+  /** Which top-bar entry is the page being read. */
+  current?: 'examples' | 'inspector' | 'docs';
+}
+
+const { title, description, current } = Astro.props;
+const base = import.meta.env.BASE_URL.replace(/\/$/, '');
+---
+
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>{title}</title>
+    <meta name="description" content={description} />
+    <meta property="og:title" content={title} />
+    <meta property="og:description" content={description} />
+    <meta property="og:type" content="website" />
+  </head>
+  <body>
+    <div class="shell">
+      <header class="topbar">
+        <a class="wordmark" href={`${base}/`}>wizzard</a>
+        <nav>
+          <a href={`${base}/examples/`} aria-current={current === 'examples' ? 'page' : undefined}>
+            Examples
+          </a>
+          <a
+            href={`${base}/inspector/`}
+            aria-current={current === 'inspector' ? 'page' : undefined}
+          >
+            Inspector
+          </a>
+          <a href={`${base}/docs/start/`} aria-current={current === 'docs' ? 'page' : undefined}>
+            Docs
+          </a>
+          <a href="https://github.com/ZizzX/wizzard-packages">GitHub</a>
+        </nav>
+      </header>
+
+      <main>
+        <slot />
+      </main>
+
+      <footer class="site-footer">
+        <span>MIT licensed</span>
+        <a href="https://github.com/ZizzX/wizzard-packages">Source</a>
+        <a href={`${base}/docs/start/`}>Documentation</a>
+      </footer>
+    </div>
+  </body>
+</html>

--- a/site/src/pages/examples/index.astro
+++ b/site/src/pages/examples/index.astro
@@ -1,0 +1,99 @@
+---
+import Page from '../../layouts/Page.astro';
+
+/**
+ * The index of the reference applications.
+ *
+ * Each row links to the React rendering. The framework a visitor last chose is
+ * remembered, but it is remembered by rewriting these links rather than by
+ * swapping anything on the page it opens: a preference read from storage can
+ * never decide what the server rendered, so it can never cause a mismatch.
+ */
+const base = import.meta.env.BASE_URL.replace(/\/$/, '');
+
+const APPS = [
+  {
+    slug: 'onboarding',
+    ref: 'R-A',
+    heading: 'Change your answer. Keep the right data.',
+    blurb:
+      'Onboarding with a conditional branch and backtracking. The payer type decides the route, the visitor walks back across the branch, and the flow says what is submitted and what is forgotten.',
+    proves: ['when', 'on.next', 'back() across branches', 'clearOnLeave'],
+    ready: true,
+  },
+  {
+    slug: 'reload',
+    ref: 'R-B',
+    heading: 'Reload halfway through. Continue safely.',
+    blurb:
+      'A form that survives F5, validates a field against an asynchronous resolver, and is not corrupted by a reload during that validation.',
+    proves: ['persist', 'snapshot contract', 'busy', 'hydrateMismatch'],
+    ready: false,
+  },
+  {
+    slug: 'passengers',
+    ref: 'R-C',
+    heading: 'Add passengers. Revisit any passenger.',
+    blurb:
+      'One block of steps per passenger: add and remove them, then go back and edit the second after finishing the third.',
+    proves: ['GroupStep', 'repeat', 'frame stack', 'group entry and exit'],
+    ready: false,
+  },
+];
+
+const title = 'Examples - wizzard';
+const description =
+  'Three reference applications, each running on both bindings, from the same flow definition the page shows.';
+---
+
+<Page title={title} description={description} current="examples">
+  <section class="hero hero-tight">
+    <h1>Three applications, <em>not three screenshots</em>.</h1>
+    <p class="lede">
+      Each of these runs in this page, on the binding you pick, from the flow definition printed
+      below it. They are the same applications the end-to-end suite drives, so nothing is shown
+      here that the engine cannot do.
+    </p>
+  </section>
+
+  <ul class="example-index">
+    {
+      APPS.map((app) => (
+        <li class={app.ready ? undefined : 'is-pending'}>
+          <p class="example-ref">{app.ref}</p>
+          <h2>
+            {app.ready ? (
+              <a data-example={app.slug} href={`${base}/examples/${app.slug}/`}>
+                {app.heading}
+              </a>
+            ) : (
+              app.heading
+            )}
+          </h2>
+          <p>{app.blurb}</p>
+          <p class="example-proves">
+            {app.proves.map((what) => (
+              <code>{what}</code>
+            ))}
+          </p>
+          {!app.ready && <p class="example-pending">Not written yet.</p>}
+        </li>
+      ))
+    }
+  </ul>
+</Page>
+
+<script>
+  // The remembered framework, applied to the links out of this page and nowhere
+  // else. Storage is unavailable in some browsers and empty in most of them, so
+  // the default is what the markup already says.
+  try {
+    if (localStorage.getItem('wizzard:framework') === 'vue') {
+      for (const link of document.querySelectorAll<HTMLAnchorElement>('a[data-example]')) {
+        link.href = `${link.href}vue/`;
+      }
+    }
+  } catch {
+    // A browser that refuses storage gets the default, which is not an error.
+  }
+</script>

--- a/site/src/pages/examples/onboarding/index.astro
+++ b/site/src/pages/examples/onboarding/index.astro
@@ -1,0 +1,40 @@
+---
+import flowSource from '@examples/reference/src/onboarding/flow.ts?raw';
+import registrySource from '@examples/reference/src/onboarding/registry.ts?raw';
+import appSource from '@examples/reference/src/onboarding/App.tsx?raw';
+
+import ExampleShell from '../../../components/ExampleShell.astro';
+import OnboardingReact from '../../../islands/OnboardingReact';
+
+const sources = [
+  {
+    name: 'flow.ts',
+    lang: 'ts' as const,
+    code: flowSource,
+    note: 'The route. Everything that decides where the visitor goes next is in this object, and nothing that decides it is anywhere else.',
+  },
+  {
+    name: 'registry.ts',
+    lang: 'ts' as const,
+    code: registrySource,
+    note: 'What a flow cannot serialize: the validators, named by the `$ref` above and looked up at runtime.',
+  },
+  {
+    name: 'App.tsx',
+    lang: 'tsx' as const,
+    code: appSource,
+    note: 'The rendering. It knows the fields and the labels; it asks the engine which step is current and draws that one.',
+  },
+];
+---
+
+<ExampleShell
+  slug="onboarding"
+  ref="R-A"
+  heading="Change your answer. Keep the right data."
+  lede="Onboarding with a conditional branch and backtracking. Pick a payer type and the route changes; walk back across the branch and the answers are still there; finish, and the flow submits what it collected and nothing else."
+  framework="react"
+  sources={sources}
+>
+  <OnboardingReact client:load />
+</ExampleShell>

--- a/site/src/pages/examples/onboarding/vue.astro
+++ b/site/src/pages/examples/onboarding/vue.astro
@@ -1,0 +1,40 @@
+---
+import flowSource from '@examples/reference/src/onboarding/flow.ts?raw';
+import registrySource from '@examples/reference/src/onboarding/registry.ts?raw';
+import appSource from '@examples/reference/src/onboarding/Onboarding.vue?raw';
+
+import ExampleShell from '../../../components/ExampleShell.astro';
+import OnboardingVue from '../../../islands/OnboardingVue.vue';
+
+const sources = [
+  {
+    name: 'flow.ts',
+    lang: 'ts' as const,
+    code: flowSource,
+    note: 'The same file the React page shows. One definition, two renderings - that is the claim this pair of pages exists to make.',
+  },
+  {
+    name: 'registry.ts',
+    lang: 'ts' as const,
+    code: registrySource,
+    note: 'Also the same file. The validators are functions of the data, so neither binding has a version of its own.',
+  },
+  {
+    name: 'Onboarding.vue',
+    lang: 'vue' as const,
+    code: appSource,
+    note: 'The rendering. Step for step and message for message the React file, with `v-if` where the other has `&&`.',
+  },
+];
+---
+
+<ExampleShell
+  slug="onboarding"
+  ref="R-A"
+  heading="Change your answer. Keep the right data."
+  lede="Onboarding with a conditional branch and backtracking. Pick a payer type and the route changes; walk back across the branch and the answers are still there; finish, and the flow submits what it collected and nothing else."
+  framework="vue"
+  sources={sources}
+>
+  <OnboardingVue client:load />
+</ExampleShell>

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -1,8 +1,5 @@
 ---
-import '@fontsource-variable/inter-tight';
-import '@fontsource-variable/jetbrains-mono';
-import '../styles/tokens.css';
-import '../styles/site.css';
+import Page from '../layouts/Page.astro';
 import HeroFlow from '../components/HeroFlow';
 import { FlowRow } from '../components/FlowRow';
 import { flowA, flowB, flowC, subFlowsC, dataC, registryB } from '../../../contract/fixtures';
@@ -13,28 +10,7 @@ const description =
   'Order, conditions and validation live in a flow definition you can read, diff and ship. React and Vue bindings over one headless engine.';
 ---
 
-<html lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>{title}</title>
-    <meta name="description" content={description} />
-    <meta property="og:title" content={title} />
-    <meta property="og:description" content={description} />
-    <meta property="og:type" content="website" />
-  </head>
-  <body>
-    <div class="shell">
-      <header class="topbar">
-        <a class="wordmark" href={`${base}/`}>wizzard</a>
-        <nav>
-          <a href={`${base}/inspector/`}>Inspector</a>
-          <a href={`${base}/docs/start/`}>Docs</a>
-          <a href="https://github.com/ZizzX/wizzard-packages">GitHub</a>
-        </nav>
-      </header>
-
-      <main>
+<Page title={title} description={description}>
         <section class="hero">
           <h1>Headless multi-step flows for React and Vue &mdash; <em>the flow is JSON</em>.</h1>
           <p class="lede">
@@ -70,6 +46,9 @@ const description =
               A branch the visitor left behind stops applying, and the data it collected stops
               being submitted. The definition says which, so no component has to remember.
             </p>
+            <p>
+              <a href={`${base}/examples/onboarding/`}>Run this one, on React or Vue</a>
+            </p>
           </FlowRow>
 
           <FlowRow
@@ -98,13 +77,4 @@ const description =
             </p>
           </FlowRow>
         </div>
-      </main>
-
-      <footer class="site-footer">
-        <span>MIT licensed</span>
-        <a href="https://github.com/ZizzX/wizzard-packages">Source</a>
-        <a href={`${base}/docs/start/`}>Documentation</a>
-      </footer>
-    </div>
-  </body>
-</html>
+      </Page>

--- a/site/src/pages/inspector.astro
+++ b/site/src/pages/inspector.astro
@@ -1,8 +1,5 @@
 ---
-import '@fontsource-variable/inter-tight';
-import '@fontsource-variable/jetbrains-mono';
-import '../styles/tokens.css';
-import '../styles/site.css';
+import Page from '../layouts/Page.astro';
 import Inspector from '../components/Inspector';
 
 const base = import.meta.env.BASE_URL.replace(/\/$/, '');
@@ -11,28 +8,7 @@ const description =
   'A flow is data. Run one, replay a recording of one frame by frame, or paste your own and see its structure drawn.';
 ---
 
-<html lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>{title}</title>
-    <meta name="description" content={description} />
-    <meta property="og:title" content={title} />
-    <meta property="og:description" content={description} />
-    <meta property="og:type" content="website" />
-  </head>
-  <body>
-    <div class="shell">
-      <header class="topbar">
-        <a class="wordmark" href={`${base}/`}>wizzard</a>
-        <nav>
-          <a href={`${base}/inspector/`} aria-current="page">Inspector</a>
-          <a href={`${base}/docs/start/`}>Docs</a>
-          <a href="https://github.com/ZizzX/wizzard-packages">GitHub</a>
-        </nav>
-      </header>
-
-      <main>
+<Page title={title} description={description} current="inspector">
         <section class="hero hero-tight">
           <h1>A flow is data. <em>Watch one replay itself.</em></h1>
           <p class="lede">
@@ -44,20 +20,11 @@ const description =
 
           <div class="actions">
             <a class="button button-primary" href={`${base}/docs/start/`}>Run this yourself</a>
-            <a class="button button-secondary" href={`${base}/#examples`}>See the examples</a>
+            <a class="button button-secondary" href={`${base}/examples/`}>See the examples</a>
             <span class="install">
               <span class="tag">install</span>
               <span>npm i @wizzard-packages/core @wizzard-packages/react</span>
             </span>
           </div>
         </section>
-      </main>
-
-      <footer class="site-footer">
-        <span>MIT licensed</span>
-        <a href="https://github.com/ZizzX/wizzard-packages">Source</a>
-        <a href={`${base}/docs/start/`}>Documentation</a>
-      </footer>
-    </div>
-  </body>
-</html>
+      </Page>

--- a/site/src/styles/site.css
+++ b/site/src/styles/site.css
@@ -121,14 +121,20 @@ body {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: var(--space-6);
+  flex-wrap: wrap;
+  gap: var(--space-3) var(--space-6);
   min-height: 60px;
+  padding: var(--space-3) 0;
   border-bottom: var(--border) solid var(--line);
 }
 
+/* Four entries do not fit beside the wordmark on a 390px screen, and a bar
+   that overflows takes the whole page with it. It wraps instead: the gap is
+   the row gap too, so a wrapped second line is spaced, not stacked. */
 .topbar nav {
   display: flex;
-  gap: var(--space-6);
+  flex-wrap: wrap;
+  gap: var(--space-3) var(--space-6);
   font-family: var(--font-mono);
   font-size: var(--text-sm);
 }
@@ -1072,4 +1078,240 @@ svg.interactive .node {
   font-size: var(--text-xs);
   color: var(--st-error);
   overflow-wrap: anywhere;
+}
+
+/* ---------------------------------------------------------------------------
+   Examples: the index, the page around one application, and the application.
+
+   The controls reuse `.field`, `.segmented`, `.actions` and `.button` from the
+   instrument above rather than growing a second set: an example that looked
+   like a different product would undo what the pages are for. */
+
+.example-index {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  border-top: var(--border) solid var(--line);
+}
+
+.example-index li {
+  padding: var(--space-8) 0;
+  border-bottom: var(--border) solid var(--line);
+  max-width: var(--measure);
+}
+
+.example-index h2 {
+  font-size: var(--text-xl);
+  margin: var(--space-2) 0 var(--space-3);
+}
+
+.example-index p {
+  margin: 0;
+  color: var(--fg-muted);
+}
+
+.example-ref {
+  font-family: var(--font-mono);
+  font-size: var(--text-label);
+  letter-spacing: var(--track-label);
+  color: var(--fg-muted);
+  margin: 0;
+}
+
+.example-proves {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  margin-top: var(--space-3) !important;
+}
+
+.example-proves code {
+  border: var(--border) solid var(--line);
+  border-radius: var(--radius-control);
+  padding: 0 var(--space-2);
+  font-size: var(--text-xs);
+}
+
+.example-index .is-pending h2,
+.example-pending {
+  color: var(--fg-muted);
+}
+
+/* The framework toggle is two links. It is a route change, so the page that
+   answers is rendered by the server for that framework and no stored
+   preference can disagree with what arrived. */
+.framework {
+  display: inline-flex;
+  border: var(--border) solid var(--line);
+  border-radius: var(--radius-control);
+  overflow: hidden;
+}
+
+.framework a {
+  display: inline-flex;
+  align-items: center;
+  min-height: var(--control-h);
+  min-width: var(--target-min);
+  justify-content: center;
+  padding: 0 var(--space-4);
+  font-size: var(--text-sm);
+  text-decoration: none;
+  color: var(--fg-muted);
+}
+
+.framework a + a {
+  border-left: var(--border) solid var(--line);
+}
+
+.framework a[aria-current='page'] {
+  background: var(--accent-soft);
+  color: var(--fg);
+}
+
+.framework-note {
+  margin: var(--space-3) 0 var(--space-8);
+  max-width: var(--measure);
+  color: var(--fg-muted);
+  font-size: var(--text-sm);
+}
+
+.example-stage {
+  border: var(--border) solid var(--line);
+  border-radius: var(--radius-panel);
+  background: var(--surface);
+  padding: var(--space-6);
+  max-width: var(--measure);
+}
+
+.example-source {
+  border-top: var(--border) solid var(--line);
+  padding-top: var(--space-8);
+  max-width: var(--measure-wide);
+}
+
+.example-source h3 {
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  margin: var(--space-8) 0 var(--space-2);
+}
+
+.example-source article p {
+  margin: 0 0 var(--space-3);
+  color: var(--fg-muted);
+  font-size: var(--text-sm);
+  max-width: var(--measure);
+}
+
+/* One colour, and a scrollbar rather than a wrap: a definition read as a
+   picture of itself must not be re-flowed to fit the column. */
+.code-block {
+  margin: 0;
+  padding: var(--space-4);
+  border: var(--border) solid var(--line);
+  border-radius: var(--radius-panel);
+  background: var(--surface);
+  overflow-x: auto;
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  line-height: 1.6;
+  color: var(--fg);
+}
+
+.code-block::before {
+  content: attr(data-lang);
+  display: block;
+  margin-bottom: var(--space-3);
+  color: var(--fg-muted);
+  font-size: var(--text-label);
+  letter-spacing: var(--track-label);
+  text-transform: uppercase;
+}
+
+/* The application itself. */
+
+.app {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.app h2 {
+  font-size: var(--text-lg);
+  margin: 0;
+}
+
+.app h2:focus-visible {
+  outline: var(--focus-ring);
+  outline-offset: var(--focus-offset);
+}
+
+.app fieldset.field {
+  border: 0;
+  margin: 0;
+  padding: 0;
+}
+
+.app .actions button {
+  min-height: var(--target-min);
+}
+
+.check {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  min-height: var(--target-min);
+  font-size: var(--text-sm);
+}
+
+.field-hint {
+  color: var(--fg-muted);
+  font-size: var(--text-xs);
+}
+
+.field-error {
+  color: var(--st-error);
+  font-size: var(--text-xs);
+  margin: 0;
+}
+
+.app-data {
+  margin: 0;
+  padding: var(--space-4);
+  border: var(--border) solid var(--line);
+  border-radius: var(--radius-panel);
+  background: var(--bg);
+  overflow-x: auto;
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+}
+
+/* What the engine says about itself, printed rather than described: the route
+   it computed, the steps it counts as finished, and the slices that have been
+   edited since. */
+.app-state {
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  gap: var(--space-1) var(--space-4);
+  margin: 0;
+  padding-top: var(--space-4);
+  border-top: var(--border) solid var(--line);
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+}
+
+.app-state dt {
+  color: var(--fg-muted);
+}
+
+.app-state dd {
+  margin: 0;
+  color: var(--fg-muted);
+  overflow-wrap: anywhere;
+}
+
+.app-live {
+  margin: 0;
+  min-height: 1.25em;
+  color: var(--fg-muted);
+  font-size: var(--text-xs);
 }


### PR DESCRIPTION
The first of the three reference applications the 1.0 release is evidenced by: **R-A, onboarding with a conditional branch and backtracking**, written once in `examples/reference` and rendered by React and by Vue from the same flow definition.

## What it proves

| Construct | How the application uses it |
| --- | --- |
| `when` | Company is on the route only while the payer is a business. |
| `on.next` as a target list | A visitor who already has an account jumps to Review over two steps that stay reachable. The list is exhaustive on purpose: a target list where nothing matches ends the flow, so the ordinary route is spelled out after the fast path. |
| `clearOnLeave` | The one-time code is dropped whichever way the step is left, so it is in neither the submission nor a saved session. |
| the back stack | Back crosses the branch; the answers behind it survive, because nothing is cleared by returning to a step. |
| `completed` / `dirty` | Printed under the form, so the page states what the engine says about itself rather than describing it. |

## The site

`/examples/` lists the three applications; `/examples/onboarding/` and `/examples/onboarding/vue/` run this one.

- **The framework toggle is a link.** Each page mounts one runtime, decided by its URL. The remembered preference only rewrites the links out of the index, so it can never disagree with what the server rendered.
- **One runtime per page, asserted.** An e2e test downloads every script each page fetched and fails if the React page carries Vue or the other way round.
- **The code cannot drift from the code.** The source blocks are `?raw` imports of the files the island mounts — one file, read twice. They are plain `<pre>`: Starlight owns the highlighter for the build and its bundle carries only the themes it needs.
- **A static first frame.** Step 1 is drawn before anything hydrates, with the controls visibly disabled and a one-word status rather than a spinner.
- **A boundary per island**, with **Restart example**, in both bindings.

## Accessibility

By hand in both renderings, which is what the 1.1 bindings contract will be written from: labels by `for`/`id`, hint and error by `aria-describedby` so a refusal never becomes part of the field's accessible name, one polite live region for validation and step changes, focus moved to the heading of the step just entered, 44px targets. `axe` reports no violations on either page.

## Also here, because the pages needed it

- The page chrome moves into `site/src/layouts/Page.astro` rather than being copied a seventh time.
- The top bar wraps: four entries did not fit on a 390px screen, and a bar that overflows takes the page with it. This is what the inspector's phone test caught.
- `StageBoundary` offers **Restart example** when the caller can remount what failed.

## Verification

- `pnpm verify` — lint 0 errors, type-check 0 errors, 629 unit tests.
- `npx playwright test` — 108 passed, including nine new specs for this application: the pre-hydration frame, the business route, the keyboard-only walk, the refusal, the Vue page, the runtime isolation, the toggle, and `axe` on both pages.

## Not in this PR

R-B and R-C. They are listed on `/examples/` as not written yet rather than linked to a page that does not exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01St8X7YMGRoGykjjArA9v9n
