### PR TITLE
docs: documentation and work tracking are part of every change

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,42 @@
 # wizzard-packages
 
+## Documentation is part of the change
+
+Every feature, fix or behaviour change updates the README section that describes
+that surface **and** the docs page that teaches it, in the same change. Never a
+follow-up PR, never a tracked "docs debt" issue.
+
+Before opening a PR, name the README section and the `/docs/` page that describe
+what you changed, and edit both:
+
+- a new public option, prop or return value → the API behaviour table, plus the
+  guide page that owns the concept
+- a new error → its `/errors/<code>` page
+- a changed default → every snippet that relied on the old one
+- a snippet that is generated (`scripts/embed-examples.mjs`) or `?raw`-imported →
+  edit the source file and let the mechanism carry it; do not hand-write a copy
+
+Docs voice: plain prose, no emoji, no icon bullets, no decorative badges.
+
+The docs site is versioned per release, starting at 1.0.0. 0.x is not archived
+as an older version: it is torn down, not supported.
+
+## Work tracking
+
+Epics, stories and tasks live in **GitHub Issues** on this repository.
+
+- milestone = epic
+- issue with a task checklist = story
+- issue = task, closed by its PR via `Closes #N`
+
+Labels carry priority (`P0`–`P3`), kind (`epic`, `story`, `task`, `bug`,
+`docs`, `design`) and state (`blocked`). An issue that is blocked names its
+blocker in the body. `TODOS.md` stays what it is: work deliberately deferred out
+of 1.0.0, with the context to pick it up cold.
+
+Keep it current. Open an issue when work is identified, close it when its PR
+merges, and re-file rather than silently widening one that is already open.
+
 ## Skill routing
 
 When the user's request matches an available skill, invoke it via the Skill tool. When in doubt, invoke the skill.


### PR DESCRIPTION
Two rules that were agreed but written down nowhere, so every session had to be told them again.

**Documentation is part of the change.** A feature or fix updates the README section that describes that surface and the docs page that teaches it, in the same change - never a follow-up PR or a tracked docs-debt issue. The list names the four cases that actually get missed: a new public option or prop, a new error, a changed default, and a generated snippet. For the last one the rule is to edit the source file and let `scripts/embed-examples.mjs` or the `?raw` import carry it, rather than hand-writing a copy that will drift.

It also records that the docs site is versioned per release starting at 1.0.0, and that 0.x is not archived as an older version.

**Work tracking.** Epics, stories and tasks now live in GitHub Issues: milestone as epic, checklist issue as story, issue closed by its PR via `Closes #N`. Labels carry priority (`P0`-`P3`), kind, and `blocked`. `TODOS.md` keeps its own job - work deliberately deferred out of 1.0.0 - and is not the tracker.

The board this describes is already populated: fourteen epics across the `1.0.0` and `post-1.0` milestones, with the first stories opened under #57 and #58.