### PR TITLE
feat(site): a flat ground, and a surface for the blocks that need one

### DIFF
--- a/e2e/tests/site/docs.spec.ts
+++ b/e2e/tests/site/docs.spec.ts
@@ -1,0 +1,121 @@
+import AxeBuilder from '@axe-core/playwright';
+import { expect, test, type Page } from '@playwright/test';
+
+/**
+ * The documentation pages had no end-to-end coverage at all: the four specs in
+ * this directory visit the three example applications and the inspector, and
+ * nothing ever loaded a `/docs/` route. S1's acceptance says "axe 0 violations
+ * on every page", and "every page" had quietly come to mean the example pages.
+ *
+ * What that let through: Starlight paints the current sidebar entry as
+ * `--sl-color-text-invert` on a `--sl-color-text-accent` fill, and the site's
+ * own base rule for `a` - unlayered, and therefore stronger than every layered
+ * rule Starlight writes, whatever its specificity - repainted the text in the
+ * accent as well. The current page was accent on accent at 1.00:1 on all six
+ * documentation pages, in both themes, and no check ran anywhere near it.
+ */
+
+/** Every page the sidebar links to, which `sidebar.test.ts` keeps honest. */
+const DOCS = [
+  ['Getting started', 'docs/start/'],
+  ['The flow', 'docs/flow/'],
+  ['Expressions', 'docs/expressions/'],
+  ['Navigation', 'docs/navigation/'],
+  ['Validation', 'docs/validation/'],
+  ['Persistence', 'docs/persistence/'],
+] as const;
+
+/** Starlight reads the theme from this key before it paints. */
+const useTheme = (theme: 'dark' | 'light') => ({
+  colorScheme: theme,
+  storageState: {
+    cookies: [],
+    origins: [
+      {
+        origin: 'http://127.0.0.1:4321',
+        localStorage: [{ name: 'starlight-theme', value: theme }],
+      },
+    ],
+  },
+});
+
+/**
+ * Expressive Code makes a code block keyboard-scrollable from a script rather
+ * than from the markup: a `ResizeObserver` finds the blocks whose content
+ * overflows and gives them `tabindex="0"` and `role="region"`. It is debounced
+ * by 250ms and then deferred again to `requestIdleCallback`, so a scan that
+ * starts at `networkidle` reliably arrives first and reports every wide snippet
+ * as a scrollable region without keyboard access. Waiting for the attribute is
+ * the difference between testing the page and testing the race.
+ */
+const settled = async (page: Page): Promise<void> => {
+  await page.waitForFunction(() =>
+    [...document.querySelectorAll('.expressive-code pre')].every(
+      (pre) => pre.scrollWidth <= pre.clientWidth || pre.hasAttribute('tabindex')
+    )
+  );
+};
+
+const contrast = (fg: string, bg: string): number => {
+  const luminance = (colour: string): number => {
+    const channels = (colour.match(/[\d.]+/g) ?? []).slice(0, 3).map(Number);
+    const [r, g, b] = channels.map((value) => {
+      const s = value / 255;
+      return s <= 0.03928 ? s / 12.92 : ((s + 0.055) / 1.055) ** 2.4;
+    }) as [number, number, number];
+    return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+  };
+  const [lighter, darker] = [luminance(fg), luminance(bg)].sort((a, b) => b - a) as [
+    number,
+    number,
+  ];
+  return (lighter + 0.05) / (darker + 0.05);
+};
+
+for (const theme of ['dark', 'light'] as const) {
+  test.describe(`the documentation pages in ${theme}`, () => {
+    test.use(useTheme(theme));
+
+    for (const [name, path] of DOCS) {
+      test(`${name} has no accessibility violations`, async ({ page }) => {
+        await page.goto(path);
+        await expect(page.locator('#starlight__sidebar')).toBeVisible();
+        await settled(page);
+
+        const results = await new AxeBuilder({ page })
+          .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'])
+          .analyze();
+        expect(results.violations).toEqual([]);
+      });
+    }
+
+    /**
+     * axe skips a colour-contrast check it cannot resolve a background for, so
+     * the pairing that actually broke is asserted directly rather than being
+     * left to the sweep above.
+     */
+    test('the current sidebar entry is readable on its fill', async ({ page }) => {
+      await page.goto('docs/flow/');
+      const current = page.locator('#starlight__sidebar a[aria-current="page"]');
+      await expect(current).toHaveText('The flow');
+
+      const { color, background } = await current.evaluate((node) => {
+        const style = getComputedStyle(node);
+        return { color: style.color, background: style.backgroundColor };
+      });
+      expect(contrast(color, background)).toBeGreaterThanOrEqual(4.5);
+    });
+
+    test('the skip link is readable once it takes focus', async ({ page }) => {
+      await page.goto('docs/flow/');
+      await page.keyboard.press('Tab');
+
+      const skip = page.getByRole('link', { name: 'Skip to content' });
+      const { color, background } = await skip.evaluate((node) => {
+        const style = getComputedStyle(node);
+        return { color: style.color, background: style.backgroundColor };
+      });
+      expect(contrast(color, background)).toBeGreaterThanOrEqual(4.5);
+    });
+  });
+}

