### PR TITLE
feat(site): the repeated-section reference application, live on both bindings (S3)

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -4,6 +4,23 @@ Deferred work, with the context needed to pick it up cold. Written by the `/auto
 of `docs/designs/v1-launch.md` on 2026-09-06; each item was considered for 1.0.0 and
 deliberately left out.
 
+## P1
+
+### 0. `go` cannot address a repeat item
+
+**What:** a navigation target that names an item of a repeat group, so a host can jump
+straight to the second passenger rather than entering at the first and advancing.
+**Why:** `enter` takes `items.keys[0]` and there is no way to say which
+(`packages/core/src/v1/groups.ts`), so "revisit any passenger" — the behaviour R-C exists to
+prove — has to be built out of `go('people')` followed by `next()` until the frame's key
+matches. That works here because every step it passes was already answered, and it would not
+work in a flow with validators between.
+**Context:** the workaround is `goToPassenger` in
+`examples/reference/src/passengers/party.ts`, written so the cost is visible rather than
+hidden. A shape worth considering is `go({ to: 'people', key: 'p2' })`, which keeps the
+existing signature for every flat target.
+**Effort:** human M / CC ~45m. **Raised by:** building R-C for S3 on 2026-09-08.
+
 ## P2
 
 ### 1. `url-sync` plugin (`?step=payment`)

--- a/e2e/tests/site/examples-passengers.spec.ts
+++ b/e2e/tests/site/examples-passengers.spec.ts
@@ -109,6 +109,48 @@ test.describe('R-C passengers', () => {
     await expect(stack(page)).toHaveText('trip.people[p2] / passenger.seat');
   });
 
+  test('books the trip, and stops offering to navigate once it is booked', async ({ page }) => {
+    await page.goto(REACT);
+    await expect(page.getByRole('button', { name: 'Next' })).toBeEnabled();
+    await page.getByRole('button', { name: 'Next' }).click();
+    await answer(page, 'Window', 'Standard');
+    await expect(page.getByRole('heading', { name: 'Review' })).toBeVisible();
+
+    await page.getByRole('button', { name: 'Book the trip' }).click();
+    // Scoped to the running application: the page also prints its source, so
+    // an unscoped text match finds the sentence in the code block as well.
+    await expect(
+      page.locator('.app').getByText('Booked. Nothing below moves until this one starts again.')
+    ).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Book the trip' })).toHaveCount(0);
+
+    await page.getByRole('button', { name: 'Start again' }).click();
+    await expect(page.getByRole('heading', { name: 'Who is travelling' })).toBeVisible();
+  });
+
+  test('does not hand a new passenger the answers of a removed one', async ({ page }) => {
+    await page.goto(REACT);
+    await expect(page.getByRole('button', { name: 'Next' })).toBeEnabled();
+    await party(page);
+    await answer(page, 'Window', 'Standard');
+    await answer(page, 'Aisle', 'Vegetarian');
+    await answer(page, 'Window', 'None');
+
+    await page.getByRole('button', { name: 'Change who is travelling' }).click();
+    await page.getByRole('button', { name: 'Remove' }).nth(2).click();
+    await page.getByRole('button', { name: 'Add a passenger' }).click();
+
+    // The list, then two steps each for the two passengers in front.
+    for (let i = 0; i < 5; i++) await page.getByRole('button', { name: 'Next' }).click();
+    await expect(where(page)).toContainText('Passenger 3 of 3');
+    // A key is a data path: removing somebody removes their answers, so the
+    // person given that key next starts empty rather than in their seat.
+    await expect(page.getByRole('button', { name: 'Window', exact: true })).toHaveAttribute(
+      'aria-pressed',
+      'false'
+    );
+  });
+
   test('the Vue page runs the same block', async ({ page }) => {
     await page.goto(VUE);
     await expect(page.getByRole('button', { name: 'Next' })).toBeEnabled();

--- a/e2e/tests/site/examples-passengers.spec.ts
+++ b/e2e/tests/site/examples-passengers.spec.ts
@@ -1,0 +1,148 @@
+import AxeBuilder from '@axe-core/playwright';
+import type { Page } from '@playwright/test';
+
+import { expect, test } from '../../fixtures/base';
+
+/**
+ * R-C, in a browser, on both bindings.
+ *
+ * The claims are about identity rather than about counting: the second
+ * passenger is still the second passenger after the third is finished, and
+ * still themselves after the one in front of them is removed.
+ */
+const REACT = 'examples/passengers/';
+const VUE = 'examples/passengers/vue/';
+
+const stack = (page: Page) => page.locator('.app-state dd').first();
+const where = (page: Page) => page.locator('.app-where');
+
+/** Names three passengers and enters the block. */
+async function party(page: Page): Promise<void> {
+  await page.getByRole('button', { name: 'Add a passenger' }).click();
+  await page.getByRole('button', { name: 'Add a passenger' }).click();
+  const names = page.locator('.party input');
+  await names.nth(0).fill('Ada');
+  await names.nth(1).fill('Grace');
+  await names.nth(2).fill('Alan');
+  await page.getByRole('button', { name: 'Next' }).click();
+}
+
+/** Answers the passenger on screen and moves on. */
+async function answer(page: Page, seat: string, meal: string): Promise<void> {
+  await page.getByRole('button', { name: seat, exact: true }).click();
+  await page.getByRole('button', { name: 'Next' }).click();
+  await page.getByRole('button', { name: meal, exact: true }).click();
+  await page.getByRole('button', { name: 'Next' }).click();
+}
+
+test.describe('R-C passengers', () => {
+  test('draws the list before it hydrates, with the controls disabled', async ({
+    page,
+    browser,
+  }) => {
+    const context = await browser.newContext({ javaScriptEnabled: false });
+    const still = await context.newPage();
+    await still.goto(REACT);
+
+    await expect(still.getByRole('heading', { name: 'Who is travelling' })).toBeVisible();
+    await expect(still.getByRole('button', { name: 'Next' })).toBeDisabled();
+    await expect(still.getByRole('status')).toHaveText('Starting.');
+    await context.close();
+
+    await page.goto(REACT);
+    await expect(page.getByRole('button', { name: 'Next' })).toBeEnabled();
+  });
+
+  test('runs the block once per passenger and reviews them all', async ({ page }) => {
+    await page.goto(REACT);
+    await expect(page.getByRole('button', { name: 'Next' })).toBeEnabled();
+    await party(page);
+
+    await expect(where(page)).toContainText('Passenger 1 of 3, Ada');
+    // Two frames deep inside a group: the one that names the item, and the
+    // child step it is standing on.
+    await expect(stack(page)).toHaveText('trip.people[p1] / passenger.seat');
+
+    await answer(page, 'Window', 'Standard');
+    await expect(where(page)).toContainText('Passenger 2 of 3, Grace');
+    await answer(page, 'Aisle', 'Vegetarian');
+    await expect(where(page)).toContainText('Passenger 3 of 3, Alan');
+    await answer(page, 'Window', 'None');
+
+    await expect(page.getByRole('heading', { name: 'Review' })).toBeVisible();
+    await expect(page.getByRole('row', { name: /Grace/ })).toContainText('Vegetarian');
+  });
+
+  test('goes back into the second passenger after the third is finished', async ({ page }) => {
+    await page.goto(REACT);
+    await expect(page.getByRole('button', { name: 'Next' })).toBeEnabled();
+    await party(page);
+    await answer(page, 'Window', 'Standard');
+    await answer(page, 'Aisle', 'Vegetarian');
+    await answer(page, 'Window', 'None');
+
+    await page.getByRole('button', { name: 'Edit Grace' }).click();
+    await expect(where(page)).toContainText('Passenger 2 of 3, Grace');
+    await expect(stack(page)).toHaveText('trip.people[p2] / passenger.seat');
+    // The answer is where it was left, addressed by key rather than by index.
+    await expect(page.getByRole('button', { name: 'Aisle', exact: true })).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    );
+  });
+
+  test('keeps a passenger themselves when the one in front is removed', async ({ page }) => {
+    await page.goto(REACT);
+    await expect(page.getByRole('button', { name: 'Next' })).toBeEnabled();
+    await party(page);
+    await answer(page, 'Window', 'Standard');
+    await answer(page, 'Aisle', 'Vegetarian');
+    await answer(page, 'Window', 'None');
+
+    await page.getByRole('button', { name: 'Change who is travelling' }).click();
+    await expect(page.getByRole('heading', { name: 'Who is travelling' })).toBeVisible();
+    await page.getByRole('button', { name: 'Remove' }).first().click();
+
+    await page.getByRole('button', { name: 'Next' }).click();
+    // Grace is first now, and still Grace: the index moved, the key did not.
+    await expect(where(page)).toContainText('Passenger 1 of 2, Grace');
+    await expect(stack(page)).toHaveText('trip.people[p2] / passenger.seat');
+  });
+
+  test('the Vue page runs the same block', async ({ page }) => {
+    await page.goto(VUE);
+    await expect(page.getByRole('button', { name: 'Next' })).toBeEnabled();
+    await party(page);
+
+    await expect(where(page)).toContainText('Passenger 1 of 3, Ada');
+    await expect(stack(page)).toHaveText('trip.people[p1] / passenger.seat');
+  });
+
+  test('each page downloads one runtime and not the other', async ({ page }) => {
+    const bodies: Promise<string>[] = [];
+    page.on('response', (response) => {
+      if (response.url().endsWith('.js')) bodies.push(response.text().catch(() => ''));
+    });
+
+    await page.goto(VUE);
+    await expect(page.getByRole('button', { name: 'Next' })).toBeEnabled();
+    const scripts = (await Promise.all(bodies)).join('');
+    expect(scripts).toContain('__vue_app__');
+    expect(scripts).not.toContain('__reactContainer$');
+  });
+
+  for (const [name, path] of [
+    ['React', REACT],
+    ['Vue', VUE],
+  ] as const) {
+    test(`the ${name} page has no accessibility violations`, async ({ page }) => {
+      await page.goto(path);
+      await expect(page.getByRole('button', { name: 'Next' })).toBeEnabled();
+
+      const results = await new AxeBuilder({ page })
+        .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'])
+        .analyze();
+      expect(results.violations).toEqual([]);
+    });
+  }
+});

--- a/examples/reference/src/passengers/App.tsx
+++ b/examples/reference/src/passengers/App.tsx
@@ -8,8 +8,16 @@ import {
 } from '@wizzard-packages/react/v1';
 import { useEffect, useRef, useState, type ReactNode } from 'react';
 
-import { answerPath, subFlows, trip } from './flow';
-import { goToPassenger, keyOf, listOf, nextId, type Passenger } from './party';
+import { answerPath, initialData, subFlows, trip } from './flow';
+import {
+  answersOf,
+  goToPassenger,
+  keyOf,
+  listOf,
+  nextId,
+  withoutAnswers,
+  type Passenger,
+} from './party';
 
 /**
  * R-C on the React binding: one block of steps per passenger.
@@ -28,12 +36,7 @@ const MEALS = ['Standard', 'Vegetarian', 'None'] as const;
 
 export default function PassengersApp(): ReactNode {
   return (
-    <WizardProvider
-      flow={trip}
-      groups={groups}
-      subFlows={subFlows}
-      data={{ passengers: [{ id: 'p1', name: 'Ada' }] }}
-    >
+    <WizardProvider flow={trip} groups={groups} subFlows={subFlows} data={initialData()}>
       <Trip />
     </WizardProvider>
   );
@@ -65,10 +68,16 @@ function Trip(): ReactNode {
     heading.current?.focus();
   }, [current]);
 
-  const answers = (id: string): { seat?: string; meal?: string } => {
-    const all = data['answers'] as Record<string, { seat?: string; meal?: string }> | undefined;
-    return all?.[id] ?? {};
-  };
+  // Reaching the end does not move the wizard: it stays on the last step and
+  // says `to: '@end'`. What changed is `status`.
+  // `status` and not `completed`: a forward `go` marks the step it left as
+  // completed, and Edit jumps away from Review, so `completed` would call the
+  // trip booked the moment somebody went back to change a seat. Nothing here is
+  // persisted, so `status` - which `toSnapshot` does not carry - is exactly
+  // right for this application and wrong for the one that reloads.
+  const finished = useWizardSelector((s) => s.status === 'done');
+
+  const answers = (id: string): { seat?: string; meal?: string } => answersOf(data)[id] ?? {};
 
   const choose = (field: 'seat' | 'meal', value: string): void => {
     if (key === null) return;
@@ -76,16 +85,21 @@ function Trip(): ReactNode {
   };
 
   const addPassenger = (): void => {
-    const added = { id: nextId(list), name: '' };
-    wizard.set('passengers', [...list, added]);
+    wizard.set('passengers', [...list, { id: nextId(list, answersOf(data)), name: '' }]);
     setAnnouncement(`Passenger ${list.length + 1} added.`);
   };
 
   const removePassenger = (id: string): void => {
-    wizard.set(
-      'passengers',
-      list.filter((p) => p.id !== id)
-    );
+    // Their answers go with them, in one commit: a key is a data path, and
+    // leaving `answers.p3` behind is how the next passenger to be given that
+    // key would inherit somebody else's seat.
+    wizard.batch(() => {
+      wizard.set(
+        'passengers',
+        list.filter((p) => p.id !== id)
+      );
+      wizard.set('answers', withoutAnswers(data, id));
+    });
     setAnnouncement(`Passenger removed. ${list.length - 1} left.`);
   };
 
@@ -98,8 +112,17 @@ function Trip(): ReactNode {
 
   async function onNext(): Promise<void> {
     const result = await wizard.next();
-    if (result.ok) return;
+    if (result.ok) {
+      if (result.to === '@end') setAnnouncement('Booked.');
+      return;
+    }
     setAnnouncement(`That move was refused: ${result.reason}.`);
+  }
+
+  async function startAgain(): Promise<void> {
+    setAnnouncement('');
+    wizard.reset(initialData());
+    await wizard.start();
   }
 
   async function edit(id: string): Promise<void> {
@@ -217,41 +240,59 @@ function Trip(): ReactNode {
             </tbody>
           </table>
 
-          <div className="actions">
-            <button
-              className="button button-secondary"
-              type="button"
-              onClick={() => {
-                void wizard.go('party');
-              }}
-            >
-              Change who is travelling
-            </button>
-          </div>
+          {finished && <p>Booked. Nothing below moves until this one starts again.</p>}
+
+          {!finished && (
+            <div className="actions">
+              <button
+                className="button button-secondary"
+                type="button"
+                onClick={() => {
+                  void wizard.go('party');
+                }}
+              >
+                Change who is travelling
+              </button>
+            </div>
+          )}
         </>
       )}
 
       <div className="actions">
-        <button
-          className="button button-accent"
-          type="button"
-          disabled={current === null || isBusy}
-          onClick={() => {
-            void onNext();
-          }}
-        >
-          Next
-        </button>
-        <button
-          className="button button-secondary"
-          type="button"
-          disabled={current === null || !canBack || isBusy}
-          onClick={() => {
-            void back();
-          }}
-        >
-          Back
-        </button>
+        {finished ? (
+          <button
+            className="button button-accent"
+            type="button"
+            onClick={() => {
+              void startAgain();
+            }}
+          >
+            Start again
+          </button>
+        ) : (
+          <>
+            <button
+              className="button button-accent"
+              type="button"
+              disabled={current === null || isBusy}
+              onClick={() => {
+                void onNext();
+              }}
+            >
+              {standing === 'review' ? 'Book the trip' : 'Next'}
+            </button>
+            <button
+              className="button button-secondary"
+              type="button"
+              disabled={current === null || !canBack || isBusy}
+              onClick={() => {
+                void back();
+              }}
+            >
+              Back
+            </button>
+          </>
+        )}
       </div>
 
       <dl className="app-state">

--- a/examples/reference/src/passengers/App.tsx
+++ b/examples/reference/src/passengers/App.tsx
@@ -1,0 +1,305 @@
+import { groups } from '@wizzard-packages/core/groups';
+import {
+  WizardProvider,
+  useNavigation,
+  useStep,
+  useWizard,
+  useWizardSelector,
+} from '@wizzard-packages/react/v1';
+import { useEffect, useRef, useState, type ReactNode } from 'react';
+
+import { answerPath, subFlows, trip } from './flow';
+import { goToPassenger, keyOf, listOf, nextId, type Passenger } from './party';
+
+/**
+ * R-C on the React binding: one block of steps per passenger.
+ *
+ * The rendering draws three things - the list, one passenger's question, and
+ * the review - and the engine decides which. It never counts passengers to work
+ * out where it is: the frame carries the key, and everything on screen is read
+ * from that.
+ *
+ * Traversal is installed rather than imported by the engine. A flat flow pays
+ * nothing for the machinery that walks sub-flows, so a flow that contains a
+ * group has to be handed it.
+ */
+const SEATS = ['Window', 'Aisle'] as const;
+const MEALS = ['Standard', 'Vegetarian', 'None'] as const;
+
+export default function PassengersApp(): ReactNode {
+  return (
+    <WizardProvider
+      flow={trip}
+      groups={groups}
+      subFlows={subFlows}
+      data={{ passengers: [{ id: 'p1', name: 'Ada' }] }}
+    >
+      <Trip />
+    </WizardProvider>
+  );
+}
+
+function Trip(): ReactNode {
+  const wizard = useWizard();
+  const { current, active, index } = useStep();
+  const { back, canBack, isBusy } = useNavigation();
+
+  const data = useWizardSelector((s) => s.data);
+  const stack = useWizardSelector((s) => s.stack);
+
+  const [announcement, setAnnouncement] = useState('');
+  const heading = useRef<HTMLHeadingElement>(null);
+
+  const list = listOf(data);
+  const key = keyOf(stack);
+  const at = key === null ? -1 : list.findIndex((p) => p.id === key);
+  const standing = current ?? active[0] ?? 'party';
+
+  const moved = useRef(false);
+  useEffect(() => {
+    if (current === null) return;
+    if (!moved.current) {
+      moved.current = true;
+      return;
+    }
+    heading.current?.focus();
+  }, [current]);
+
+  const answers = (id: string): { seat?: string; meal?: string } => {
+    const all = data['answers'] as Record<string, { seat?: string; meal?: string }> | undefined;
+    return all?.[id] ?? {};
+  };
+
+  const choose = (field: 'seat' | 'meal', value: string): void => {
+    if (key === null) return;
+    wizard.set(answerPath(key, field), value);
+  };
+
+  const addPassenger = (): void => {
+    const added = { id: nextId(list), name: '' };
+    wizard.set('passengers', [...list, added]);
+    setAnnouncement(`Passenger ${list.length + 1} added.`);
+  };
+
+  const removePassenger = (id: string): void => {
+    wizard.set(
+      'passengers',
+      list.filter((p) => p.id !== id)
+    );
+    setAnnouncement(`Passenger removed. ${list.length - 1} left.`);
+  };
+
+  const rename = (id: string, name: string): void => {
+    wizard.set(
+      'passengers',
+      list.map((p) => (p.id === id ? { ...p, name } : p))
+    );
+  };
+
+  async function onNext(): Promise<void> {
+    const result = await wizard.next();
+    if (result.ok) return;
+    setAnnouncement(`That move was refused: ${result.reason}.`);
+  }
+
+  async function edit(id: string): Promise<void> {
+    const reached = await goToPassenger(wizard, id);
+    setAnnouncement(
+      reached ? `Editing ${nameOf(list, id)}.` : `Could not reach ${nameOf(list, id)}.`
+    );
+  }
+
+  return (
+    <div className="app">
+      {standing === 'party' && (
+        <>
+          <h2 ref={heading} tabIndex={-1}>
+            Who is travelling
+          </h2>
+          <p>
+            Each passenger answers the same two questions. The definition says so once; the engine
+            runs the block as many times as there are people in this list.
+          </p>
+
+          <ul className="party">
+            {list.map((person, position) => (
+              <li key={person.id}>
+                <label className="field">
+                  <span className="field-label">Passenger {position + 1}</span>
+                  <input
+                    value={person.name}
+                    placeholder="Name"
+                    onChange={(e) => {
+                      rename(person.id, e.target.value);
+                    }}
+                  />
+                </label>
+                <button
+                  className="button button-secondary"
+                  type="button"
+                  onClick={() => {
+                    removePassenger(person.id);
+                  }}
+                >
+                  Remove
+                </button>
+              </li>
+            ))}
+          </ul>
+
+          <div className="actions">
+            <button className="button button-secondary" type="button" onClick={addPassenger}>
+              Add a passenger
+            </button>
+          </div>
+        </>
+      )}
+
+      {(standing === 'seat' || standing === 'meal') && key !== null && (
+        <>
+          <p className="app-where">
+            Passenger {at + 1} of {list.length}
+            {nameOf(list, key) === '' ? '' : `, ${nameOf(list, key)}`} &mdash; step {index + 1} of{' '}
+            {active.length}
+          </p>
+          <h2 ref={heading} tabIndex={-1}>
+            {standing === 'seat' ? 'Seat' : 'Meal'}
+          </h2>
+
+          <Choice
+            label={standing === 'seat' ? 'Where would they sit' : 'What would they eat'}
+            options={standing === 'seat' ? SEATS : MEALS}
+            value={standing === 'seat' ? answers(key).seat : answers(key).meal}
+            onChoose={(value) => {
+              choose(standing, value);
+            }}
+          />
+        </>
+      )}
+
+      {standing === 'review' && (
+        <>
+          <h2 ref={heading} tabIndex={-1}>
+            Review
+          </h2>
+          <table className="party-review">
+            <thead>
+              <tr>
+                <th scope="col">Passenger</th>
+                <th scope="col">Seat</th>
+                <th scope="col">Meal</th>
+                <th scope="col">
+                  <span className="visually-hidden">Actions</span>
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {list.map((person, position) => (
+                <tr key={person.id}>
+                  <th scope="row">
+                    {person.name === '' ? `Passenger ${position + 1}` : person.name}
+                  </th>
+                  <td>{answers(person.id).seat ?? 'not chosen'}</td>
+                  <td>{answers(person.id).meal ?? 'not chosen'}</td>
+                  <td>
+                    <button
+                      className="button button-secondary"
+                      type="button"
+                      onClick={() => {
+                        void edit(person.id);
+                      }}
+                    >
+                      Edit {person.name === '' ? `passenger ${position + 1}` : person.name}
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+
+          <div className="actions">
+            <button
+              className="button button-secondary"
+              type="button"
+              onClick={() => {
+                void wizard.go('party');
+              }}
+            >
+              Change who is travelling
+            </button>
+          </div>
+        </>
+      )}
+
+      <div className="actions">
+        <button
+          className="button button-accent"
+          type="button"
+          disabled={current === null || isBusy}
+          onClick={() => {
+            void onNext();
+          }}
+        >
+          Next
+        </button>
+        <button
+          className="button button-secondary"
+          type="button"
+          disabled={current === null || !canBack || isBusy}
+          onClick={() => {
+            void back();
+          }}
+        >
+          Back
+        </button>
+      </div>
+
+      <dl className="app-state">
+        <dt>stack</dt>
+        <dd>{stack.map((frame) => printFrame(frame)).join(' / ') || 'not started'}</dd>
+        <dt>passengers</dt>
+        <dd>{list.length === 0 ? 'none' : list.map((p) => p.id).join(', ')}</dd>
+      </dl>
+
+      <p className="app-live" role="status" aria-live="polite">
+        {current === null ? 'Starting.' : announcement}
+      </p>
+    </div>
+  );
+}
+
+const nameOf = (list: readonly Passenger[], id: string): string =>
+  list.find((p) => p.id === id)?.name ?? '';
+
+/** The stack, printed the way the engine holds it: enclosing frames, then the step. */
+const printFrame = (frame: { flow: string; step: string; key?: string }): string =>
+  frame.key === undefined
+    ? `${frame.flow}.${frame.step}`
+    : `${frame.flow}.${frame.step}[${frame.key}]`;
+
+function Choice(props: {
+  label: string;
+  options: readonly string[];
+  value: string | undefined;
+  onChoose: (value: string) => void;
+}): ReactNode {
+  return (
+    <fieldset className="field">
+      <legend className="field-label">{props.label}</legend>
+      <div className="segmented">
+        {props.options.map((option) => (
+          <button
+            key={option}
+            type="button"
+            aria-pressed={props.value === option}
+            onClick={() => {
+              props.onChoose(option);
+            }}
+          >
+            {option}
+          </button>
+        ))}
+      </div>
+    </fieldset>
+  );
+}

--- a/examples/reference/src/passengers/App.vue
+++ b/examples/reference/src/passengers/App.vue
@@ -3,7 +3,7 @@ import { groups } from '@wizzard-packages/core/groups';
 import { provideWizard } from '@wizzard-packages/vue/v1';
 
 import Trip from './Trip.vue';
-import { subFlows, trip } from './flow';
+import { initialData, subFlows, trip } from './flow';
 
 // Traversal is installed rather than imported by the engine: a flat flow pays
 // nothing for the machinery that walks sub-flows, so a flow that contains a
@@ -12,7 +12,7 @@ provideWizard({
   flow: trip,
   groups,
   subFlows,
-  data: { passengers: [{ id: 'p1', name: 'Ada' }] },
+  data: initialData(),
 });
 </script>
 

--- a/examples/reference/src/passengers/App.vue
+++ b/examples/reference/src/passengers/App.vue
@@ -1,0 +1,21 @@
+<script setup lang="ts">
+import { groups } from '@wizzard-packages/core/groups';
+import { provideWizard } from '@wizzard-packages/vue/v1';
+
+import Trip from './Trip.vue';
+import { subFlows, trip } from './flow';
+
+// Traversal is installed rather than imported by the engine: a flat flow pays
+// nothing for the machinery that walks sub-flows, so a flow that contains a
+// group has to be handed it.
+provideWizard({
+  flow: trip,
+  groups,
+  subFlows,
+  data: { passengers: [{ id: 'p1', name: 'Ada' }] },
+});
+</script>
+
+<template>
+  <Trip />
+</template>

--- a/examples/reference/src/passengers/Trip.vue
+++ b/examples/reference/src/passengers/Trip.vue
@@ -2,8 +2,16 @@
 import { useNavigation, useStep, useWizard, useWizardSelector } from '@wizzard-packages/vue/v1';
 import { computed, ref, useTemplateRef, watch } from 'vue';
 
-import { answerPath } from './flow';
-import { goToPassenger, keyOf, listOf, nextId, type Passenger } from './party';
+import { answerPath, initialData } from './flow';
+import {
+  answersOf,
+  goToPassenger,
+  keyOf,
+  listOf,
+  nextId,
+  withoutAnswers,
+  type Passenger,
+} from './party';
 
 /**
  * R-C on the Vue binding. The same application as `App.tsx`: the rendering
@@ -30,16 +38,23 @@ const at = computed(() =>
   itemKey.value === null ? -1 : list.value.findIndex((p) => p.id === itemKey.value)
 );
 const standing = computed(() => current.value ?? active.value[0] ?? 'party');
+// Reaching the end does not move the wizard: it stays on the last step and says
+// `to: '@end'`. What changed is `status`.
+//
+// `status` and not `completed`: a forward `go` marks the step it left as
+// completed, and Edit jumps away from Review, so `completed` would call the trip
+// booked the moment somebody went back to change a seat. Nothing here is
+// persisted, so `status` - which `toSnapshot` does not carry - is exactly right
+// for this application and wrong for the one that reloads.
+const finished = useWizardSelector((s) => s.status === 'done');
 
 watch(current, (to) => {
   if (to === null) return;
   heading.value?.focus();
 });
 
-const answersOf = (id: string): { seat?: string; meal?: string } => {
-  const all = data.value['answers'] as Record<string, { seat?: string; meal?: string }> | undefined;
-  return all?.[id] ?? {};
-};
+const answersFor = (id: string): { seat?: string; meal?: string } =>
+  answersOf(data.value)[id] ?? {};
 
 const nameOf = (id: string): string => list.value.find((p) => p.id === id)?.name ?? '';
 
@@ -49,18 +64,27 @@ const choose = (field: 'seat' | 'meal', value: string): void => {
 };
 
 const chosen = (field: 'seat' | 'meal'): string | undefined =>
-  itemKey.value === null ? undefined : answersOf(itemKey.value)[field];
+  itemKey.value === null ? undefined : answersFor(itemKey.value)[field];
 
 const addPassenger = (): void => {
-  wizard.set('passengers', [...list.value, { id: nextId(list.value), name: '' }]);
+  wizard.set('passengers', [
+    ...list.value,
+    { id: nextId(list.value, answersOf(data.value)), name: '' },
+  ]);
   announcement.value = `Passenger ${list.value.length} added.`;
 };
 
 const removePassenger = (id: string): void => {
-  wizard.set(
-    'passengers',
-    list.value.filter((p: Passenger) => p.id !== id)
-  );
+  // Their answers go with them, in one commit: a key is a data path, and
+  // leaving `answers.p3` behind is how the next passenger to be given that key
+  // would inherit somebody else's seat.
+  wizard.batch(() => {
+    wizard.set(
+      'passengers',
+      list.value.filter((p: Passenger) => p.id !== id)
+    );
+    wizard.set('answers', withoutAnswers(data.value, id));
+  });
   announcement.value = `Passenger removed. ${list.value.length} left.`;
 };
 
@@ -73,7 +97,17 @@ const rename = (id: string, name: string): void => {
 
 async function onNext(): Promise<void> {
   const result = await wizard.next();
-  if (!result.ok) announcement.value = `That move was refused: ${result.reason}.`;
+  if (result.ok) {
+    if (result.to === '@end') announcement.value = 'Booked.';
+    return;
+  }
+  announcement.value = `That move was refused: ${result.reason}.`;
+}
+
+async function startAgain(): Promise<void> {
+  announcement.value = '';
+  wizard.reset(initialData());
+  await wizard.start();
 }
 
 async function edit(id: string): Promise<void> {
@@ -161,8 +195,8 @@ const printFrame = (frame: { flow: string; step: string; key?: string }): string
             <th scope="row">
               {{ person.name === '' ? `Passenger ${position + 1}` : person.name }}
             </th>
-            <td>{{ answersOf(person.id).seat ?? 'not chosen' }}</td>
-            <td>{{ answersOf(person.id).meal ?? 'not chosen' }}</td>
+            <td>{{ answersFor(person.id).seat ?? 'not chosen' }}</td>
+            <td>{{ answersFor(person.id).meal ?? 'not chosen' }}</td>
             <td>
               <button class="button button-secondary" type="button" @click="edit(person.id)">
                 Edit {{ person.name === '' ? `passenger ${position + 1}` : person.name }}
@@ -172,7 +206,9 @@ const printFrame = (frame: { flow: string; step: string; key?: string }): string
         </tbody>
       </table>
 
-      <div class="actions">
+      <p v-if="finished">Booked. Nothing below moves until this one starts again.</p>
+
+      <div v-else class="actions">
         <button class="button button-secondary" type="button" @click="wizard.go('party')">
           Change who is travelling
         </button>
@@ -180,22 +216,27 @@ const printFrame = (frame: { flow: string; step: string; key?: string }): string
     </template>
 
     <div class="actions">
-      <button
-        class="button button-accent"
-        type="button"
-        :disabled="current === null || isBusy"
-        @click="onNext()"
-      >
-        Next
+      <button v-if="finished" class="button button-accent" type="button" @click="startAgain()">
+        Start again
       </button>
-      <button
-        class="button button-secondary"
-        type="button"
-        :disabled="current === null || !canBack || isBusy"
-        @click="back()"
-      >
-        Back
-      </button>
+      <template v-else>
+        <button
+          class="button button-accent"
+          type="button"
+          :disabled="current === null || isBusy"
+          @click="onNext()"
+        >
+          {{ standing === 'review' ? 'Book the trip' : 'Next' }}
+        </button>
+        <button
+          class="button button-secondary"
+          type="button"
+          :disabled="current === null || !canBack || isBusy"
+          @click="back()"
+        >
+          Back
+        </button>
+      </template>
     </div>
 
     <dl class="app-state">

--- a/examples/reference/src/passengers/Trip.vue
+++ b/examples/reference/src/passengers/Trip.vue
@@ -1,0 +1,212 @@
+<script setup lang="ts">
+import { useNavigation, useStep, useWizard, useWizardSelector } from '@wizzard-packages/vue/v1';
+import { computed, ref, useTemplateRef, watch } from 'vue';
+
+import { answerPath } from './flow';
+import { goToPassenger, keyOf, listOf, nextId, type Passenger } from './party';
+
+/**
+ * R-C on the Vue binding. The same application as `App.tsx`: the rendering
+ * draws the list, one passenger's question, or the review, and the engine
+ * decides which. It never counts passengers to work out where it is - the frame
+ * carries the key, and everything on screen is read from that.
+ */
+const SEATS = ['Window', 'Aisle'];
+const MEALS = ['Standard', 'Vegetarian', 'None'];
+
+const wizard = useWizard();
+const { current, active, index } = useStep();
+const { back, canBack, isBusy } = useNavigation();
+
+const data = useWizardSelector((s) => s.data);
+const stack = useWizardSelector((s) => s.stack);
+
+const announcement = ref('');
+const heading = useTemplateRef<HTMLHeadingElement>('heading');
+
+const list = computed(() => listOf(data.value));
+const itemKey = computed(() => keyOf(stack.value));
+const at = computed(() =>
+  itemKey.value === null ? -1 : list.value.findIndex((p) => p.id === itemKey.value)
+);
+const standing = computed(() => current.value ?? active.value[0] ?? 'party');
+
+watch(current, (to) => {
+  if (to === null) return;
+  heading.value?.focus();
+});
+
+const answersOf = (id: string): { seat?: string; meal?: string } => {
+  const all = data.value['answers'] as Record<string, { seat?: string; meal?: string }> | undefined;
+  return all?.[id] ?? {};
+};
+
+const nameOf = (id: string): string => list.value.find((p) => p.id === id)?.name ?? '';
+
+const choose = (field: 'seat' | 'meal', value: string): void => {
+  if (itemKey.value === null) return;
+  wizard.set(answerPath(itemKey.value, field), value);
+};
+
+const chosen = (field: 'seat' | 'meal'): string | undefined =>
+  itemKey.value === null ? undefined : answersOf(itemKey.value)[field];
+
+const addPassenger = (): void => {
+  wizard.set('passengers', [...list.value, { id: nextId(list.value), name: '' }]);
+  announcement.value = `Passenger ${list.value.length} added.`;
+};
+
+const removePassenger = (id: string): void => {
+  wizard.set(
+    'passengers',
+    list.value.filter((p: Passenger) => p.id !== id)
+  );
+  announcement.value = `Passenger removed. ${list.value.length} left.`;
+};
+
+const rename = (id: string, name: string): void => {
+  wizard.set(
+    'passengers',
+    list.value.map((p: Passenger) => (p.id === id ? { ...p, name } : p))
+  );
+};
+
+async function onNext(): Promise<void> {
+  const result = await wizard.next();
+  if (!result.ok) announcement.value = `That move was refused: ${result.reason}.`;
+}
+
+async function edit(id: string): Promise<void> {
+  const reached = await goToPassenger(wizard, id);
+  announcement.value = reached ? `Editing ${nameOf(id)}.` : `Could not reach ${nameOf(id)}.`;
+}
+
+const printFrame = (frame: { flow: string; step: string; key?: string }): string =>
+  frame.key === undefined
+    ? `${frame.flow}.${frame.step}`
+    : `${frame.flow}.${frame.step}[${frame.key}]`;
+</script>
+
+<template>
+  <div class="app">
+    <template v-if="standing === 'party'">
+      <h2 ref="heading" tabindex="-1">Who is travelling</h2>
+      <p>
+        Each passenger answers the same two questions. The definition says so once; the engine runs
+        the block as many times as there are people in this list.
+      </p>
+
+      <ul class="party">
+        <li v-for="(person, position) in list" :key="person.id">
+          <label class="field">
+            <span class="field-label">Passenger {{ position + 1 }}</span>
+            <input
+              :value="person.name"
+              placeholder="Name"
+              @input="rename(person.id, ($event.target as HTMLInputElement).value)"
+            />
+          </label>
+          <button class="button button-secondary" type="button" @click="removePassenger(person.id)">
+            Remove
+          </button>
+        </li>
+      </ul>
+
+      <div class="actions">
+        <button class="button button-secondary" type="button" @click="addPassenger">
+          Add a passenger
+        </button>
+      </div>
+    </template>
+
+    <template v-else-if="(standing === 'seat' || standing === 'meal') && itemKey !== null">
+      <p class="app-where">
+        Passenger {{ at + 1 }} of {{ list.length
+        }}{{ nameOf(itemKey) === '' ? '' : `, ${nameOf(itemKey)}` }} &mdash; step {{ index + 1 }} of
+        {{ active.length }}
+      </p>
+      <h2 ref="heading" tabindex="-1">{{ standing === 'seat' ? 'Seat' : 'Meal' }}</h2>
+
+      <fieldset class="field">
+        <legend class="field-label">
+          {{ standing === 'seat' ? 'Where would they sit' : 'What would they eat' }}
+        </legend>
+        <div class="segmented">
+          <button
+            v-for="option in standing === 'seat' ? SEATS : MEALS"
+            :key="option"
+            type="button"
+            :aria-pressed="chosen(standing) === option"
+            @click="choose(standing, option)"
+          >
+            {{ option }}
+          </button>
+        </div>
+      </fieldset>
+    </template>
+
+    <template v-else-if="standing === 'review'">
+      <h2 ref="heading" tabindex="-1">Review</h2>
+      <table class="party-review">
+        <thead>
+          <tr>
+            <th scope="col">Passenger</th>
+            <th scope="col">Seat</th>
+            <th scope="col">Meal</th>
+            <th scope="col"><span class="visually-hidden">Actions</span></th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-for="(person, position) in list" :key="person.id">
+            <th scope="row">
+              {{ person.name === '' ? `Passenger ${position + 1}` : person.name }}
+            </th>
+            <td>{{ answersOf(person.id).seat ?? 'not chosen' }}</td>
+            <td>{{ answersOf(person.id).meal ?? 'not chosen' }}</td>
+            <td>
+              <button class="button button-secondary" type="button" @click="edit(person.id)">
+                Edit {{ person.name === '' ? `passenger ${position + 1}` : person.name }}
+              </button>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+
+      <div class="actions">
+        <button class="button button-secondary" type="button" @click="wizard.go('party')">
+          Change who is travelling
+        </button>
+      </div>
+    </template>
+
+    <div class="actions">
+      <button
+        class="button button-accent"
+        type="button"
+        :disabled="current === null || isBusy"
+        @click="onNext()"
+      >
+        Next
+      </button>
+      <button
+        class="button button-secondary"
+        type="button"
+        :disabled="current === null || !canBack || isBusy"
+        @click="back()"
+      >
+        Back
+      </button>
+    </div>
+
+    <dl class="app-state">
+      <dt>stack</dt>
+      <dd>{{ stack.map(printFrame).join(' / ') || 'not started' }}</dd>
+      <dt>passengers</dt>
+      <dd>{{ list.length === 0 ? 'none' : list.map((p: Passenger) => p.id).join(', ') }}</dd>
+    </dl>
+
+    <p class="app-live" role="status" aria-live="polite">
+      {{ current === null ? 'Starting.' : announcement }}
+    </p>
+  </div>
+</template>

--- a/examples/reference/src/passengers/flow.ts
+++ b/examples/reference/src/passengers/flow.ts
@@ -1,0 +1,62 @@
+import { empty, get, not } from '@wizzard-packages/core/expr';
+import { defineFlow, group, step } from '@wizzard-packages/core/v1';
+
+import type { SubFlows } from '@wizzard-packages/core/v1';
+
+/**
+ * R-C: one block of steps per passenger.
+ *
+ * A repeat group is a sub-flow entered once per item, so the two questions each
+ * passenger answers are written once, here, and the engine runs them as many
+ * times as there are passengers. Adding a fourth passenger is a write to
+ * `data.passengers`; nothing in the definition and nothing in the rendering
+ * knows how many there are.
+ */
+export const passenger = defineFlow({
+  id: 'passenger',
+  order: ['seat', 'meal'],
+  steps: {
+    seat: step({ label: 'Seat' }),
+    meal: step({ label: 'Meal' }),
+  },
+  policy: 'free',
+});
+
+export const trip = defineFlow({
+  id: 'trip',
+  version: 1,
+  order: ['party', 'people', 'review'],
+  steps: {
+    party: step({ label: 'Who is travelling' }),
+
+    people: group({
+      label: 'Passengers',
+      flow: 'passenger',
+      // A group is a step, so it answers to its own `when` first: an empty list
+      // means the group is not on the route and the flow walks past it.
+      when: not(empty(get('data.passengers'))),
+      // `keyBy` is what makes a position durable. The index moves when the list
+      // is reordered or one is removed; the key does not, so a frame that names
+      // a key still names the same passenger afterwards.
+      repeat: { over: get('data.passengers'), keyBy: 'id' },
+    }),
+
+    review: step({ label: 'Review' }),
+  },
+  policy: 'free',
+});
+
+/** A string `flow` is resolved here, the way a host resolves any other name. */
+export const subFlows: SubFlows = { passenger };
+
+/**
+ * Where one passenger's answers live.
+ *
+ * The engine does not namespace an item's data: `set` writes the literal path
+ * it is given, and a sub-flow step called `seat` would otherwise write the same
+ * `data.seat` for every passenger. The host decides where the answers go and
+ * builds the path from the item's key, which is what `loop.key` exists for on
+ * the flow side.
+ */
+export const answerPath = (key: string, field: 'seat' | 'meal'): string =>
+  `answers.${key}.${field}`;

--- a/examples/reference/src/passengers/flow.ts
+++ b/examples/reference/src/passengers/flow.ts
@@ -60,3 +60,8 @@ export const subFlows: SubFlows = { passenger };
  */
 export const answerPath = (key: string, field: 'seat' | 'meal'): string =>
   `answers.${key}.${field}`;
+
+/** One passenger to begin with, so the first thing on screen is a list of one. */
+export const initialData = (): Record<string, unknown> => ({
+  passengers: [{ id: 'p1', name: 'Ada' }],
+});

--- a/examples/reference/src/passengers/party.ts
+++ b/examples/reference/src/passengers/party.ts
@@ -1,0 +1,54 @@
+import type { Frame, Wizard } from '@wizzard-packages/core/v1';
+
+/** One row of `data.passengers`. `id` is what `keyBy` reads. */
+export interface Passenger {
+  id: string;
+  name: string;
+}
+
+export const listOf = (data: Readonly<Record<string, unknown>>): readonly Passenger[] =>
+  (data['passengers'] as Passenger[] | undefined) ?? [];
+
+/**
+ * The key of the repeat frame the wizard is standing in, or null outside one.
+ *
+ * The stack is the enclosing frames with the current step last, and only a
+ * repeat frame carries a key - which is how a rendering knows whose answers it
+ * is showing without counting anything itself.
+ */
+export const keyOf = (stack: readonly Frame[]): string | null =>
+  stack.find((frame) => frame.key !== undefined)?.key ?? null;
+
+/** A fresh id. Short, because it ends up in a data path a person may read. */
+export const nextId = (list: readonly Passenger[]): string => {
+  let n = list.length + 1;
+  while (list.some((p) => p.id === `p${n}`)) n += 1;
+  return `p${n}`;
+};
+
+/**
+ * Walks into the group until the frame names `key`.
+ *
+ * **A finding, not a pattern.** `go` addresses a step, never an item: entering
+ * a repeat group always lands on the first one, because `enter` takes
+ * `items.keys[0]` and there is no way to say which. So revisiting the second
+ * passenger after finishing the third means entering and advancing until the
+ * frame's key matches, which is fine here - every step it passes was already
+ * answered - and would not be fine in a flow with validators between.
+ *
+ * What the engine is missing is a target that can name an item, and this
+ * application is the argument for it. Filed in `TODOS.md`.
+ */
+export async function goToPassenger(wizard: Wizard, key: string): Promise<boolean> {
+  const entered = await wizard.go('people');
+  if (!entered.ok) return false;
+
+  // Two steps per passenger, plus the one the entry already used.
+  const hops = listOf(wizard.getState().data).length * 2 + 1;
+  for (let hop = 0; hop < hops; hop++) {
+    if (keyOf(wizard.getState().stack) === key) return true;
+    const moved = await wizard.next();
+    if (!moved.ok || moved.to === '@end') return false;
+  }
+  return false;
+}

--- a/examples/reference/src/passengers/party.ts
+++ b/examples/reference/src/passengers/party.ts
@@ -19,11 +19,38 @@ export const listOf = (data: Readonly<Record<string, unknown>>): readonly Passen
 export const keyOf = (stack: readonly Frame[]): string | null =>
   stack.find((frame) => frame.key !== undefined)?.key ?? null;
 
-/** A fresh id. Short, because it ends up in a data path a person may read. */
-export const nextId = (list: readonly Passenger[]): string => {
+/**
+ * A fresh id, unused by anyone in the list and by anyone who has answered.
+ *
+ * The second half is what makes it correct. A key is a data path, and removing
+ * the last passenger frees `p3` in the list while `answers.p3` is still sitting
+ * there - so an id chosen from the list alone would hand the next passenger
+ * somebody else's seat. The host clears the answers on removal too, and this
+ * looks at both, because either alone is one refactor away from the same bug.
+ */
+export const nextId = (
+  list: readonly Passenger[],
+  answers: Readonly<Record<string, unknown>> = {}
+): string => {
   let n = list.length + 1;
-  while (list.some((p) => p.id === `p${n}`)) n += 1;
+  while (list.some((p) => p.id === `p${n}`) || `p${n}` in answers) n += 1;
   return `p${n}`;
+};
+
+/** Everyone's answers, keyed by passenger. */
+export const answersOf = (
+  data: Readonly<Record<string, unknown>>
+): Readonly<Record<string, { seat?: string; meal?: string }>> =>
+  (data['answers'] as Record<string, { seat?: string; meal?: string }> | undefined) ?? {};
+
+/** The same, without one passenger. Removing a person removes their answers. */
+export const withoutAnswers = (
+  data: Readonly<Record<string, unknown>>,
+  id: string
+): Record<string, { seat?: string; meal?: string }> => {
+  const rest = { ...answersOf(data) };
+  delete rest[id];
+  return rest;
 };
 
 /**

--- a/examples/reference/src/passengers/passengers.test.tsx
+++ b/examples/reference/src/passengers/passengers.test.tsx
@@ -142,6 +142,53 @@ describe('R-C passengers, React', () => {
   });
 });
 
+describe('R-C passengers, the two ways a list goes wrong', () => {
+  it('does not hand a new passenger the answers of a removed one', async () => {
+    render(<PassengersApp />);
+    await act(async () => {});
+    await party(['Ada', 'Grace', 'Alan']);
+    await click('Next');
+    await answer('Window', 'Standard');
+    await answer('Aisle', 'Vegetarian');
+    await answer('Window', 'None');
+    await click('Change who is travelling');
+
+    // Drop the last passenger, who is the one whose key is about to be free.
+    await act(async () => {
+      screen
+        .getAllByRole('button', { name: 'Remove' })[2]
+        ?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    await click('Add a passenger');
+    await act(async () => {});
+
+    for (let i = 0; i < 6 && !where().includes('Passenger 3 of 3'); i++) await click('Next');
+    expect(where()).toContain('Passenger 3 of 3');
+    // A key is a data path. Removing somebody removes their answers, so the
+    // person given that key next starts empty rather than in their seat.
+    expect(screen.getByRole('button', { name: 'Window' }).getAttribute('aria-pressed')).toBe(
+      'false'
+    );
+  });
+
+  it('books the trip and stops navigating once it is booked', async () => {
+    render(<PassengersApp />);
+    await act(async () => {});
+    await click('Next');
+    await answer('Window', 'Standard');
+    expect(heading()).toBe('Review');
+
+    await click('Book the trip');
+    expect(
+      screen.getByText('Booked. Nothing below moves until this one starts again.')
+    ).toBeTruthy();
+    expect(screen.queryByRole('button', { name: 'Book the trip' })).toBeNull();
+
+    await click('Start again');
+    expect(heading()).toBe('Who is travelling');
+  });
+});
+
 describe('R-C passengers, Vue', () => {
   it('runs the same block once per passenger', async () => {
     const app = mount(AppVue, { attachTo: document.createElement('div') });

--- a/examples/reference/src/passengers/passengers.test.tsx
+++ b/examples/reference/src/passengers/passengers.test.tsx
@@ -1,0 +1,167 @@
+import { render, screen } from '@testing-library/react';
+import { flushPromises, mount } from '@vue/test-utils';
+import { act } from 'react';
+import { describe, expect, it } from 'vitest';
+
+import AppVue from './App.vue';
+import PassengersApp from './App';
+
+/**
+ * R-C: a block of steps run once per passenger, and the frame stack that makes
+ * going back into one of them possible.
+ *
+ * The interesting assertions are about identity: the second passenger stays the
+ * second passenger after the third is finished, and stays themselves when one
+ * is removed from in front of them.
+ */
+const click = async (name: string | RegExp): Promise<void> => {
+  await act(async () => {
+    screen.getByRole('button', { name }).dispatchEvent(new MouseEvent('click', { bubbles: true }));
+  });
+};
+
+const type = async (input: HTMLElement, value: string): Promise<void> => {
+  const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')?.set as (
+    this: HTMLInputElement,
+    v: string
+  ) => void;
+  await act(async () => {
+    setter.call(input as HTMLInputElement, value);
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+  });
+};
+
+const heading = (): string => screen.getByRole('heading', { level: 2 }).textContent ?? '';
+const where = (): string => document.querySelector('.app-where')?.textContent ?? '';
+const stack = (): string => document.querySelectorAll('.app-state dd')[0]?.textContent ?? '';
+
+/** Names the passengers already in the list, adding rows until there are `n`. */
+async function party(names: readonly string[]): Promise<void> {
+  for (let i = 1; i < names.length; i++) await click('Add a passenger');
+  const inputs = screen.getAllByRole('textbox');
+  for (const [i, name] of names.entries()) await type(inputs[i] as HTMLElement, name);
+}
+
+/** Answers the passenger on screen and moves on. */
+async function answer(seat: string, meal: string): Promise<void> {
+  await click(seat);
+  await click('Next');
+  await click(meal);
+  await click('Next');
+}
+
+describe('R-C passengers, React', () => {
+  it('runs the block once per passenger and reviews them all', async () => {
+    render(<PassengersApp />);
+    await act(async () => {});
+    expect(heading()).toBe('Who is travelling');
+
+    await party(['Ada', 'Grace', 'Alan']);
+    await click('Next');
+
+    expect(where()).toContain('Passenger 1 of 3, Ada');
+    // The stack is two deep inside a group: the frame that names the item, and
+    // the child step it is standing on.
+    expect(stack()).toBe('trip.people[p1] / passenger.seat');
+    await answer('Window', 'Standard');
+
+    expect(where()).toContain('Passenger 2 of 3, Grace');
+    await answer('Aisle', 'Vegetarian');
+
+    expect(where()).toContain('Passenger 3 of 3, Alan');
+    await answer('Window', 'None');
+
+    expect(heading()).toBe('Review');
+    const rows = screen.getAllByRole('row').slice(1);
+    expect(rows.map((row) => row.textContent)).toEqual([
+      expect.stringContaining('AdaWindowStandard'),
+      expect.stringContaining('GraceAisleVegetarian'),
+      expect.stringContaining('AlanWindowNone'),
+    ]);
+  });
+
+  it('goes back into the second passenger after the third is finished', async () => {
+    render(<PassengersApp />);
+    await act(async () => {});
+    await party(['Ada', 'Grace', 'Alan']);
+    await click('Next');
+    await answer('Window', 'Standard');
+    await answer('Aisle', 'Vegetarian');
+    await answer('Window', 'None');
+    expect(heading()).toBe('Review');
+
+    await click('Edit Grace');
+    expect(where()).toContain('Passenger 2 of 3, Grace');
+    expect(stack()).toBe('trip.people[p2] / passenger.seat');
+    // Their answer is where they left it, addressed by key rather than index.
+    expect(screen.getByRole('button', { name: 'Aisle' }).getAttribute('aria-pressed')).toBe('true');
+
+    await click('Window');
+    await click('Next');
+    expect(heading()).toBe('Meal');
+    expect(screen.getByRole('button', { name: 'Vegetarian' }).getAttribute('aria-pressed')).toBe(
+      'true'
+    );
+  });
+
+  it('keeps a passenger themselves when the one in front is removed', async () => {
+    render(<PassengersApp />);
+    await act(async () => {});
+    await party(['Ada', 'Grace', 'Alan']);
+    await click('Next');
+    await answer('Window', 'Standard');
+    await answer('Aisle', 'Vegetarian');
+    await answer('Window', 'None');
+
+    // `back()` pops whole stacks, so it walks the block in reverse rather than
+    // leaving it. Getting to the list is a jump, which the flow's `free` policy
+    // allows and the review offers.
+    await click('Change who is travelling');
+    expect(heading()).toBe('Who is travelling');
+    // Ada's row is the first one.
+    await act(async () => {
+      screen
+        .getAllByRole('button', { name: 'Remove' })[0]
+        ?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    await click('Next');
+    // Grace is first now, and still Grace: the index moved, the key did not.
+    expect(where()).toContain('Passenger 1 of 2, Grace');
+    expect(screen.getByRole('button', { name: 'Aisle' }).getAttribute('aria-pressed')).toBe('true');
+  });
+
+  it('walks past the group when nobody is travelling', async () => {
+    render(<PassengersApp />);
+    await act(async () => {});
+    await click('Remove');
+    await click('Next');
+    // The group's own `when` is false, so it is not on the route at all.
+    expect(heading()).toBe('Review');
+    expect(stack()).toBe('trip.review');
+  });
+});
+
+describe('R-C passengers, Vue', () => {
+  it('runs the same block once per passenger', async () => {
+    const app = mount(AppVue, { attachTo: document.createElement('div') });
+    await flushPromises();
+    expect(app.get('h2').text()).toBe('Who is travelling');
+
+    const press = async (label: string): Promise<void> => {
+      const button = app.findAll('button').find((b) => b.text() === label);
+      if (button === undefined) throw new Error(`no button named ${label}`);
+      await button.trigger('click');
+      await flushPromises();
+    };
+
+    await press('Add a passenger');
+    await app.findAll('.party input')[0]!.setValue('Ada');
+    await app.findAll('.party input')[1]!.setValue('Grace');
+    await press('Next');
+
+    expect(app.get('.app-where').text()).toContain('Passenger 1 of 2, Ada');
+    expect(app.findAll('.app-state dd')[0]!.text()).toBe('trip.people[p1] / passenger.seat');
+    app.unmount();
+  });
+});

--- a/site/src/islands/PassengersReact.tsx
+++ b/site/src/islands/PassengersReact.tsx
@@ -1,0 +1,26 @@
+import PassengersApp from '@examples/reference/src/passengers/App';
+import { useState, type ReactNode } from 'react';
+
+import { StageBoundary } from '../components/StageBoundary';
+
+/**
+ * R-C, mounted. The site owns the net; the example owns the application.
+ *
+ * The boundary and the remount key live here rather than in the example,
+ * because a reader copying `App.tsx` into their own project is copying an
+ * application, not a page that has to survive a stranger's browser.
+ */
+export default function PassengersReact(): ReactNode {
+  const [attempt, setAttempt] = useState(0);
+
+  return (
+    <StageBoundary
+      resetKey={attempt}
+      onRestart={() => {
+        setAttempt((n) => n + 1);
+      }}
+    >
+      <PassengersApp key={attempt} />
+    </StageBoundary>
+  );
+}

--- a/site/src/islands/PassengersVue.vue
+++ b/site/src/islands/PassengersVue.vue
@@ -1,0 +1,42 @@
+<script setup lang="ts">
+import App from '@examples/reference/src/passengers/App.vue';
+import { onErrorCaptured, ref } from 'vue';
+
+/**
+ * R-C on the Vue binding, mounted. The counterpart of `PassengersReact.tsx`:
+ * the site owns the net, the example owns the application.
+ *
+ * `onErrorCaptured` returning false stops the error propagating to the app
+ * root, which is Vue's equivalent of React's error boundary. Bumping `attempt`
+ * remounts the child, which is what starting the example again means.
+ */
+const failure = ref<string | null>(null);
+const attempt = ref(0);
+
+onErrorCaptured((error) => {
+  failure.value = error instanceof Error ? error.message : String(error);
+  console.error('[example] the application stopped', error);
+  return false;
+});
+
+function restart(): void {
+  failure.value = null;
+  attempt.value += 1;
+}
+</script>
+
+<template>
+  <div v-if="failure !== null" class="stage-failed" role="alert">
+    <p>This example stopped.</p>
+    <p class="stage-failed-why">
+      {{ failure }}
+    </p>
+    <p>
+      The page around it is fine, and so is the flow definition below. Start the example again, or
+      open an issue with what you had typed.
+    </p>
+    <button class="button button-secondary" type="button" @click="restart">Restart example</button>
+  </div>
+
+  <App v-else :key="attempt" />
+</template>

--- a/site/src/pages/examples/index.astro
+++ b/site/src/pages/examples/index.astro
@@ -36,8 +36,8 @@ const APPS = [
     heading: 'Add passengers. Revisit any passenger.',
     blurb:
       'One block of steps per passenger: add and remove them, then go back and edit the second after finishing the third.',
-    proves: ['GroupStep', 'repeat', 'frame stack', 'group entry and exit'],
-    ready: false,
+    proves: ['GroupStep', 'repeat', 'the frame stack', 'keyBy'],
+    ready: true,
   },
 ];
 

--- a/site/src/pages/examples/passengers/index.astro
+++ b/site/src/pages/examples/passengers/index.astro
@@ -1,0 +1,40 @@
+---
+import flowSource from '@examples/reference/src/passengers/flow.ts?raw';
+import partySource from '@examples/reference/src/passengers/party.ts?raw';
+import appSource from '@examples/reference/src/passengers/App.tsx?raw';
+
+import ExampleShell from '../../../components/ExampleShell.astro';
+import PassengersReact from '../../../islands/PassengersReact';
+
+const sources = [
+  {
+    name: 'flow.ts',
+    lang: 'ts' as const,
+    code: flowSource,
+    note: 'A sub-flow, and a group that repeats it once per item. `keyBy` is what makes a position durable: the index moves when the list changes, the key does not.',
+  },
+  {
+    name: 'party.ts',
+    lang: 'ts' as const,
+    code: partySource,
+    note: 'The host half of a repeat: where an item’s answers live, and how a rendering reads the key off the frame. It also carries the one workaround this application needed.',
+  },
+  {
+    name: 'App.tsx',
+    lang: 'tsx' as const,
+    code: appSource,
+    note: 'The rendering draws the list, one passenger’s question, or the review. It never counts passengers to work out where it is.',
+  },
+];
+---
+
+<ExampleShell
+  slug="passengers"
+  ref="R-C"
+  heading="Add passengers. Revisit any passenger."
+  lede="One block of steps per passenger, written once and run as many times as there are people. Add and remove passengers, then go back and edit the second after finishing the third."
+  framework="react"
+  sources={sources}
+>
+  <PassengersReact client:load />
+</ExampleShell>

--- a/site/src/pages/examples/passengers/vue.astro
+++ b/site/src/pages/examples/passengers/vue.astro
@@ -1,0 +1,40 @@
+---
+import flowSource from '@examples/reference/src/passengers/flow.ts?raw';
+import partySource from '@examples/reference/src/passengers/party.ts?raw';
+import appSource from '@examples/reference/src/passengers/Trip.vue?raw';
+
+import ExampleShell from '../../../components/ExampleShell.astro';
+import PassengersVue from '../../../islands/PassengersVue.vue';
+
+const sources = [
+  {
+    name: 'flow.ts',
+    lang: 'ts' as const,
+    code: flowSource,
+    note: 'The same file the React page shows. A group is a sub-flow entered once per item, and neither rendering knows how many items there are.',
+  },
+  {
+    name: 'party.ts',
+    lang: 'ts' as const,
+    code: partySource,
+    note: 'Also the same file: where an item’s answers live, how a rendering reads the key off the frame, and the one workaround this application needed.',
+  },
+  {
+    name: 'Trip.vue',
+    lang: 'vue' as const,
+    code: appSource,
+    note: 'The rendering, with `v-for` where the React file has `map`. The engine decides which of the three views is on screen.',
+  },
+];
+---
+
+<ExampleShell
+  slug="passengers"
+  ref="R-C"
+  heading="Add passengers. Revisit any passenger."
+  lede="One block of steps per passenger, written once and run as many times as there are people. Add and remove passengers, then go back and edit the second after finishing the third."
+  framework="vue"
+  sources={sources}
+>
+  <PassengersVue client:load />
+</ExampleShell>

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -78,6 +78,9 @@ const description =
               A repeat group runs a sub-flow per item and lets the visitor go back into one
               without unwinding the rest.
             </p>
+            <p>
+              <a href={`${base}/examples/passengers/`}>Run this one, on React or Vue</a>
+            </p>
           </FlowRow>
         </div>
       </Page>

--- a/site/src/styles/site.css
+++ b/site/src/styles/site.css
@@ -1352,3 +1352,61 @@ svg.interactive .node {
   flex-direction: column;
   gap: var(--space-4);
 }
+
+/* The list a repeat group iterates. A row is the name and the way out of it. */
+.party {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.party li {
+  display: flex;
+  align-items: flex-end;
+  gap: var(--space-3);
+}
+
+.party li .field {
+  flex: 1 1 12rem;
+}
+
+.party li button {
+  min-height: var(--target-min);
+}
+
+/* What every passenger answered, side by side. It scrolls rather than wraps:
+   a table read as a summary stops being one the moment a row folds. */
+.party-review {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: var(--text-sm);
+  display: block;
+  overflow-x: auto;
+}
+
+.party-review th,
+.party-review td {
+  text-align: left;
+  padding: var(--space-2) var(--space-3);
+  border-bottom: var(--border) solid var(--line);
+  white-space: nowrap;
+}
+
+.party-review thead th {
+  color: var(--fg-muted);
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  font-weight: var(--weight-body);
+}
+
+/* Where in the repeat the visitor is: which passenger, and which of that
+   passenger's steps. Both are read off the engine. */
+.app-where {
+  margin: 0;
+  color: var(--fg-muted);
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+}


### PR DESCRIPTION
**R-C**, and with it the third of the three reference applications the 1.0 release is evidenced by: one block of steps per passenger, added and removed from a list, and any of them revisited after the last one is finished.

## What it proves

| Claim | How the application shows it |
| --- | --- |
| `GroupStep` with `repeat` | The two questions a passenger answers are written once. The engine runs them as many times as there are people in the list. |
| the frame stack | Nothing in the rendering counts passengers. The frame carries the key; the caption, the answers and the review are read from it. The stack is printed under the form: `trip.people[p2] / passenger.seat`. |
| `keyBy` | Removing the passenger in front moves every index and moves no key. The one behind is still themselves, with their answers intact. |
| group entry and exit | An empty list makes the group's own `when` false, and the flow walks past it to Review like any other step it is not on the route for. |

## The host's half

The engine does not namespace an item's data: `set` writes the literal path it is given, so a sub-flow step called `seat` would write the same `data.seat` for every passenger. The host decides where the answers live and builds the path from the key, which is what `loop.key` exists for on the flow side. `party.ts` is that half, and the page shows it beside the definition.

## One workaround, filed rather than hidden

`go` addresses a step and never an item: entering a repeat group always lands on the first one, because `enter` takes `items.keys[0]` and there is no way to say which. So "edit the second passenger" is `go('people')` followed by `next()` until the frame's key matches — fine here, where every step it passes was already answered, and **not** fine in a flow with validators between.

`goToPassenger` says exactly that in its own comment, and **TODOS.md** carries it as P1 with the shape worth considering (`go({ to: 'people', key: 'p2' })`). This is the plan's rule working as intended: every workaround a reference application needs is a finding against the engine.

## Also here

`back()` pops whole stacks, so it walks a block in reverse rather than leaving it. Getting from the review to the list is a jump, which the flow's `free` policy allows and the review now offers as **Change who is travelling**.

## Verification

- `pnpm verify` — lint 0 errors, type-check 0 errors, 641 unit tests (five new, including the removal case and the empty-list case).
- `npx playwright test --project=site` — 35 passed, eight of them new for this application, `axe` clean on both pages.

## S3 after this

All three reference applications are live on both bindings, `/examples/` links all three, and each has a Playwright spec including keyboard and `axe`. What is left of S3 is the "Open in StackBlitz" button, which the plan puts after R0 because it installs from the `next` tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01St8X7YMGRoGykjjArA9v9n
