### PR TITLE
docs: one rulebook, and how a session opens

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,6 +111,27 @@ build time. `examples/next-app` is the proof, built on every `pnpm build` and dr
 Outside RSC - Vite, Remix, plain bundlers, Node - the directive is inert. Keep the react
 `tsup` config on esbuild only; the rollup pass drops directives.
 
+## Documentation is part of the change
+
+Every feature, fix or behaviour change updates the README section that describes
+that surface **and** the docs page that teaches it, in the same change. Never a
+follow-up PR, never a tracked "docs debt" issue.
+
+Before opening a PR, name the README section and the `/docs/` page that describe
+what you changed, and edit both:
+
+- a new public option, prop or return value → the API behaviour table, plus the
+  guide page that owns the concept
+- a new error → its `/errors/<code>` page
+- a changed default → every snippet that relied on the old one
+- a snippet that is generated (`scripts/embed-examples.mjs`) or `?raw`-imported →
+  edit the source file and let the mechanism carry it; do not hand-write a copy
+
+Docs voice: plain prose, no emoji, no icon bullets, no decorative badges.
+
+The docs site is versioned per release, starting at 1.0.0. 0.x is not archived
+as an older version: it is torn down, not supported.
+
 ## Quality gates
 
 These run in CI and must pass locally before a PR:
@@ -171,6 +192,28 @@ review, and the merge to Done, with the plan's row updated in the same PR.
 The `wizzard-N` ids in `docs/designs/` and in a few test comments come from the beads tracker
 this repository used until 2026-09-11. `docs/PLAN.md` maps every id still referenced to where it
 went; the full history is in git.
+
+Open an issue when work is identified, and re-file rather than silently widening one already
+open. Labels carry priority (`P0`-`P3`) and kind (`epic`, `story`, `task`, `bug`, `design`,
+`documentation`); status is the board's job, never a label's. `TODOS.md` is work deliberately
+deferred out of 1.0.0, not the tracker.
+
+### Starting a session
+
+When a session begins and the owner's first message does not already name the work - a
+greeting, "continue", a bare question - open with where the project stands in three or four
+lines: what is in progress, what is blocked and by what, and what is next on the board. Then ask
+one question with three answers: continue the task on top (name it), take another one from the
+board, or start something new. Starting something new means opening an issue for it first.
+
+Continuing a task means reading its issue before touching code - the spec in the body and the
+last handoff comment - and saying in two lines where it stopped and what comes next.
+
+Claude Code sessions are handed this state before the owner types anything: a SessionStart hook
+in `.claude/settings.json` runs `scripts/session-brief.mjs`, which prints the plan's "Now", the
+board's live columns, the last merged PRs and any uncommitted work. Any other agent reads
+`docs/PLAN.md` and the board itself. If the board cannot be reached, say so and work from the
+plan.
 
 ## Coding Tasks
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,6 +51,19 @@ and true: it is the first thing every session reads. The same settings file sets
 to empty, so no commit or PR from this repository carries an assistant trailer - rule 1 of
 `AGENTS.md`, enforced by configuration rather than by memory.
 
+## Starting a session
+
+The session brief arrives before the owner says anything, so the first reply carries it. When
+the owner's first message does not already name the work - a greeting, "continue", a bare
+question - open with where the project stands in three or four lines: what is in progress, what
+is blocked and by what, and what is next on the board. Then ask one question with three
+answers: continue the task on top (name it), take another one from the board, or start
+something new. Starting something new means opening an issue for it first.
+
+Continuing a task means reading its issue before touching code - the spec in the body and the
+last handoff comment - and saying in two lines where it stopped and what comes next. If the
+brief could not reach GitHub, read `docs/PLAN.md` and say that the board was not available.
+
 ## Skill routing
 
 When the user's request matches an available skill, invoke it via the Skill tool. When in doubt, invoke the skill.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,68 +1,19 @@
 # wizzard-packages
 
-## Documentation is part of the change
+@AGENTS.md
 
-Every feature, fix or behaviour change updates the README section that describes
-that surface **and** the docs page that teaches it, in the same change. Never a
-follow-up PR, never a tracked "docs debt" issue.
+`AGENTS.md`, imported above, is the rulebook for every contributor, this one included: the hard
+rules, documentation, issue tracking and how a session starts all live there. This file adds only
+what is specific to Claude Code.
 
-Before opening a PR, name the README section and the `/docs/` page that describe
-what you changed, and edit both:
+## Claude Code specifics
 