--- a/site/DESIGN.md
+++ b/site/DESIGN.md
@@ -91,22 +91,21 @@ inside their own scroll container, and never widen the page.
 
 Dark is the default and light follows the visitor's system preference; both are complete
 palettes, not an inversion. The neutral is cool - an ink ground biased toward the accent - so
-the page reads as a drawing sheet and the cyan reads as belonging to it rather than sitting on
-top of it.
+the cyan reads as belonging to the page rather than as sitting on top of it.
 
-| Token              | Dark        | Light       | Use                                         |
-| ------------------ | ----------- | ----------- | ------------------------------------------- |
-| `--bg`             | `#0B0E14`   | `#F4F6F9`   | page ground                                 |
-| `--surface`        | `#10141C`   | `#FFFFFF`   | panels, form wells, code blocks             |
-| `--surface-raised` | `#141926`   | `#EDF1F6`   | the one layer above surface; used sparingly |
-| `--line`           | `#1E2530`   | `#DCE3EC`   | hairlines, node borders at rest, the grid   |
-| `--line-strong`    | `#2C3648`   | `#B9C4D2`   | dividers that separate sections             |
-| `--fg`             | `#E6EDF3`   | `#0B0E14`   | body and headings                           |
-| `--fg-muted`       | `#93A1B4`   | `#4A5666`   | secondary text, captions, labels            |
-| `--fg-faint`       | `#6E7C90`   | `#7A8798`   | non-text only: rules, disabled glyphs       |
-| `--accent`         | `#35D6D0`   | `#0E6E6A`   | the active step, primary action, links      |
-| `--accent-soft`    | `#35D6D01F` | `#0E6E6A14` | fill behind the active node                 |
-| `--on-accent`      | `#06121A`   | `#FFFFFF`   | text on an accent fill                      |
+| Token              | Dark        | Light       | Use                                          |
+| ------------------ | ----------- | ----------- | -------------------------------------------- |
+| `--bg`             | `#0B0E14`   | `#F4F6F9`   | page ground                                  |
+| `--surface`        | `#10141C`   | `#FFFFFF`   | panels, form wells, code blocks              |
+| `--surface-raised` | `#141926`   | `#EDF1F6`   | the one layer above surface; used sparingly  |
+| `--line`           | `#1E2530`   | `#DCE3EC`   | hairlines, node borders at rest, table rules |
+| `--line-strong`    | `#2C3648`   | `#B9C4D2`   | dividers that separate sections              |
+| `--fg`             | `#E6EDF3`   | `#0B0E14`   | body and headings                            |
+| `--fg-muted`       | `#93A1B4`   | `#4A5666`   | secondary text, captions, labels             |
+| `--fg-faint`       | `#6E7C90`   | `#7A8798`   | non-text only: rules, disabled glyphs        |
+| `--accent`         | `#35D6D0`   | `#0E6E6A`   | the active step, primary action, links       |
+| `--accent-soft`    | `#35D6D01F` | `#0E6E6A14` | fill behind the active node                  |
+| `--on-accent`      | `#06121A`   | `#FFFFFF`   | text on an accent fill                       |
 
 `--fg-faint` must never carry text; it exists for rules and for glyphs that repeat a label
 already present, and it clears the 3:1 a non-text mark needs and nothing more. Every other
