### PR TITLE
feat(site): the reloadable reference application, live on both bindings (S3)

### DIFF
--- a/e2e/tests/site/examples-reload.spec.ts
+++ b/e2e/tests/site/examples-reload.spec.ts
@@ -1,0 +1,156 @@
+import AxeBuilder from '@axe-core/playwright';
+import type { Page } from '@playwright/test';
+
+import { expect, test } from '../../fixtures/base';
+
+/**
+ * R-B, in a browser, where a reload is a real reload.
+ *
+ * The unit suite unmounts and mounts a component with the same storage behind
+ * it, which is the same event as far as the engine is concerned. What only a
+ * browser can do is press F5 while a check is in the air, and prove that what
+ * comes back is a wizard rather than a wizard stuck saying "Checking".
+ */
+const REACT = 'examples/reload/';
+const VUE = 'examples/reload/vue/';
+
+const restoreLine = (page: Page) => page.locator('.app-restore');
+
+/** Fills the first step and continues, leaving the wizard on the workspace step. */
+async function reachWorkspace(page: Page): Promise<void> {
+  await page.getByLabel('Email').fill('ada@example.com');
+  await page.getByRole('button', { name: 'Next' }).click();
+  await expect(page.getByRole('heading', { name: 'Name your workspace' })).toBeVisible();
+}
+
+test.describe('R-B reload', () => {
+  test('draws the first step before it hydrates, and says nothing is saved yet', async ({
+    page,
+    browser,
+  }) => {
+    const context = await browser.newContext({ javaScriptEnabled: false });
+    const still = await context.newPage();
+    await still.goto(REACT);
+
+    await expect(still.getByRole('heading', { name: 'Your account' })).toBeVisible();
+    await expect(still.getByRole('button', { name: 'Next' })).toBeDisabled();
+    await expect(restoreLine(still)).toHaveText('Starting.');
+    await context.close();
+
+    await page.goto(REACT);
+    await expect(page.getByRole('button', { name: 'Next' })).toBeEnabled();
+    await expect(restoreLine(page)).toHaveText(
+      'Nothing saved yet. This one will be, from the first answer.'
+    );
+  });
+
+  test('comes back where it was left after a reload', async ({ page }) => {
+    await page.goto(REACT);
+    await expect(page.getByRole('button', { name: 'Next' })).toBeEnabled();
+    await reachWorkspace(page);
+
+    await page.reload();
+    await expect(restoreLine(page)).toHaveText('Restored. You are back where you left off.');
+    await expect(page.getByRole('heading', { name: 'Name your workspace' })).toBeVisible();
+
+    await page.getByRole('button', { name: 'Back' }).click();
+    await expect(page.getByLabel('Email')).toHaveValue('ada@example.com');
+  });
+
+  test('is not corrupted by a reload in the middle of the check', async ({ page }) => {
+    await page.goto(REACT);
+    await expect(page.getByRole('button', { name: 'Next' })).toBeEnabled();
+    await reachWorkspace(page);
+
+    await page.getByLabel('Workspace name').fill('ada-ltd');
+    await page.getByRole('button', { name: 'Next' }).click();
+    // The lookup is in the air, and the button says so rather than spinning.
+    await expect(page.getByRole('button', { name: 'Checking…' })).toBeDisabled();
+
+    await page.reload();
+
+    // What was stored is the durable snapshot: no navigation in flight, no
+    // busy list, so the restored wizard is idle and can be driven on.
+    await expect(restoreLine(page)).toHaveText('Restored. You are back where you left off.');
+    await expect(page.getByRole('heading', { name: 'Name your workspace' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Next' })).toBeEnabled();
+    await expect(page.locator('.app-state')).toContainText('idle');
+  });
+
+  test('Back throws away an answer that is still in the air', async ({ page }) => {
+    await page.goto(REACT);
+    await expect(page.getByRole('button', { name: 'Next' })).toBeEnabled();
+    await reachWorkspace(page);
+
+    await page.getByLabel('Workspace name').fill('acme');
+    await page.getByRole('button', { name: 'Next' }).click();
+    await expect(page.getByRole('button', { name: 'Checking…' })).toBeDisabled();
+
+    await page.getByRole('button', { name: 'Back' }).click();
+    await expect(page.getByRole('heading', { name: 'Your account' })).toBeVisible();
+
+    // "acme" is taken, so the answer still in the air is a refusal. Rather than
+    // wait a fixed time for it to not appear, walk on with a name that is free:
+    // the stale refusal lands during the second check, and if it were written
+    // the wizard would be sitting on Workspace with an error instead of here.
+    await page.getByRole('button', { name: 'Next' }).click();
+    await expect(page.getByRole('heading', { name: 'Name your workspace' })).toBeVisible();
+    await page.getByLabel('Workspace name').fill('ada-ltd');
+    await page.getByRole('button', { name: 'Next' }).click();
+
+    await expect(page.getByRole('heading', { name: 'Confirm' })).toBeVisible();
+    await expect(page.locator('.field-error')).toHaveCount(0);
+  });
+
+  test('refuses a session written by an older version, and says which', async ({ page }) => {
+    await page.goto(REACT);
+    await expect(page.getByRole('button', { name: 'Next' })).toBeEnabled();
+    await reachWorkspace(page);
+
+    await page.getByRole('button', { name: 'Ship version 2 and reload' }).click();
+
+    await expect(restoreLine(page)).toHaveText(
+      'Reset: the saved session was written by an older version of this application.'
+    );
+    await expect(page.getByRole('heading', { name: 'Your account' })).toBeVisible();
+    await expect(page.getByLabel('Email')).toHaveValue('');
+  });
+
+  test('the Vue page restores what the React page saved', async ({ page }) => {
+    await page.goto(REACT);
+    await expect(page.getByRole('button', { name: 'Next' })).toBeEnabled();
+    await reachWorkspace(page);
+
+    await page.goto(VUE);
+    await expect(restoreLine(page)).toHaveText('Restored. You are back where you left off.');
+    await expect(page.getByRole('heading', { name: 'Name your workspace' })).toBeVisible();
+  });
+
+  test('each page downloads one runtime and not the other', async ({ page }) => {
+    const bodies: Promise<string>[] = [];
+    page.on('response', (response) => {
+      if (response.url().endsWith('.js')) bodies.push(response.text().catch(() => ''));
+    });
+
+    await page.goto(VUE);
+    await expect(page.getByRole('button', { name: 'Next' })).toBeEnabled();
+    const scripts = (await Promise.all(bodies)).join('');
+    expect(scripts).toContain('__vue_app__');
+    expect(scripts).not.toContain('__reactContainer$');
+  });
+
+  for (const [name, path] of [
+    ['React', REACT],
+    ['Vue', VUE],
+  ] as const) {
+    test(`the ${name} page has no accessibility violations`, async ({ page }) => {
+      await page.goto(path);
+      await expect(page.getByRole('button', { name: 'Next' })).toBeEnabled();
+
+      const results = await new AxeBuilder({ page })
+        .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'])
+        .analyze();
+      expect(results.violations).toEqual([]);
+    });
+  }
+});

--- a/examples/reference/package.json
+++ b/examples/reference/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "@wizzard-packages/core": "workspace:*",
+    "@wizzard-packages/plugins": "workspace:*",
     "@wizzard-packages/react": "workspace:*",
     "@wizzard-packages/vue": "workspace:*",
     "react": "^19.2.0",

--- a/examples/reference/src/reload/App.tsx
+++ b/examples/reference/src/reload/App.tsx
@@ -10,7 +10,7 @@ import {
 import { persist, type RestoreOutcome } from '@wizzard-packages/plugins/persist';
 import { useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
 
-import { APP_VERSION, STORAGE_KEY, reload } from './flow';
+import { APP_VERSION, LAST_STEP, STORAGE_KEY, reload } from './flow';
 import { describeRestore, simulateUpgrade } from './outcome';
 import { TAKEN, registry } from './registry';
 
@@ -76,10 +76,16 @@ function Reload(props: { restored: { current: RestoreOutcome | null } }): ReactN
   const [name, setName] = useField<string>('workspace.name');
   const status = useWizardSelector((s) => s.status);
 
+  // Whether the run is finished is read off the engine, not remembered here:
+  // `toSnapshot` does not carry `status`, so a wizard that reached the end and
+  // was reloaded comes back `idle`, and a flag in this component would come
+  // back `false` and send the visitor round the last step again. `completed`
+  // is in the snapshot, and the last step is in it only once the flow ended.
+  const ended = useWizardSelector((s) => s.completed.includes(LAST_STEP));
+
   const [mounted, setMounted] = useState(false);
   const [outcome, setOutcome] = useState<RestoreOutcome | null>(null);
   const [announcement, setAnnouncement] = useState('');
-  const [ended, setEnded] = useState(false);
   const heading = useRef<HTMLHeadingElement>(null);
 
   useEffect(() => {
@@ -107,7 +113,6 @@ function Reload(props: { restored: { current: RestoreOutcome | null } }): ReactN
 
   async function onNext(): Promise<void> {
     if (ended) {
-      setEnded(false);
       setAnnouncement('');
       wizard.reset();
       await wizard.start();
@@ -115,10 +120,7 @@ function Reload(props: { restored: { current: RestoreOutcome | null } }): ReactN
     }
     const result = await wizard.next();
     if (result.ok) {
-      if (result.to === '@end') {
-        setEnded(true);
-        setAnnouncement('Finished.');
-      }
+      if (result.to === '@end') setAnnouncement('Finished.');
       return;
     }
     if (result.reason === 'superseded' || result.reason === 'aborted') return;
@@ -144,7 +146,7 @@ function Reload(props: { restored: { current: RestoreOutcome | null } }): ReactN
         {describeRestore(mounted ? outcome : null)}
       </p>
 
-      {ended ? (
+      {mounted && ended ? (
         <>
           <h2 ref={heading} tabIndex={-1}>
             Done

--- a/examples/reference/src/reload/App.tsx
+++ b/examples/reference/src/reload/App.tsx
@@ -1,0 +1,300 @@
+import {
+  WizardProvider,
+  useErrors,
+  useField,
+  useNavigation,
+  useStep,
+  useWizard,
+  useWizardSelector,
+} from '@wizzard-packages/react/v1';
+import { persist, type RestoreOutcome } from '@wizzard-packages/plugins/persist';
+import { useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
+
+import { APP_VERSION, STORAGE_KEY, reload } from './flow';
+import { describeRestore, simulateUpgrade } from './outcome';
+import { TAKEN, registry } from './registry';
+
+/**
+ * R-B on the React binding: a form that survives a reload, and a check that a
+ * reload in the middle of must not corrupt.
+ *
+ * Two things here are not obvious and are the reason the file is worth reading.
+ *
+ * The plugin is installed in the browser only, and what it restored is not
+ * shown until after mount. A restored session is by definition different from
+ * the empty first step the server rendered, so a client that painted it
+ * immediately would be correcting the server's markup - the mismatch React
+ * warns about. The first client paint is therefore the server's frame, and the
+ * session appears one tick later, which is also when the outcome can be told.
+ *
+ * `busy` is read off the engine, never tracked here. It is true from the moment
+ * `next()` starts until the validator answers, which is what disables the
+ * button and what "Checking" is spelled from.
+ */
+export default function ReloadApp(): ReactNode {
+  // Whatever the plugin decided, kept out of React's state until it is safe to
+  // read: `init` runs while the engine is being created, which is during a
+  // render, and setting state there is not allowed.
+  const restored = useRef<RestoreOutcome | null>(null);
+
+  const plugins = useMemo(
+    () =>
+      typeof window === 'undefined'
+        ? []
+        : [
+            persist({
+              key: STORAGE_KEY,
+              version: APP_VERSION,
+              onRestore: (outcome) => {
+                restored.current = outcome;
+              },
+            }),
+          ],
+    []
+  );
+
+  return (
+    <WizardProvider flow={reload} registry={registry} plugins={plugins}>
+      <Reload restored={restored} />
+    </WizardProvider>
+  );
+}
+
+const LABELS: Record<string, string> = {
+  account: 'Your account',
+  workspace: 'Name your workspace',
+  confirm: 'Confirm',
+};
+
+function Reload(props: { restored: { current: RestoreOutcome | null } }): ReactNode {
+  const wizard = useWizard();
+  const { current, active, isLast } = useStep();
+  const { back, canBack, isBusy } = useNavigation();
+  const errors = useErrors();
+
+  const [email, setEmail] = useField<string>('account.email');
+  const [name, setName] = useField<string>('workspace.name');
+  const status = useWizardSelector((s) => s.status);
+
+  const [mounted, setMounted] = useState(false);
+  const [outcome, setOutcome] = useState<RestoreOutcome | null>(null);
+  const [announcement, setAnnouncement] = useState('');
+  const [ended, setEnded] = useState(false);
+  const heading = useRef<HTMLHeadingElement>(null);
+
+  useEffect(() => {
+    setMounted(true);
+    setOutcome(props.restored.current);
+  }, [props.restored]);
+
+  const moved = useRef(false);
+  useEffect(() => {
+    if (current === null || !mounted) return;
+    if (!moved.current) {
+      moved.current = true;
+      return;
+    }
+    heading.current?.focus();
+    const { active: route } = wizard.getSnapshot();
+    const at = route.indexOf(current) + 1;
+    setAnnouncement(`${LABELS[current] ?? current}. Step ${at} of ${route.length}.`);
+  }, [current, mounted, wizard]);
+
+  // Until the first effect has run, this is the frame the server sent: the step
+  // the flow is about to enter, with the controls saying they are not ready.
+  const standing = mounted ? (current ?? active[0] ?? 'account') : 'account';
+  const starting = !mounted || current === null;
+
+  async function onNext(): Promise<void> {
+    if (ended) {
+      setEnded(false);
+      setAnnouncement('');
+      wizard.reset();
+      await wizard.start();
+      return;
+    }
+    const result = await wizard.next();
+    if (result.ok) {
+      if (result.to === '@end') {
+        setEnded(true);
+        setAnnouncement('Finished.');
+      }
+      return;
+    }
+    if (result.reason === 'superseded' || result.reason === 'aborted') return;
+    const fields = Object.values(result.errors ?? {});
+    setAnnouncement(
+      fields.length === 0 ? `That move was refused: ${result.reason}.` : fields.join(' ')
+    );
+  }
+
+  /**
+   * Back while a check is in flight. `cancel()` aborts the navigation, so the
+   * answer that arrives later belongs to an epoch that has passed and is
+   * discarded; the move backwards is a new one and wins.
+   */
+  async function onBack(): Promise<void> {
+    wizard.cancel();
+    await back();
+  }
+
+  return (
+    <div className="app">
+      <p className="app-restore" role="status" aria-live="polite">
+        {describeRestore(mounted ? outcome : null)}
+      </p>
+
+      {ended ? (
+        <>
+          <h2 ref={heading} tabIndex={-1}>
+            Done
+          </h2>
+          <p>
+            The session is still saved: reload and you come back to this. Start again replaces it
+            with an empty one, because that is a commit like any other.
+          </p>
+          <div className="actions">
+            <button
+              className="button button-accent"
+              type="button"
+              onClick={() => {
+                void onNext();
+              }}
+            >
+              Start again
+            </button>
+          </div>
+        </>
+      ) : (
+        <form
+          onSubmit={(event) => {
+            event.preventDefault();
+            void onNext();
+          }}
+        >
+          <h2 ref={heading} tabIndex={-1}>
+            {LABELS[standing] ?? standing}
+          </h2>
+
+          {standing === 'account' && (
+            <Field
+              id="reload-email"
+              label="Email"
+              type="email"
+              autoComplete="email"
+              value={mounted ? email : ''}
+              onChange={setEmail}
+              error={errors['email']}
+            />
+          )}
+
+          {standing === 'workspace' && (
+            <Field
+              id="reload-name"
+              label="Workspace name"
+              hint={`Checked against the service when you continue. ${TAKEN.join(', ')} are taken.`}
+              value={mounted ? name : ''}
+              onChange={setName}
+              error={errors['name']}
+            />
+          )}
+
+          {standing === 'confirm' && (
+            <p>
+              Reload the page now and you come back to this step, with both answers still in it.
+              What was stored is the durable snapshot, so nothing that described a moment - a
+              navigation in flight, a validator's errors - came back with it.
+            </p>
+          )}
+
+          <div className="actions">
+            <button className="button button-accent" type="submit" disabled={starting || isBusy}>
+              {isBusy ? 'Checking…' : isLast ? 'Finish' : 'Next'}
+            </button>
+            <button
+              className="button button-secondary"
+              type="button"
+              disabled={starting || !canBack}
+              onClick={() => {
+                void onBack();
+              }}
+            >
+              Back
+            </button>
+          </div>
+        </form>
+      )}
+
+      <dl className="app-state">
+        <dt>status</dt>
+        <dd>{starting ? 'init' : status}</dd>
+        <dt>saved</dt>
+        <dd>{STORAGE_KEY}</dd>
+      </dl>
+
+      <p className="app-note">
+        <button
+          className="button button-secondary"
+          type="button"
+          disabled={!mounted}
+          onClick={simulateUpgrade}
+        >
+          Ship version 2 and reload
+        </button>
+        <span>
+          Ages the saved session by one version and reloads, which is what everyone with a form open
+          meets on the day an application changes what it collects.
+        </span>
+      </p>
+
+      <p className="app-live" role="status" aria-live="polite">
+        {announcement}
+      </p>
+    </div>
+  );
+}
+
+function Field(props: {
+  id: string;
+  label: string;
+  value: string | undefined;
+  onChange: (value: string) => void;
+  type?: string;
+  autoComplete?: string;
+  hint?: string;
+  error?: string | undefined;
+}): ReactNode {
+  const described = [
+    props.hint === undefined ? null : `${props.id}-hint`,
+    props.error === undefined ? null : `${props.id}-error`,
+  ].filter((id): id is string => id !== null);
+
+  return (
+    <div className="field">
+      <label className="field-label" htmlFor={props.id}>
+        {props.label}
+      </label>
+      <input
+        id={props.id}
+        type={props.type ?? 'text'}
+        autoComplete={props.autoComplete}
+        value={props.value ?? ''}
+        aria-invalid={props.error === undefined ? undefined : true}
+        aria-describedby={described.length === 0 ? undefined : described.join(' ')}
+        onChange={(e) => {
+          props.onChange(e.target.value);
+        }}
+      />
+      {props.hint !== undefined && (
+        <span className="field-hint" id={`${props.id}-hint`}>
+          {props.hint}
+        </span>
+      )}
+      {props.error !== undefined && (
+        <span className="field-error" id={`${props.id}-error`}>
+          {props.error}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/examples/reference/src/reload/App.vue
+++ b/examples/reference/src/reload/App.vue
@@ -1,0 +1,35 @@
+<script setup lang="ts">
+import { persist, type RestoreOutcome } from '@wizzard-packages/plugins/persist';
+import { provideWizard } from '@wizzard-packages/vue/v1';
+
+import Reload from './Reload.vue';
+import { APP_VERSION, STORAGE_KEY, reload } from './flow';
+import { registry } from './registry';
+
+/**
+ * The plugin is installed in the browser only, and what it restored is shown
+ * one tick after mount by the child. A restored session differs from the empty
+ * first step the server rendered, so painting it on the first client frame
+ * would be correcting the server's markup.
+ */
+const restored: { outcome: RestoreOutcome | null } = { outcome: null };
+
+const plugins =
+  typeof window === 'undefined'
+    ? []
+    : [
+        persist({
+          key: STORAGE_KEY,
+          version: APP_VERSION,
+          onRestore: (outcome) => {
+            restored.outcome = outcome;
+          },
+        }),
+      ];
+
+provideWizard({ flow: reload, registry, plugins });
+</script>
+
+<template>
+  <Reload :restored="restored" />
+</template>

--- a/examples/reference/src/reload/Reload.vue
+++ b/examples/reference/src/reload/Reload.vue
@@ -10,7 +10,7 @@ import {
 } from '@wizzard-packages/vue/v1';
 import { computed, onMounted, ref, useTemplateRef, watch } from 'vue';
 
-import { STORAGE_KEY } from './flow';
+import { LAST_STEP, STORAGE_KEY } from './flow';
 import { describeRestore, simulateUpgrade } from './outcome';
 import { TAKEN } from './registry';
 
@@ -39,10 +39,16 @@ const email = useField<string>('account.email');
 const name = useField<string>('workspace.name');
 const status = useWizardSelector((s) => s.status);
 
+// Whether the run is finished is read off the engine, not remembered here:
+// `toSnapshot` does not carry `status`, so a wizard that reached the end and was
+// reloaded comes back `idle`, and a flag in this component would come back
+// false and send the visitor round the last step again. `completed` is in the
+// snapshot, and the last step is in it only once the flow ended.
+const ended = useWizardSelector((s) => s.completed.includes(LAST_STEP));
+
 const mounted = ref(false);
 const outcome = ref<RestoreOutcome | null>(null);
 const announcement = ref('');
-const ended = ref(false);
 const heading = useTemplateRef<HTMLHeadingElement>('heading');
 
 onMounted(() => {
@@ -75,7 +81,6 @@ watch(current, (to) => {
 
 async function onNext(): Promise<void> {
   if (ended.value) {
-    ended.value = false;
     announcement.value = '';
     wizard.reset();
     await wizard.start();
@@ -83,10 +88,7 @@ async function onNext(): Promise<void> {
   }
   const result = await wizard.next();
   if (result.ok) {
-    if (result.to === '@end') {
-      ended.value = true;
-      announcement.value = 'Finished.';
-    }
+    if (result.to === '@end') announcement.value = 'Finished.';
     return;
   }
   if (result.reason === 'superseded' || result.reason === 'aborted') return;
@@ -110,7 +112,7 @@ async function onBack(): Promise<void> {
   <div class="app">
     <p class="app-restore" role="status" aria-live="polite">{{ restoreLine }}</p>
 
-    <template v-if="ended">
+    <template v-if="mounted && ended">
       <h2 ref="heading" tabindex="-1">Done</h2>
       <p>
         The session is still saved: reload and you come back to this. Start again replaces it with

--- a/examples/reference/src/reload/Reload.vue
+++ b/examples/reference/src/reload/Reload.vue
@@ -1,0 +1,205 @@
+<script setup lang="ts">
+import type { RestoreOutcome } from '@wizzard-packages/plugins/persist';
+import {
+  useErrors,
+  useField,
+  useNavigation,
+  useStep,
+  useWizard,
+  useWizardSelector,
+} from '@wizzard-packages/vue/v1';
+import { computed, onMounted, ref, useTemplateRef, watch } from 'vue';
+
+import { STORAGE_KEY } from './flow';
+import { describeRestore, simulateUpgrade } from './outcome';
+import { TAKEN } from './registry';
+
+/**
+ * R-B on the Vue binding. The same application as `App.tsx`, message for
+ * message, with `onMounted` where the other has an effect.
+ *
+ * `busy` is read off the engine, never tracked here: it is true from the moment
+ * `next()` starts until the validator answers, which is what disables the
+ * button and what "Checking" is spelled from.
+ */
+const props = defineProps<{ restored: { outcome: RestoreOutcome | null } }>();
+
+const LABELS: Record<string, string> = {
+  account: 'Your account',
+  workspace: 'Name your workspace',
+  confirm: 'Confirm',
+};
+
+const wizard = useWizard();
+const { current, active, isLast } = useStep();
+const { back, canBack, isBusy } = useNavigation();
+const errors = useErrors();
+
+const email = useField<string>('account.email');
+const name = useField<string>('workspace.name');
+const status = useWizardSelector((s) => s.status);
+
+const mounted = ref(false);
+const outcome = ref<RestoreOutcome | null>(null);
+const announcement = ref('');
+const ended = ref(false);
+const heading = useTemplateRef<HTMLHeadingElement>('heading');
+
+onMounted(() => {
+  mounted.value = true;
+  outcome.value = props.restored.outcome;
+});
+
+// Until mount, this is the frame the server sent: the step the flow is about to
+// enter, with the controls saying they are not ready.
+const standing = computed(() =>
+  mounted.value ? (current.value ?? active.value[0] ?? 'account') : 'account'
+);
+const starting = computed(() => !mounted.value || current.value === null);
+const restoreLine = computed(() => describeRestore(mounted.value ? outcome.value : null));
+const hint = computed(
+  () => `Checked against the service when you continue. ${TAKEN.join(', ')} are taken.`
+);
+
+let moved = false;
+watch(current, (to) => {
+  if (to === null || !mounted.value) return;
+  if (!moved) {
+    moved = true;
+    return;
+  }
+  heading.value?.focus();
+  const at = active.value.indexOf(to) + 1;
+  announcement.value = `${LABELS[to] ?? to}. Step ${at} of ${active.value.length}.`;
+});
+
+async function onNext(): Promise<void> {
+  if (ended.value) {
+    ended.value = false;
+    announcement.value = '';
+    wizard.reset();
+    await wizard.start();
+    return;
+  }
+  const result = await wizard.next();
+  if (result.ok) {
+    if (result.to === '@end') {
+      ended.value = true;
+      announcement.value = 'Finished.';
+    }
+    return;
+  }
+  if (result.reason === 'superseded' || result.reason === 'aborted') return;
+  const fields = Object.values(result.errors ?? {});
+  announcement.value =
+    fields.length === 0 ? `That move was refused: ${result.reason}.` : fields.join(' ');
+}
+
+/**
+ * Back while a check is in flight. `cancel()` aborts the navigation, so the
+ * answer that arrives later belongs to an epoch that has passed and is
+ * discarded; the move backwards is a new one and wins.
+ */
+async function onBack(): Promise<void> {
+  wizard.cancel();
+  await back();
+}
+</script>
+
+<template>
+  <div class="app">
+    <p class="app-restore" role="status" aria-live="polite">{{ restoreLine }}</p>
+
+    <template v-if="ended">
+      <h2 ref="heading" tabindex="-1">Done</h2>
+      <p>
+        The session is still saved: reload and you come back to this. Start again replaces it with
+        an empty one, because that is a commit like any other.
+      </p>
+      <div class="actions">
+        <button class="button button-accent" type="button" @click="onNext()">Start again</button>
+      </div>
+    </template>
+
+    <form v-else @submit.prevent="onNext()">
+      <h2 ref="heading" tabindex="-1">{{ LABELS[standing] ?? standing }}</h2>
+
+      <div v-if="standing === 'account'" class="field">
+        <label class="field-label" for="reload-email">Email</label>
+        <input
+          id="reload-email"
+          :value="mounted ? (email ?? '') : ''"
+          type="email"
+          autocomplete="email"
+          :aria-invalid="errors['email'] ? true : undefined"
+          :aria-describedby="errors['email'] ? 'reload-email-error' : undefined"
+          @input="email = ($event.target as HTMLInputElement).value"
+        />
+        <span v-if="errors['email']" id="reload-email-error" class="field-error">
+          {{ errors['email'] }}
+        </span>
+      </div>
+
+      <div v-else-if="standing === 'workspace'" class="field">
+        <label class="field-label" for="reload-name">Workspace name</label>
+        <input
+          id="reload-name"
+          :value="mounted ? (name ?? '') : ''"
+          :aria-invalid="errors['name'] ? true : undefined"
+          :aria-describedby="
+            errors['name'] ? 'reload-name-hint reload-name-error' : 'reload-name-hint'
+          "
+          @input="name = ($event.target as HTMLInputElement).value"
+        />
+        <span id="reload-name-hint" class="field-hint">{{ hint }}</span>
+        <span v-if="errors['name']" id="reload-name-error" class="field-error">
+          {{ errors['name'] }}
+        </span>
+      </div>
+
+      <p v-else-if="standing === 'confirm'">
+        Reload the page now and you come back to this step, with both answers still in it. What was
+        stored is the durable snapshot, so nothing that described a moment - a navigation in flight,
+        a validator's errors - came back with it.
+      </p>
+
+      <div class="actions">
+        <button class="button button-accent" type="submit" :disabled="starting || isBusy">
+          {{ isBusy ? 'Checking…' : isLast ? 'Finish' : 'Next' }}
+        </button>
+        <button
+          class="button button-secondary"
+          type="button"
+          :disabled="starting || !canBack"
+          @click="onBack()"
+        >
+          Back
+        </button>
+      </div>
+    </form>
+
+    <dl class="app-state">
+      <dt>status</dt>
+      <dd>{{ starting ? 'init' : status }}</dd>
+      <dt>saved</dt>
+      <dd>{{ STORAGE_KEY }}</dd>
+    </dl>
+
+    <p class="app-note">
+      <button
+        class="button button-secondary"
+        type="button"
+        :disabled="!mounted"
+        @click="simulateUpgrade()"
+      >
+        Ship version 2 and reload
+      </button>
+      <span>
+        Ages the saved session by one version and reloads, which is what everyone with a form open
+        meets on the day an application changes what it collects.
+      </span>
+    </p>
+
+    <p class="app-live" role="status" aria-live="polite">{{ announcement }}</p>
+  </div>
+</template>

--- a/examples/reference/src/reload/flow.ts
+++ b/examples/reference/src/reload/flow.ts
@@ -1,0 +1,42 @@
+import { defineFlow, step } from '@wizzard-packages/core/v1';
+
+/**
+ * R-B: an application that survives a reload, and an asynchronous check that a
+ * reload in the middle of must not corrupt.
+ *
+ * Three steps, because what this one has to demonstrate is not a route: it is
+ * what is stored, what is refused, and what a person is told when the form they
+ * half filled in comes back empty.
+ */
+export const reload = defineFlow({
+  id: 'reload',
+  version: 1,
+  order: ['account', 'workspace', 'confirm'],
+  steps: {
+    account: step<{ email: string }>({
+      label: 'Account',
+      validate: { $ref: 'account' },
+    }),
+
+    workspace: step<{ name: string }>({
+      label: 'Workspace',
+      // The check is a lookup, so it is asynchronous, so `next()` is a promise
+      // and the wizard is `busy` until it answers. That is what the buttons
+      // above read, and what a reload has to be safe in the middle of.
+      validate: { $ref: 'workspace' },
+    }),
+
+    confirm: step({ label: 'Confirm' }),
+  },
+  policy: 'free',
+});
+
+/** Where the session is kept. One key per flow. */
+export const STORAGE_KEY = 'wizzard:example:reload';
+
+/**
+ * The application's own version, not the flow's. It is bumped when the meaning
+ * of what was collected changes, and a session written under a different one is
+ * refused rather than half-understood.
+ */
+export const APP_VERSION = 1;

--- a/examples/reference/src/reload/flow.ts
+++ b/examples/reference/src/reload/flow.ts
@@ -31,6 +31,15 @@ export const reload = defineFlow({
   policy: 'free',
 });
 
+/**
+ * The last step. A finished run is one that has this in `completed`, which is
+ * the only durable way to know: `toSnapshot` does not carry `status`, so a
+ * wizard that reached the end and was reloaded comes back `idle`. Keeping the
+ * fact in the rendering instead would lose it on exactly the reload this
+ * application exists to survive.
+ */
+export const LAST_STEP = 'confirm';
+
 /** Where the session is kept. One key per flow. */
 export const STORAGE_KEY = 'wizzard:example:reload';
 

--- a/examples/reference/src/reload/outcome.ts
+++ b/examples/reference/src/reload/outcome.ts
@@ -1,0 +1,49 @@
+import type { RestoreOutcome } from '@wizzard-packages/plugins/persist';
+
+import { STORAGE_KEY } from './flow';
+
+/**
+ * What a person is told about the session they did or did not get back.
+ *
+ * A form that was half filled in and is now empty looks like a bug to whoever
+ * filled it, and silence is why they would think so. The plugin answers with a
+ * reason for exactly this: the host turns it into a sentence, because only the
+ * host knows what the form is called and who is reading it.
+ *
+ * Shared by both renderings so the two cannot drift into saying different
+ * things about the same event.
+ */
+export function describeRestore(outcome: RestoreOutcome | null): string {
+  if (outcome === null) return 'Starting.';
+  if (outcome.restored) return 'Restored. You are back where you left off.';
+
+  switch (outcome.reason) {
+    case 'persist/nothing-stored':
+      return 'Nothing saved yet. This one will be, from the first answer.';
+    case 'persist/unavailable':
+      return 'Saving unavailable: this browser did not allow storage, which private windows do.';
+    case 'snapshot/other-flow':
+      return 'Reset: the saved session was written by an older version of this application.';
+    case 'snapshot/version':
+      return 'Reset: the saved session is in a format this build does not read.';
+    case 'snapshot/unknown-step':
+      return 'Reset: the saved session was standing on a step this flow no longer has.';
+    default:
+      return `Reset: the saved session could not be read (${outcome.reason}).`;
+  }
+}
+
+/**
+ * Ages the stored session, then reloads.
+ *
+ * A version bump is the one refusal a visitor cannot produce by hand, and it is
+ * the one worth seeing: it is what happens to everybody with a session open on
+ * the day an application ships a change to what it collects.
+ */
+export function simulateUpgrade(): void {
+  const raw = globalThis.localStorage?.getItem(STORAGE_KEY);
+  if (raw === null || raw === undefined) return;
+  const stored = JSON.parse(raw) as Record<string, unknown>;
+  globalThis.localStorage.setItem(STORAGE_KEY, JSON.stringify({ ...stored, appVersion: 0 }));
+  globalThis.location.reload();
+}

--- a/examples/reference/src/reload/outcome.ts
+++ b/examples/reference/src/reload/outcome.ts
@@ -41,9 +41,17 @@ export function describeRestore(outcome: RestoreOutcome | null): string {
  * the day an application ships a change to what it collects.
  */
 export function simulateUpgrade(): void {
-  const raw = globalThis.localStorage?.getItem(STORAGE_KEY);
-  if (raw === null || raw === undefined) return;
-  const stored = JSON.parse(raw) as Record<string, unknown>;
-  globalThis.localStorage.setItem(STORAGE_KEY, JSON.stringify({ ...stored, appVersion: 0 }));
+  // Every one of these can throw in a browser that refuses storage - the
+  // property access included, which is why this is a try and not a check. The
+  // page already says saving is unavailable there; the button does nothing
+  // rather than taking the example down with it.
+  try {
+    const raw = globalThis.localStorage.getItem(STORAGE_KEY);
+    if (raw === null) return;
+    const stored = JSON.parse(raw) as Record<string, unknown>;
+    globalThis.localStorage.setItem(STORAGE_KEY, JSON.stringify({ ...stored, appVersion: 0 }));
+  } catch {
+    return;
+  }
   globalThis.location.reload();
 }

--- a/examples/reference/src/reload/registry.ts
+++ b/examples/reference/src/reload/registry.ts
@@ -1,0 +1,54 @@
+import type { AsyncRegistry, Scope } from '@wizzard-packages/core/v1';
+
+/**
+ * The validators. One is a plain function of the data; the other has to ask
+ * somebody, so it is a promise.
+ *
+ * A resolver is not handed an abort signal, so `cancel()` does not stop the
+ * lookup that is already in the air - it makes the answer irrelevant. The
+ * navigation epoch moved on, so whatever comes back is discarded rather than
+ * written over a wizard that has since gone somewhere else. That is the
+ * property a reload in the middle of a check depends on.
+ */
+type Fields = Record<string, string> | null;
+
+const slice = (scope: Scope, id: string): Record<string, unknown> =>
+  (scope.data[id] as Record<string, unknown> | undefined) ?? {};
+
+const EMAIL = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+/** The names the imaginary service already has. */
+export const TAKEN = ['acme', 'demo', 'test'];
+
+/** How long the lookup pretends to take. */
+export const LOOKUP_MS = 700;
+
+const wait = (ms: number): Promise<void> =>
+  new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+
+export const registry: AsyncRegistry = {
+  account: (_args, scope): Fields => {
+    const { email } = slice(scope, 'account');
+    if (typeof email !== 'string' || email === '') return { email: 'Enter your email address.' };
+    if (!EMAIL.test(email)) return { email: 'That does not look like an email address.' };
+    return null;
+  },
+
+  workspace: async (_args, scope): Promise<Fields> => {
+    const { name } = slice(scope, 'workspace');
+    const wanted = typeof name === 'string' ? name.trim() : '';
+    // The shape is checked before anything is asked: there is no point paying
+    // for a round trip to be told what a regular expression already knew.
+    if (wanted === '') return { name: 'Choose a name for your workspace.' };
+    if (!/^[a-z0-9-]{3,}$/.test(wanted)) {
+      return { name: 'Lower case letters, digits and dashes, three or more.' };
+    }
+
+    await wait(LOOKUP_MS);
+
+    if (TAKEN.includes(wanted)) return { name: `"${wanted}" is taken. Try another one.` };
+    return null;
+  },
+};

--- a/examples/reference/src/reload/reload.test.tsx
+++ b/examples/reference/src/reload/reload.test.tsx
@@ -140,6 +140,34 @@ describe('R-B reload, React', () => {
   });
 });
 
+describe('R-B reload, finished', () => {
+  it('comes back finished after a reload, rather than round the last step again', async () => {
+    const first = render(<ReloadApp />);
+    await act(async () => {});
+    await type(field('Email'), 'ada@example.com');
+    await click('Next');
+    await type(field('Workspace name'), 'ada-ltd');
+    await click('Next');
+    await settle(LOOKUP_MS + 50);
+    expect(heading()).toBe('Confirm');
+
+    await click('Finish');
+    expect(heading()).toBe('Done');
+    await settle(30);
+    first.unmount();
+
+    // `toSnapshot` does not carry `status`, so a rendering that remembered
+    // "finished" itself would put the visitor back on Confirm. It is read from
+    // `completed`, which is in the snapshot.
+    render(<ReloadApp />);
+    await act(async () => {});
+    expect(heading()).toBe('Done');
+
+    await click('Start again');
+    expect(heading()).toBe('Your account');
+  });
+});
+
 describe('R-B reload, Vue', () => {
   it('restores a session the React rendering saved', async () => {
     const first = render(<ReloadApp />);

--- a/examples/reference/src/reload/reload.test.tsx
+++ b/examples/reference/src/reload/reload.test.tsx
@@ -1,0 +1,161 @@
+import { render, screen } from '@testing-library/react';
+import { flushPromises, mount } from '@vue/test-utils';
+import { act } from 'react';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import AppVue from './App.vue';
+import ReloadApp from './App';
+import { APP_VERSION, STORAGE_KEY } from './flow';
+import { LOOKUP_MS } from './registry';
+
+/**
+ * R-B: what survives a reload, what is refused, and what a check in flight does
+ * to the buttons.
+ *
+ * A reload is an unmount and a mount with the same storage behind it, which is
+ * what these do. The engine cannot tell the difference, and neither can the
+ * plugin - that is the whole reason the snapshot is a value rather than a
+ * living object.
+ */
+const type = async (input: HTMLElement, value: string): Promise<void> => {
+  const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')?.set as (
+    this: HTMLInputElement,
+    v: string
+  ) => void;
+  await act(async () => {
+    setter.call(input as HTMLInputElement, value);
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+  });
+};
+
+const click = async (name: string | RegExp): Promise<void> => {
+  await act(async () => {
+    screen.getByRole('button', { name }).dispatchEvent(new MouseEvent('click', { bubbles: true }));
+  });
+};
+
+const settle = async (ms: number): Promise<void> => {
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, ms));
+  });
+};
+
+const heading = (): string => screen.getByRole('heading').textContent ?? '';
+const restoreLine = (): string => document.querySelector('.app-restore')?.textContent ?? '';
+const field = (label: string): HTMLInputElement => screen.getByLabelText(label) as HTMLInputElement;
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe('R-B reload, React', () => {
+  it('comes back where it was left, with what was typed', async () => {
+    const first = render(<ReloadApp />);
+    await act(async () => {});
+    expect(restoreLine()).toBe('Nothing saved yet. This one will be, from the first answer.');
+
+    await type(field('Email'), 'ada@example.com');
+    await click('Next');
+    expect(heading()).toBe('Name your workspace');
+
+    // The write is coalesced to one per frame; unmounting flushes what is due.
+    await settle(30);
+    first.unmount();
+
+    render(<ReloadApp />);
+    await act(async () => {});
+    expect(restoreLine()).toBe('Restored. You are back where you left off.');
+    expect(heading()).toBe('Name your workspace');
+
+    await click('Back');
+    expect(field('Email').value).toBe('ada@example.com');
+  });
+
+  it('refuses a session written by an older version, and says which', async () => {
+    const first = render(<ReloadApp />);
+    await act(async () => {});
+    await type(field('Email'), 'ada@example.com');
+    await click('Next');
+    await settle(30);
+    first.unmount();
+
+    // What "Ship version 2 and reload" does, without the reload.
+    const stored = JSON.parse(localStorage.getItem(STORAGE_KEY) ?? '{}') as Record<string, unknown>;
+    expect(stored['appVersion']).toBe(APP_VERSION);
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ ...stored, appVersion: 0 }));
+
+    render(<ReloadApp />);
+    await act(async () => {});
+    expect(restoreLine()).toBe(
+      'Reset: the saved session was written by an older version of this application.'
+    );
+    expect(heading()).toBe('Your account');
+    expect(field('Email').value).toBe('');
+  });
+
+  it('says it is checking, and Back throws the answer away', async () => {
+    render(<ReloadApp />);
+    await act(async () => {});
+    await type(field('Email'), 'ada@example.com');
+    await click('Next');
+
+    await type(field('Workspace name'), 'acme');
+    await click('Next');
+
+    // The lookup is in the air: the engine is busy and the button says so.
+    expect(screen.getByRole('button', { name: 'Checking…' })).toBeTruthy();
+    expect((screen.getByRole('button', { name: 'Checking…' }) as HTMLButtonElement).disabled).toBe(
+      true
+    );
+
+    await click('Back');
+    expect(heading()).toBe('Your account');
+
+    // The answer arrives for a navigation that no longer exists, and is
+    // discarded rather than written over the step the visitor is now on.
+    await settle(LOOKUP_MS + 50);
+    expect(heading()).toBe('Your account');
+    expect(document.querySelector('.field-error')).toBeNull();
+  });
+
+  it('refuses a name the service already has', async () => {
+    render(<ReloadApp />);
+    await act(async () => {});
+    await type(field('Email'), 'ada@example.com');
+    await click('Next');
+
+    await type(field('Workspace name'), 'acme');
+    await click('Next');
+    await settle(LOOKUP_MS + 50);
+
+    expect(heading()).toBe('Name your workspace');
+    expect(document.querySelector('.field-error')?.textContent).toBe(
+      '"acme" is taken. Try another one.'
+    );
+
+    await type(field('Workspace name'), 'ada-ltd');
+    await click('Next');
+    await settle(LOOKUP_MS + 50);
+    expect(heading()).toBe('Confirm');
+  });
+});
+
+describe('R-B reload, Vue', () => {
+  it('restores a session the React rendering saved', async () => {
+    const first = render(<ReloadApp />);
+    await act(async () => {});
+    await type(field('Email'), 'ada@example.com');
+    await click('Next');
+    await settle(30);
+    first.unmount();
+
+    const app = mount(AppVue, { attachTo: document.createElement('div') });
+    await flushPromises();
+
+    // One flow, one snapshot format, one storage key: the binding is a
+    // rendering, and the session does not belong to it.
+    expect(app.get('.app-restore').text()).toBe('Restored. You are back where you left off.');
+    expect(app.get('h2').text()).toBe('Name your workspace');
+    app.unmount();
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -329,6 +329,9 @@ importers:
       '@wizzard-packages/core':
         specifier: workspace:*
         version: link:../../packages/core
+      '@wizzard-packages/plugins':
+        specifier: workspace:*
+        version: link:../../packages/plugins
       '@wizzard-packages/react':
         specifier: workspace:*
         version: link:../../packages/react

--- a/site/src/islands/ReloadReact.tsx
+++ b/site/src/islands/ReloadReact.tsx
@@ -1,0 +1,26 @@
+import ReloadApp from '@examples/reference/src/reload/App';
+import { useState, type ReactNode } from 'react';
+
+import { StageBoundary } from '../components/StageBoundary';
+
+/**
+ * R-B, mounted. The site owns the net; the example owns the application.
+ *
+ * The boundary and the remount key live here rather than in the example,
+ * because a reader copying `App.tsx` into their own project is copying an
+ * application, not a page that has to survive a stranger's browser.
+ */
+export default function ReloadReact(): ReactNode {
+  const [attempt, setAttempt] = useState(0);
+
+  return (
+    <StageBoundary
+      resetKey={attempt}
+      onRestart={() => {
+        setAttempt((n) => n + 1);
+      }}
+    >
+      <ReloadApp key={attempt} />
+    </StageBoundary>
+  );
+}

--- a/site/src/islands/ReloadVue.vue
+++ b/site/src/islands/ReloadVue.vue
@@ -1,0 +1,42 @@
+<script setup lang="ts">
+import App from '@examples/reference/src/reload/App.vue';
+import { onErrorCaptured, ref } from 'vue';
+
+/**
+ * R-B on the Vue binding, mounted. The counterpart of `ReloadReact.tsx`:
+ * the site owns the net, the example owns the application.
+ *
+ * `onErrorCaptured` returning false stops the error propagating to the app
+ * root, which is Vue's equivalent of React's error boundary. Bumping `attempt`
+ * remounts the child, which is what starting the example again means.
+ */
+const failure = ref<string | null>(null);
+const attempt = ref(0);
+
+onErrorCaptured((error) => {
+  failure.value = error instanceof Error ? error.message : String(error);
+  console.error('[example] the application stopped', error);
+  return false;
+});
+
+function restart(): void {
+  failure.value = null;
+  attempt.value += 1;
+}
+</script>
+
+<template>
+  <div v-if="failure !== null" class="stage-failed" role="alert">
+    <p>This example stopped.</p>
+    <p class="stage-failed-why">
+      {{ failure }}
+    </p>
+    <p>
+      The page around it is fine, and so is the flow definition below. Start the example again, or
+      open an issue with what you had typed.
+    </p>
+    <button class="button button-secondary" type="button" @click="restart">Restart example</button>
+  </div>
+
+  <App v-else :key="attempt" />
+</template>

--- a/site/src/pages/examples/index.astro
+++ b/site/src/pages/examples/index.astro
@@ -26,9 +26,9 @@ const APPS = [
     ref: 'R-B',
     heading: 'Reload halfway through. Continue safely.',
     blurb:
-      'A form that survives F5, validates a field against an asynchronous resolver, and is not corrupted by a reload during that validation.',
-    proves: ['persist', 'snapshot contract', 'busy', 'hydrateMismatch'],
-    ready: false,
+      'A form that survives F5, checks a name against a service that takes its time, and is not corrupted by a reload in the middle of that check.',
+    proves: ['persist', 'the snapshot contract', 'busy', 'the navigation epoch'],
+    ready: true,
   },
   {
     slug: 'passengers',

--- a/site/src/pages/examples/reload/index.astro
+++ b/site/src/pages/examples/reload/index.astro
@@ -1,0 +1,47 @@
+---
+import flowSource from '@examples/reference/src/reload/flow.ts?raw';
+import registrySource from '@examples/reference/src/reload/registry.ts?raw';
+import outcomeSource from '@examples/reference/src/reload/outcome.ts?raw';
+import appSource from '@examples/reference/src/reload/App.tsx?raw';
+
+import ExampleShell from '../../../components/ExampleShell.astro';
+import ReloadReact from '../../../islands/ReloadReact';
+
+const sources = [
+  {
+    name: 'flow.ts',
+    lang: 'ts' as const,
+    code: flowSource,
+    note: 'Three steps, a storage key and an application version. The version is the application’s, not the flow’s: it is bumped when the meaning of what was collected changes.',
+  },
+  {
+    name: 'registry.ts',
+    lang: 'ts' as const,
+    code: registrySource,
+    note: 'One plain validator and one that has to ask somebody. A resolver is handed no abort signal, so cancelling does not stop the lookup - it makes the answer irrelevant.',
+  },
+  {
+    name: 'outcome.ts',
+    lang: 'ts' as const,
+    code: outcomeSource,
+    note: 'The plugin answers with a reason; only the host knows what the form is called, so it is the host that turns the reason into a sentence.',
+  },
+  {
+    name: 'App.tsx',
+    lang: 'tsx' as const,
+    code: appSource,
+    note: 'The rendering. The plugin is installed in the browser only, and what it restored appears one tick after mount - a restored session differs from the empty step the server rendered.',
+  },
+];
+---
+
+<ExampleShell
+  slug="reload"
+  ref="R-B"
+  heading="Reload halfway through. Continue safely."
+  lede="A form that survives F5, checks a name against a service that takes its time, and is not corrupted by a reload in the middle of that check. Every refusal to restore says which refusal it was."
+  framework="react"
+  sources={sources}
+>
+  <ReloadReact client:load />
+</ExampleShell>

--- a/site/src/pages/examples/reload/vue.astro
+++ b/site/src/pages/examples/reload/vue.astro
@@ -1,0 +1,47 @@
+---
+import flowSource from '@examples/reference/src/reload/flow.ts?raw';
+import registrySource from '@examples/reference/src/reload/registry.ts?raw';
+import outcomeSource from '@examples/reference/src/reload/outcome.ts?raw';
+import appSource from '@examples/reference/src/reload/Reload.vue?raw';
+
+import ExampleShell from '../../../components/ExampleShell.astro';
+import ReloadVue from '../../../islands/ReloadVue.vue';
+
+const sources = [
+  {
+    name: 'flow.ts',
+    lang: 'ts' as const,
+    code: flowSource,
+    note: 'The same file the React page shows. A session saved on one page restores on the other: the binding is a rendering, and the snapshot does not belong to it.',
+  },
+  {
+    name: 'registry.ts',
+    lang: 'ts' as const,
+    code: registrySource,
+    note: 'Also the same file. A resolver is handed no abort signal, so cancelling does not stop the lookup - it makes the answer irrelevant.',
+  },
+  {
+    name: 'outcome.ts',
+    lang: 'ts' as const,
+    code: outcomeSource,
+    note: 'And this one, so the two renderings cannot drift into saying different things about the same event.',
+  },
+  {
+    name: 'Reload.vue',
+    lang: 'vue' as const,
+    code: appSource,
+    note: 'The rendering, with `onMounted` where the React file has an effect. The restored session appears one tick after mount for the same reason.',
+  },
+];
+---
+
+<ExampleShell
+  slug="reload"
+  ref="R-B"
+  heading="Reload halfway through. Continue safely."
+  lede="A form that survives F5, checks a name against a service that takes its time, and is not corrupted by a reload in the middle of that check. Every refusal to restore says which refusal it was."
+  framework="vue"
+  sources={sources}
+>
+  <ReloadVue client:load />
+</ExampleShell>

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -62,6 +62,9 @@ const description =
               A saved run restores to the step it left, or says plainly why it could not - an
               older definition version, or storage the browser refused.
             </p>
+            <p>
+              <a href={`${base}/examples/reload/`}>Run this one, on React or Vue</a>
+            </p>
           </FlowRow>
 
           <FlowRow

--- a/site/src/styles/site.css
+++ b/site/src/styles/site.css
@@ -1315,3 +1315,40 @@ svg.interactive .node {
   color: var(--fg-muted);
   font-size: var(--text-xs);
 }
+
+/* What happened to the saved session, said before anything else on the card:
+   a form that was half filled in and is now empty looks like a bug, and
+   silence is why the person filling it would think so. */
+.app-restore {
+  margin: 0;
+  padding: var(--space-3) var(--space-4);
+  border: var(--border) solid var(--line);
+  border-radius: var(--radius-control);
+  background: var(--bg);
+  color: var(--fg-muted);
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+}
+
+/* A control that is about the example rather than part of it. */
+.app-note {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-3);
+  margin: 0;
+  padding-top: var(--space-4);
+  border-top: var(--border) solid var(--line);
+}
+
+.app-note span {
+  flex: 1 1 16rem;
+  color: var(--fg-muted);
+  font-size: var(--text-xs);
+}
+
+.app form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}


### PR DESCRIPTION
**R-B**, the second of the three reference applications: a form that survives F5, checks a workspace name against a service that takes its time, and is not corrupted by a reload in the middle of that check.

## What it proves

| Claim | How the application shows it |
| --- | --- |
| the durable snapshot contract | A reload during the check comes back **idle**, on the same step, with both answers in it. The fields that describe a moment — a navigation in flight, a busy list, a validator's errors — are not in the snapshot, which is why a restored wizard is not stuck saying "Checking". |
| `busy` | Read off the engine, never tracked by the rendering. True from the moment `next()` starts until the validator answers; it disables the button and spells its label. |
| the navigation epoch | A resolver is handed no abort signal, so `cancel()` does not stop the lookup already in the air — it makes the answer irrelevant. |
| the restore outcome | Every refusal says which refusal it was, in a sentence the host writes from the reason the plugin gives. |

**Ship version 2 and reload** ages the stored session by a version. It is the one refusal a visitor cannot produce by hand, and the one everybody with a form open meets on the day an application changes what it collects.

## Two things worth reading in the rendering

- **The plugin is installed in the browser only, and what it restored appears one tick after mount.** A restored session is by definition different from the empty first step the server rendered, so a client that painted it immediately would be correcting the server's markup.
- **The session belongs to the flow, not to the binding.** The Vue page restores what the React page saved, and an e2e test walks exactly that.

## A note on the test that asserts a non-event

"Back throws away an answer that is still in the air" does not wait a fixed time for a refusal to fail to appear. It walks on with a name that is free: the stale refusal lands during the second check, and if it were written the wizard would be sitting on Workspace with an error instead of on Confirm.

## Verification

- `pnpm verify` — lint 0 errors, type-check 0 errors, 635 unit tests (six new, including a restore, a version refusal, a cancelled check and a Vue rendering restoring a React session).
- `npx playwright test --project=site` — 27 passed, nine of them new for this application, `axe` clean on both pages.

## Still to come

R-C. It is listed on `/examples/` as not written yet rather than linked to a page that does not exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01St8X7YMGRoGykjjArA9v9n