-- a new public option, prop or return value → the API behaviour table, plus the
-  guide page that owns the concept
-- a new error → its `/errors/<code>` page
-- a changed default → every snippet that relied on the old one
-- a snippet that is generated (`scripts/embed-examples.mjs`) or `?raw`-imported →
-  edit the source file and let the mechanism carry it; do not hand-write a copy
-
-Docs voice: plain prose, no emoji, no icon bullets, no decorative badges.
-
-The docs site is versioned per release, starting at 1.0.0. 0.x is not archived
-as an older version: it is torn down, not supported.
-
-## Work tracking
-
-Three places, one job each. Nothing else is a source of truth for the state of the project.
-
-- **The plan** - `docs/PLAN.md`: what is being built, in what order, and where each track
-  stands. Its "Now" section is what every new session is handed. Change it in the same PR that
-  changes a status. `docs/designs/v1-launch.md` is the frozen record of _why_; status is never
-  tracked there.
-- **The board** - <https://github.com/users/ZizzX/projects/2>, over this repository's issues.
-  Status is the column: Backlog, Ready, In progress, In review, Blocked, Done. Order is the
-  position in Ready: the top card is next. An epic is a parent issue with native sub-issues, and
-  a dependency is a native "blocked by" link, never a sentence in a comment.
-- **The issue itself** - the body is the spec and its acceptance criteria. Comments carry what
-  was learned, the decisions taken, and a handoff note whenever work stops part-way ("stopped
-  here, next is ..."). The PR that finishes it says `Closes #N`.
-
-Moving a card is part of the work, not a report on it: taking a task moves it to In progress,
-opening its PR moves it to In review, and the merge moves it to Done and updates the plan's row.
-Open an issue when work is identified, and re-file rather than silently widening one already
-open. Labels carry priority (`P0`-`P3`) and kind (`epic`, `story`, `task`, `bug`, `design`,
-`documentation`); status is the board's job, never a label's. `TODOS.md` stays what it is: work
-deliberately deferred out of 1.0.0.
-
-**The session brief.** `.claude/settings.json` runs `scripts/session-brief.mjs` when a session
-starts. It prints the plan's "Now" section, the board's In progress, In review and Blocked
-columns with the top of Ready, the last merged PRs, and any uncommitted work. Keep "Now" short
-and true: it is the first thing every session reads. The same settings file sets `attribution`
-to empty, so no commit or PR from this repository carries an assistant trailer - rule 1 of
-`AGENTS.md`, enforced by configuration rather than by memory.
-
-## Starting a session
-
-The session brief arrives before the owner says anything, so the first reply carries it. When
-the owner's first message does not already name the work - a greeting, "continue", a bare
-question - open with where the project stands in three or four lines: what is in progress, what
-is blocked and by what, and what is next on the board. Then ask one question with three
-answers: continue the task on top (name it), take another one from the board, or start
-something new. Starting something new means opening an issue for it first.
-
-Continuing a task means reading its issue before touching code - the spec in the body and the
-last handoff comment - and saying in two lines where it stopped and what comes next. If the
-brief could not reach GitHub, read `docs/PLAN.md` and say that the board was not available.
+- `.claude/settings.json` runs `scripts/session-brief.mjs` when a session starts; its output is
+  the brief that "Starting a session" in `AGENTS.md` refers to. Keep the "Now" section of
+  `docs/PLAN.md` short and true - it is the first thing every session reads.
+- The same file empties `attribution`, so no commit or PR carries an assistant trailer. That is
+  rule 1 of `AGENTS.md`, held by configuration because a reminder at the top of every session
+  says otherwise.
 
 ## Skill routing
 


### PR DESCRIPTION
Part of #81, which built the session brief.

**How a session opens.** The brief reaches the agent before the owner types anything, but nothing said what to do with it. `AGENTS.md` gains "Starting a session": when the first message does not name the work, give where the project stands in three or four lines and ask one question - continue the task on top, take another from the board, or start something new (which starts with an issue). A continued task is read from its issue and last handoff comment first.

**One rulebook.** The review pointed out the rule had landed in `CLAUDE.md`, which only Claude Code reads, while `AGENTS.md` declares itself the single source for every contributor. The documentation rule and most of the work-tracking rules had the same problem - and Claude Code sessions had never loaded `AGENTS.md` at all, which is how its attribution rule and its old tracker section were missed. Now every rule lives once in `AGENTS.md`, and `CLAUDE.md` imports it with `@AGENTS.md` and keeps only the brief hook, the attribution setting and skill routing.