@@ -119,12 +118,47 @@ The amber this replaced could not make that claim. White on the light `#B4640F` 
 4.40:1 under a 15px bold label. It shipped that way and no check caught it, because the check
 was never run on that pair.
 
-### The ground is a drawing sheet
+### The ground is flat
 
-The page ground carries a hairline grid on the same 32px step the layout counts in, drawn in
-`--line` as two CSS gradients: no image, no request, and it moves with the theme. It is the
-one decorative element in the system, and it earns its place by being the same measurement the
-graph is laid out on. Nothing else may add a background pattern.
+The page ground is one fill and carries no pattern. Nothing on this site may add a background
+pattern, gradient or texture to it.
+
+It used to draw a hairline grid on the same 32px step the layout counts in, as a drawing-sheet
+metaphor. The metaphor cost more than it earned. A pattern on `body` shows through every
+element that has no fill of its own, so the reference table on `/docs/flow/` had grid lines
+running behind its rows, and the demo panels read as outlines drawn over graph paper rather
+than as panels sitting on a page. In light it was worse than in dark: a near-white ground
+exposes more of it, and the large empty areas of a documentation page are exactly where it was
+loudest.
+
+Depth is the surface ladder's job instead. Every widely read documentation site this one was
+measured against puts a flat ground under the page and lets blocks carry the contrast, and none
+of them uses a shadow to do it.
+
+### Which things get a surface
+
+A surface is a fill, a hairline, and a radius. It is not free: a page where everything is a
+card has no hierarchy at all, so the list is short and closed.
+
+| Gets a surface                                        | Stays on the ground                           |
+| ----------------------------------------------------- | --------------------------------------------- |
+| Code blocks                                           | The top bar, apart from one hairline under it |
+| Tables: filled header row, hairline rows, in a border | The documentation sidebar                     |
+| Panels that hold an instrument, and their form wells  | The table of contents                         |
+| Cards in a gallery of examples                        | Prose, headings, captions, the footer         |
+
+The nav is the case people get wrong. Every site in that comparison paints its header in
+exactly the page ground colour; one of them draws a hairline under it, and none uses a fill or
+a shadow. A tinted header is the tell of a site that reached for elevation where it needed
+whitespace.
+
+A block that scrolls keeps its own scrolling. A table or code block wider than the column
+scrolls inside itself and never widens the page - `--measure-wide` exists for exactly this. Do
+not give a table `display: table` or `overflow: hidden` to make a radius clip: `overflow` does
+not apply to a table box, so the table keeps its intrinsic width and pushes the whole page
+sideways on a phone. Starlight already makes wide tables `display: block; overflow-x: auto`,
+which is what clips the radius correctly, so the rule here is to add the fill and the border
+and leave the box alone.
 
 ### Semantic colours
 
@@ -204,6 +238,29 @@ visitor is meant to hit, and `--control-h-compact` (32px), for a control that si
 another component's frame and is not the reason the visitor is there — the copy button on a
 code block, the Rebuild control on a graph. A compact control still carries a 44px hit area
 through padding.
+
+### Where a rule sits in the cascade
+
+Half of this site is Starlight's and half is ours, and the two meet in the cascade rather than
+in a file. Starlight writes everything it draws inside `@layer starlight.*`. We therefore
+declare the order once, at the top of `tokens.css`:
+
+```css
+@layer site.base, starlight.reset, starlight.base, starlight.core, starlight.content,
+  starlight.components, starlight.utils;
+```
+
+`site.base` holds element-level defaults — what a bare `a` or `table` gets — and is the
+weakest layer on the page, so a default of ours can never beat a component rule of Starlight's.
+Everything else the site writes stays **outside** a layer, which is stronger than all of them,
+because the custom pages own their appearance completely.
+
+Zero specificity does not substitute for this. The cascade compares layers before it compares
+specificity, so an unlayered `:where(a)` beats a layered `[aria-current='page']` — which is
+exactly what happened: the base link colour repainted Starlight's current sidebar entry and its
+skip link in `--accent`, on top of the `--accent` fill Starlight had already put behind them.
+Both measured 1.00:1 and neither could be read. Anything Starlight paints on a fill takes
+`--on-accent` through `--sl-color-text-invert`, which is the pairing the palette measures.
 
 ## Browser surfaces
 

--- a/site/src/styles/site.css
+++ b/site/src/styles/site.css
@@ -13,19 +13,18 @@
   box-sizing: border-box;
 }
 
-/* The ground is a drawing sheet: a hairline grid on the same 32px step the
-   layout counts in, so the page reads as something measured rather than as a
-   dark rectangle. It is one gradient pair and no image request. */
+/* The ground is one flat fill and carries no pattern. It used to draw a
+   hairline grid on a 32px step, which cost more than the metaphor was worth:
+   a pattern on `body` shows through every element that has no fill of its own,
+   so the reference table on /docs/flow/ had grid lines running behind its rows
+   and the demo panels read as outlines over graph paper rather than as panels.
+   Depth is the surface ladder's job now - see "The ground is flat" in
+   DESIGN.md. */
 body {
   font-family: var(--font-sans);
   font-size: var(--text-base);
   line-height: var(--leading-body);
   background-color: var(--bg);
-  background-image:
-    linear-gradient(var(--grid-line) var(--border), transparent var(--border)),
-    linear-gradient(90deg, var(--grid-line) var(--border), transparent var(--border));
-  background-size: 32px 32px;
-  background-position: calc(var(--border) * -1) calc(var(--border) * -1);
   color: var(--fg);
   margin: 0;
   -webkit-font-smoothing: antialiased;
@@ -83,15 +82,23 @@ body {
 
 /* Links. DESIGN.md gives `--accent` to the active step, the primary action and
    links, and nothing implemented the third: every anchor outside the top bar
-   was shipping the browser's own blue. `:where` keeps this at zero specificity
-   so Starlight's own link colours and the button classes still win.
+   was shipping the browser's own blue.
+
+   This lives in `site.base` - the weakest layer, declared in tokens.css - and
+   not merely at zero specificity. Zero specificity does not help against a
+   layer: an unlayered rule beats every layered one whatever its selector, so
+   this used to paint Starlight's current sidebar page and its skip link in the
+   accent, on top of the accent fill Starlight had already put behind them. The
+   sidebar's current page measured 1.00:1 and could not be read at all.
 
    Underlines sit clear of descenders and match the hairline weight the rest of
    the page is drawn with. */
-:where(a) {
-  color: var(--accent);
-  text-underline-offset: 0.18em;
-  text-decoration-thickness: from-font;
+@layer site.base {
+  :where(a) {
+    color: var(--accent);
+    text-underline-offset: 0.18em;
+    text-decoration-thickness: from-font;
+  }
 }
 
 :where(a):hover {
@@ -299,10 +306,15 @@ body {
 
 /* --- feature rows -------------------------------------------------------- */
 
+/* `--line-strong` rather than `--line`, because these separate sections rather
+   than bound a box, which is the distinction the palette draws between the two.
+   It mattered less while the ground carried a grid and the rules read as part
+   of it; on a flat ground they are the only rhythm this stretch of the page
+   has, and at `--line` they were too quiet to give it one. */
 .rows {
   display: flex;
   flex-direction: column;
-  border-top: var(--border) solid var(--line);
+  border-top: var(--border) solid var(--line-strong);
 }
 
 /* The claim reads across the top, the graph runs the full width under it.
@@ -314,7 +326,7 @@ body {
   display: grid;
   gap: var(--space-6);
   padding: var(--space-12) 0;
-  border-bottom: var(--border) solid var(--line);
+  border-bottom: var(--border) solid var(--line-strong);
 }
 
 /* Capped at the widest graph the page draws - 788 user units plus the frame's
@@ -1409,4 +1421,90 @@ svg.interactive .node {
   color: var(--fg-muted);
   font-family: var(--font-mono);
   font-size: var(--text-xs);
+}
+
+/* --- the documentation shell ---------------------------------------------
+   Starlight draws its own chrome and we leave almost all of it alone. What it
+   does not draw is a surface for the things its markdown renderer emits, and
+   with the ground grid gone those had nothing behind them at all. The
+   documentation sites this one was measured against are unanimous about which
+   parts get a surface: code and cards do, and the nav, the sidebar and the
+   table of contents stay on the ground with at most a hairline. None of them
+   tints its header and none uses a shadow.
+   ------------------------------------------------------------------------- */
+
+/* Section headings get the air the comparison sites give them. They agree on
+   the shape of the rhythm - tight headings, loose body, and a large gap before
+   a new section rather than after it - and the gap left between a section and
+   the paragraph above it is roughly double the gap inside one. */
+.sl-markdown-content :is(h2, h3) {
+  margin-top: var(--space-12);
+}
+
+/* A table is a block and reads as one: a header on `--surface`, hairline rows,
+   and the whole thing inside a rounded border. Before this it was bare rows on
+   the ground, whose rules were the same weight as the grid behind them, so it
+   read as text that happened to line up rather than as a table. */
+.sl-markdown-content table {
+  margin-block: var(--space-6);
+  background: var(--surface);
+  border: var(--border) solid var(--line);
+  border-radius: var(--radius-panel);
+  border-collapse: separate;
+  border-spacing: 0;
+  font-size: var(--text-sm);
+}
+
+/* One step above the table's own fill, so the header reads as a header in dark
+   as well as in light. On `--surface` it was a 1.05 step from the ground in
+   dark against 1.08 in light, and the dark one did not read as filled. */
+.sl-markdown-content thead {
+  background: var(--surface-raised);
+}
+
+.sl-markdown-content :is(th, td) {
+  padding: var(--space-3) var(--space-4);
+  border-bottom: var(--border) solid var(--line);
+  text-align: start;
+  vertical-align: top;
+}
+
+/* The fill alone does not carry the header in dark: the ladder's steps are
+   small by design, and one step over the table's own fill is a 1.05 ratio there
+   against 1.08 in light. The rule under it is `--line-strong` - the palette's
+   divider weight, as opposed to the `--line` hairlines between rows - so the
+   header is separated by the same means in both themes rather than by a fill
+   that only reads in one of them. */
+.sl-markdown-content thead th {
+  border-bottom-color: var(--line-strong);
+}
+
+.sl-markdown-content th {
+  color: var(--fg-muted);
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  font-weight: var(--weight-medium);
+  letter-spacing: var(--track-label);
+  text-transform: uppercase;
+}
+
+/* The last row closes on the border-radius, so it must not draw its own rule
+   underneath it - the two would cross at the corner. */
+.sl-markdown-content tbody tr:last-child :is(th, td) {
+  border-bottom: 0;
+}
+
+/* --- the page chrome on a phone ------------------------------------------
+   `--target-min` is 44px and the top bar and the footer were ignoring it: every
+   link in both was 24px tall, and "Docs" was 36x24. On a pointer device that is
+   fine and the compact rhythm is the point; on a touch screen it is the whole
+   navigation of the site sitting under the minimum.
+   ------------------------------------------------------------------------- */
+@media (pointer: coarse) {
+  .topbar a,
+  .site-footer a {
+    display: inline-flex;
+    align-items: center;
+    min-height: var(--target-min);
+  }
 }

--- a/site/src/styles/tokens.css
+++ b/site/src/styles/tokens.css
@@ -1,4 +1,20 @@
 /**
+ * Cascade order, declared before anything else on the page so it is this file
+ * that decides it. `site.base` holds the element-level defaults - the things a
+ * bare `<a>` or `<table>` gets - and it is deliberately the weakest layer:
+ * Starlight styles its own shell inside `starlight.*`, and a base rule of ours
+ * must never win against a component rule of theirs. Everything else the site
+ * writes stays outside a layer, which is stronger than all of these, because
+ * the custom pages own their own appearance.
+ *
+ * Zero specificity is not enough for this on its own. An unlayered `:where(a)`
+ * still beats a layered `[aria-current='page']`, because the cascade compares
+ * layers before it compares specificity.
+ */
+@layer site.base, starlight.reset, starlight.base, starlight.core, starlight.content,
+  starlight.components, starlight.utils;
+
+/**
  * The design system of DESIGN.md, as custom properties. Every colour, size,
  * duration and easing used anywhere on the site comes from this file.
  *
@@ -26,10 +42,11 @@
      The sans carries prose only, because a documentation page is paragraphs and
      a monospace paragraph is read slower than it is admired. The fallback face
      is metric-adjusted so the swap does not reflow. */
-  --font-sans: 'Inter Tight Variable', 'Inter Tight', 'Inter Tight Fallback', ui-sans-serif,
-    system-ui, sans-serif;
-  --font-mono: 'JetBrains Mono Variable', 'JetBrains Mono', ui-monospace, 'SF Mono', Menlo,
-    Consolas, monospace;
+  --font-sans:
+    'Inter Tight Variable', 'Inter Tight', 'Inter Tight Fallback', ui-sans-serif, system-ui,
+    sans-serif;
+  --font-mono:
+    'JetBrains Mono Variable', 'JetBrains Mono', ui-monospace, 'SF Mono', Menlo, Consolas, monospace;
 
   /* Type scale, px. Nothing between the steps. */
   --text-label: 0.6875rem;
@@ -139,11 +156,6 @@
   --surface-raised: #141926;
   --line: #1e2530;
   --line-strong: #2c3648;
-  /* The ground grid. It is `--line` here and softer in light, because a dark
-     line on a light ground reads stronger than a light line on a dark one at
-     the same ratio: measured 1.25 dark against 1.19 light, and the light one
-     was the one that felt loud. */
-  --grid-line: #1e2530;
   --fg: #e6edf3;
   --fg-muted: #93a1b4;
   --fg-faint: #6e7c90;
@@ -167,7 +179,6 @@
     --surface-raised: #edf1f6;
     --line: #dce3ec;
     --line-strong: #b9c4d2;
-    --grid-line: #e7ecf3;
     --fg: #0b0e14;
     --fg-muted: #4a5666;
     --fg-faint: #7a8798;
@@ -191,7 +202,6 @@
   --surface-raised: #edf1f6;
   --line: #dce3ec;
   --line-strong: #b9c4d2;
-  --grid-line: #e7ecf3;
   --fg: #0b0e14;
   --fg-muted: #4a5666;
   --fg-faint: #7a8798;
@@ -232,6 +242,13 @@
   --sl-color-accent-low: var(--accent-soft);
   --sl-color-accent-high: var(--accent);
   --sl-color-text-accent: var(--accent);
+  /* What Starlight writes on an accent fill: the sidebar's current page, the
+     skip link, a banner. Its own default is `--sl-color-accent-low`, which the
+     line above redefines as a 12% wash of the accent - so the text composited
+     to the same colour as the fill behind it and the current page was
+     unreadable at 1:1. `--on-accent` is the token the palette already measures
+     for exactly this pairing: 10.53:1 dark, 6.07:1 light. */
+  --sl-color-text-invert: var(--on-accent);
   --sl-color-bg: var(--bg);
   --sl-color-bg-nav: var(--bg);
   --sl-color-bg-sidebar: var(--bg);


### PR DESCRIPTION
Closes #75. Part of #58. Also closes #78, found on the way in.

## The ground

The page drew a hairline grid on `body` as a drawing-sheet metaphor. A pattern on `body` shows through every element that has no fill of its own, so the reference table on `/docs/flow/` had grid lines running behind its rows, and the demo panels read as outlines over graph paper rather than as panels. Light was worse than dark: a near-white ground exposes more of it, and a documentation page is mostly empty space.

The grid is gone and `--grid-line` with it - it had no other use in the repo.

## What replaces it is a shorter list than expected

Measured against the widely read documentation sites this one is judged beside, they agree on less decoration than the brief assumed. **Every one of them paints the header in exactly the page ground colour. One draws a hairline under it. None uses a fill or a shadow.** So the nav, the sidebar and the table of contents were left on the ground; giving the header a surface would have been the amateur tell, not the fix. `DESIGN.md` now carries the closed list of what may take a surface.

Tables got the most of it, because they had nothing: a fill, a header one step above it with the palette's divider weight beneath, hairline rows, and a border with a radius. Section dividers on the home page move from `--line` to `--line-strong`, which is what that weight is for - they existed before and were only legible because the grid gave that stretch of page a rhythm of its own.

## The palette did not need changing

Worth checking before touching it. `--bg` to `--surface` is a **1.05** ratio and `--bg` to `--surface-raised` is **1.10**, both inside the range the comparison sites use. The panels read as outlines because the grid ran through them, not because the step was too small.

Measured on the built table: header to body 1.051 dark / 1.134 light, header rule to header 1.444 / 1.557, row rule to body 1.196 / 1.293. The header rule is 1.2x the row rules in dark, so the header is carried by the same means in both themes rather than by a fill that only reads in one.

## A contrast bug found on the way (#78)

Starlight paints its current sidebar entry, its skip link and its banner as `--sl-color-text-invert` on a `--sl-color-text-accent` fill. The site set the fill and never set the text colour, so it fell back to Starlight's default for it - which `tokens.css` redefines as a 12% wash of the accent. **Accent on accent, 1.00:1, on all six documentation pages, in both themes.**

The token was half of it. The base link rule carried a comment claiming `:where` kept it weak enough for Starlight to win. It does not: the cascade compares layers before specificity, and that rule was in no layer while every Starlight rule is in `@layer starlight.*`. The layer order is now declared once in `tokens.css` with `site.base` as the weakest layer. Now 10.53:1 dark and 6.07:1 light.

**Nothing caught it because no e2e spec had ever loaded a `/docs/` route.** S1's "axe 0 violations on every page" had come to mean the example pages. `e2e/tests/site/docs.spec.ts` now runs axe over all six pages in both themes and asserts the two pairings directly, because axe skips a contrast check whose background it cannot resolve.

## Touch targets

`--target-min` is 44px and was applied to nothing in the page chrome; every top-bar and footer link was 24px tall, `Docs` was 36x24. Now applied under `pointer: coarse`. Measured with touch emulation: the home page went from 11 targets under 44px to none, the examples index and an example page from 7 each to none.

## One regression, caught and fixed here

Giving the table `display: table` plus `overflow: hidden` to clip the radius made the page scroll sideways on a phone - 475px of content in a 412px viewport. `overflow` does not apply to a table box, so the table kept its intrinsic width and pushed the page out. Starlight already renders wide tables as `display: block; overflow-x: auto`, which clips the radius correctly on its own. Fixed by deleting the override; the page measures 412 = 412 again. Written into `DESIGN.md` so it is not repeated.

## Verification

- 53 of 53 site e2e tests pass, including 16 new documentation checks.
- 97 of 97 site unit tests pass.
- Radius clipping confirmed programmatically rather than by eye: `border-radius: 6px`, `overflow-x: auto`, and `border-bottom: 0px` on every cell of the last row, identical in both themes.
- Screenshots taken and compared before and after at 1440 and 390, both themes.

Three findings from the screenshot review turned out not to be real and are recorded in #78: a floating toolbar overlapping content was the dev-server toolbar, "code blocks are cut off and unreadable" was a scroll container working correctly, and "wide code blocks have no keyboard access" was the code-block script adding `tabindex` from a debounced observer that the scan was outrunning.