### PR TITLE
feat(site): the four task pages, each with a runnable example

### DIFF
--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -14,9 +14,9 @@ this file is the view one level above it.
 <!-- The session brief hands this section to every new session. Keep it short and true; the
 brief shows the board and the last merged PRs live, so they are not repeated here. -->
 
-- **In progress:** S4, the documentation pages (#57), at S4-1 (#71) - the runnable-example
-  mechanism and Getting started, reviewed and being built; S4-2 to S4-4 (#72-#74) are blocked
-  by it.
+- **In progress:** S4, the documentation pages (#57). S4-1 (#71) landed in #87 - the
+  runnable-example mechanism and Getting started - so S4-2 to S4-4 (#72-#74) are unblocked and
+  S4-2, the four task pages, is being built.
 - **Next after S4:** L6, the diagnostic contract (#59), which also owns the `/errors/` pages.
 - **Waiting on the owner:** R3 (#80), because `main` has no branch protection.
 

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -15,8 +15,8 @@ this file is the view one level above it.
 brief shows the board and the last merged PRs live, so they are not repeated here. -->
 
 - **In progress:** S4, the documentation pages (#57). S4-1 (#71) landed in #87 - the
-  runnable-example mechanism and Getting started - so S4-2 to S4-4 (#72-#74) are unblocked and
-  S4-2, the four task pages, is being built.
+  runnable-example mechanism and Getting started - and S4-2 (#72) in #89 - the four task pages,
+  each with a runnable example on that mechanism. S4-3 and S4-4 (#73, #74) are next.
 - **Next after S4:** L6, the diagnostic contract (#59), which also owns the `/errors/` pages.
 - **Waiting on the owner:** R3 (#80), because `main` has no branch protection.
 

--- a/e2e/tests/site/docs-tasks.spec.ts
+++ b/e2e/tests/site/docs-tasks.spec.ts
@@ -1,0 +1,100 @@
+import type { Page } from '@playwright/test';
+
+import { expect, test } from '../../fixtures/base';
+
+/**
+ * The four task pages, and the promise that makes them worth writing: a person
+ * arrives with a phrase, not with a concept, and the page named after that
+ * phrase is the first thing search gives them.
+ *
+ * The search half is checked against Pagefind's own index rather than through
+ * Starlight's dialog: the dialog is Starlight's to test, the ranking is ours.
+ * The index cannot be queried from Node - it resolves its shards against the
+ * page's origin - so the query runs inside the browser.
+ */
+const PAGES = [
+  ['Block Next until valid', 'docs/block-next-until-valid/'],
+  ['Restore after reload', 'docs/restore-after-reload/'],
+  ['Clear abandoned branch data', 'docs/clear-abandoned-branch-data/'],
+  ['Render field errors', 'docs/render-field-errors/'],
+] as const;
+
+/** One binding's island, so nothing reaches into the panel that is hidden. */
+const stage = (page: Page, framework: 'react' | 'vue') =>
+  page.locator(`[data-example-stage="${framework}"]`);
+
+test.describe('the task pages', () => {
+  for (const [name, path] of PAGES) {
+    test(`${name} runs its example`, async ({ page }) => {
+      await page.goto(path);
+      const react = stage(page, 'react');
+
+      // The example sits below the prose, and `client:visible` means what it
+      // says: the island mounts when it is on screen.
+      await react.scrollIntoViewIfNeeded();
+      await expect(react.getByRole('button', { name: 'Next' })).toBeEnabled();
+    });
+  }
+
+  test('a refused move says which field is wrong', async ({ page }) => {
+    await page.goto('docs/block-next-until-valid/');
+    const react = stage(page, 'react');
+    await react.scrollIntoViewIfNeeded();
+    await expect(react.getByRole('button', { name: 'Next' })).toBeEnabled();
+
+    await react.getByRole('button', { name: 'Next' }).click();
+    await expect(react.getByRole('alert')).toContainText('Enter your email address');
+
+    await react.getByLabel('Your email').fill('ada@example.com');
+    await react.getByRole('button', { name: 'Next' }).click();
+    await expect(react.getByText('That address will do.')).toBeVisible();
+  });
+
+  test('what a step asked to drop is not in the submission', async ({ page }) => {
+    await page.goto('docs/clear-abandoned-branch-data/');
+    const react = stage(page, 'react');
+    await react.scrollIntoViewIfNeeded();
+    await expect(react.getByRole('button', { name: 'Next' })).toBeEnabled();
+
+    await react.getByLabel('Business').check();
+    await react.getByRole('button', { name: 'Next' }).click();
+    await react.getByLabel('Company name').fill('Acme');
+    await react.getByRole('button', { name: 'Next' }).click();
+    await react.getByLabel('Coupon code').fill('SPRING');
+    await react.getByRole('button', { name: 'Next' }).click();
+
+    const submitted = react.locator('pre');
+    await expect(submitted).toContainText('Acme');
+    await expect(submitted).not.toContainText('SPRING');
+  });
+
+  for (const [name, path] of PAGES) {
+    test(`searching "${name}" finds its page first`, async ({ page }) => {
+      // Any page will do: the index is the site's, not the page's.
+      await page.goto('docs/start/');
+
+      // The index sits at the site root, not beside the page: resolving it
+      // against `document.baseURI` asks for it under `/docs/<page>/`, which is
+      // a 404. The root is taken from the URL rather than written out, so the
+      // repository's base path stays in one place.
+      const root = `${page.url().split('/docs/')[0]}/pagefind/`;
+
+      const first = await page.evaluate(
+        async ({ phrase, base }) => {
+          const pagefind = (await import(`${base}pagefind.js`)) as {
+            options: (o: Record<string, string>) => Promise<void>;
+            search: (q: string) => Promise<{ results: { data: () => Promise<{ url: string }> }[] }>;
+          };
+          await pagefind.options({ basePath: new URL(base).pathname });
+          const found = await pagefind.search(phrase);
+          const top = found.results[0];
+          return top === undefined ? null : (await top.data()).url;
+        },
+        { phrase: name, base: root }
+      );
+
+      expect(first, `search for "${name}" returned nothing`).not.toBeNull();
+      expect(first).toContain(path.replace(/\/$/, ''));
+    });
+  }
+});

--- a/e2e/tests/site/docs.spec.ts
+++ b/e2e/tests/site/docs.spec.ts
@@ -18,6 +18,10 @@ import { expect, test, type Page } from '@playwright/test';
 /** Every page the sidebar links to, which `sidebar.test.ts` keeps honest. */
 const DOCS = [
   ['Getting started', 'docs/start/'],
+  ['Block Next until valid', 'docs/block-next-until-valid/'],
+  ['Restore after reload', 'docs/restore-after-reload/'],
+  ['Clear abandoned branch data', 'docs/clear-abandoned-branch-data/'],
+  ['Render field errors', 'docs/render-field-errors/'],
   ['The flow', 'docs/flow/'],
   ['Expressions', 'docs/expressions/'],
   ['Navigation', 'docs/navigation/'],

--- a/examples/tasks/package.json
+++ b/examples/tasks/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@examples/tasks",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "description": "One small example per task page: the smallest flow that shows one thing, run by the documentation site and asserted by vitest.",
+  "scripts": {
+    "type-check": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@wizzard-packages/core": "workspace:*",
+    "@wizzard-packages/plugins": "workspace:*",
+    "@wizzard-packages/react": "workspace:*",
+    "@wizzard-packages/vue": "workspace:*",
+    "react": "^19.2.0",
+    "react-dom": "^19.2.0",
+    "vue": "^3.5.13"
+  },
+  "devDependencies": {
+    "@testing-library/react": "^16.3.1",
+    "@types/react": "^19.2.7",
+    "@types/react-dom": "^19.2.3",
+    "@vue/test-utils": "^2.4.6",
+    "typescript": "^5.9.3"
+  }
+}

--- a/examples/tasks/src/block-next/App.tsx
+++ b/examples/tasks/src/block-next/App.tsx
@@ -1,0 +1,64 @@
+import {
+  WizardProvider,
+  useErrors,
+  useField,
+  useNavigation,
+  useStep,
+} from '@wizzard-packages/react/v1';
+
+import { signup } from './flow';
+import { registry } from './registry';
+
+export function App() {
+  return (
+    <WizardProvider flow={signup} registry={registry}>
+      <Wizard />
+    </WizardProvider>
+  );
+}
+
+export function Wizard() {
+  const { current } = useStep();
+  const { next, isBusy } = useNavigation();
+  const [email, setEmail] = useField<string>('details.email');
+  const errors = useErrors();
+
+  // Nothing is current until the engine starts, which happens in the browser.
+  const step = current ?? 'details';
+  const starting = current === null;
+
+  return (
+    <form
+      onSubmit={(e) => {
+        e.preventDefault();
+        // The refusal is the return value, not an exception: `next()` resolves
+        // to `{ ok: false, reason: 'invalid', errors }` and the flow stays put.
+        void next();
+      }}
+    >
+      {step === 'details' && (
+        <>
+          <label htmlFor="email">Your email</label>
+          <input
+            id="email"
+            value={email ?? ''}
+            onChange={(e) => setEmail(e.target.value)}
+            disabled={starting}
+            aria-invalid={errors['email'] !== undefined}
+            aria-describedby={errors['email'] === undefined ? undefined : 'email-error'}
+          />
+          {errors['email'] !== undefined && (
+            <p id="email-error" role="alert">
+              {errors['email']}
+            </p>
+          )}
+        </>
+      )}
+      {step === 'done' && <p>That address will do.</p>}
+
+      <button type="submit" disabled={starting || isBusy || step === 'done'}>
+        Next
+      </button>
+    </form>
+  );
+}

--- a/examples/tasks/src/block-next/App.tsx
+++ b/examples/tasks/src/block-next/App.tsx
@@ -5,6 +5,7 @@ import {
   useNavigation,
   useStep,
 } from '@wizzard-packages/react/v1';
+import { useId } from 'react';
 
 import { signup } from './flow';
 import { registry } from './registry';
@@ -27,6 +28,12 @@ export function Wizard() {
   const step = current ?? 'details';
   const starting = current === null;
 
+  // A generated id rather than a written one. On the page this example appears
+  // on, the React and Vue renderings are both in the document - the tab that is
+  // not showing is hidden, not removed - so a fixed `id` would be there twice
+  // and every `for` pointing at it would find the wrong field.
+  const emailId = useId();
+
   return (
     <form
       onSubmit={(e) => {
@@ -38,17 +45,17 @@ export function Wizard() {
     >
       {step === 'details' && (
         <>
-          <label htmlFor="email">Your email</label>
+          <label htmlFor={emailId}>Your email</label>
           <input
-            id="email"
+            id={emailId}
             value={email ?? ''}
             onChange={(e) => setEmail(e.target.value)}
             disabled={starting}
             aria-invalid={errors['email'] !== undefined}
-            aria-describedby={errors['email'] === undefined ? undefined : 'email-error'}
+            aria-describedby={errors['email'] === undefined ? undefined : `${emailId}-error`}
           />
           {errors['email'] !== undefined && (
-            <p id="email-error" role="alert">
+            <p id={`${emailId}-error`} role="alert">
               {errors['email']}
             </p>
           )}

--- a/examples/tasks/src/block-next/App.vue
+++ b/examples/tasks/src/block-next/App.vue
@@ -1,0 +1,15 @@
+<script setup lang="ts">
+import { provideWizard } from '@wizzard-packages/vue/v1';
+
+import Wizard from './Wizard.vue';
+import { signup } from './flow';
+import { registry } from './registry';
+
+// The wizard is provided here and consumed by the child. Vue's inject reads the
+// parent chain, so the component that provides cannot also use the composables.
+provideWizard({ flow: signup, registry });
+</script>
+
+<template>
+  <Wizard />
+</template>

--- a/examples/tasks/src/block-next/Wizard.vue
+++ b/examples/tasks/src/block-next/Wizard.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { useErrors, useField, useNavigation, useStep } from '@wizzard-packages/vue/v1';
-import { computed } from 'vue';
+import { computed, useId } from 'vue';
 
 const { current } = useStep();
 const { next, isBusy } = useNavigation();
@@ -10,6 +10,12 @@ const errors = useErrors();
 // Nothing is current until the engine starts, which happens in the browser.
 const step = computed(() => current.value ?? 'details');
 const starting = computed(() => current.value === null);
+
+// A generated id rather than a written one. On the page this example appears on,
+// the React and Vue renderings are both in the document - the tab that is not
+// showing is hidden, not removed - so a fixed `id` would be there twice and
+// every `for` pointing at it would find the wrong field.
+const emailId = useId();
 </script>
 
 <template>
@@ -17,15 +23,15 @@ const starting = computed(() => current.value === null);
        `{ ok: false, reason: 'invalid', errors }` and the flow stays put. -->
   <form @submit.prevent="next()">
     <template v-if="step === 'details'">
-      <label for="email">Your email</label>
+      <label :for="emailId">Your email</label>
       <input
-        id="email"
+        :id="emailId"
         v-model="email"
         :disabled="starting"
         :aria-invalid="errors['email'] !== undefined"
-        :aria-describedby="errors['email'] === undefined ? undefined : 'email-error'"
+        :aria-describedby="errors['email'] === undefined ? undefined : `${emailId}-error`"
       />
-      <p v-if="errors['email'] !== undefined" id="email-error" role="alert">
+      <p v-if="errors['email'] !== undefined" :id="`${emailId}-error`" role="alert">
         {{ errors['email'] }}
       </p>
     </template>

--- a/examples/tasks/src/block-next/Wizard.vue
+++ b/examples/tasks/src/block-next/Wizard.vue
@@ -1,0 +1,36 @@
+<script setup lang="ts">
+import { useErrors, useField, useNavigation, useStep } from '@wizzard-packages/vue/v1';
+import { computed } from 'vue';
+
+const { current } = useStep();
+const { next, isBusy } = useNavigation();
+const email = useField<string>('details.email');
+const errors = useErrors();
+
+// Nothing is current until the engine starts, which happens in the browser.
+const step = computed(() => current.value ?? 'details');
+const starting = computed(() => current.value === null);
+</script>
+
+<template>
+  <!-- The refusal is the return value, not an exception: `next()` resolves to
+       `{ ok: false, reason: 'invalid', errors }` and the flow stays put. -->
+  <form @submit.prevent="next()">
+    <template v-if="step === 'details'">
+      <label for="email">Your email</label>
+      <input
+        id="email"
+        v-model="email"
+        :disabled="starting"
+        :aria-invalid="errors['email'] !== undefined"
+        :aria-describedby="errors['email'] === undefined ? undefined : 'email-error'"
+      />
+      <p v-if="errors['email'] !== undefined" id="email-error" role="alert">
+        {{ errors['email'] }}
+      </p>
+    </template>
+    <p v-else-if="step === 'done'">That address will do.</p>
+
+    <button type="submit" :disabled="starting || isBusy || step === 'done'">Next</button>
+  </form>
+</template>

--- a/examples/tasks/src/block-next/block-next.test.tsx
+++ b/examples/tasks/src/block-next/block-next.test.tsx
@@ -1,0 +1,92 @@
+import { mount, flushPromises } from '@vue/test-utils';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+import AppVue from './App.vue';
+import { App } from './App';
+import expectedOutput from './headless.out.txt?raw';
+
+/**
+ * The page's claim, checked: a move that the validator refuses does not happen,
+ * says which field is wrong, and the same move succeeds once the field is.
+ */
+const type = async (input: HTMLInputElement, value: string): Promise<void> => {
+  const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')?.set as (
+    this: HTMLInputElement,
+    v: string
+  ) => void;
+  await act(async () => {
+    setter.call(input, value);
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+  });
+};
+
+const submit = async (form: HTMLFormElement): Promise<void> => {
+  await act(async () => {
+    fireEvent.submit(form);
+  });
+};
+
+/** Line endings differ between a Windows checkout and CI; the content does not. */
+const lf = (s: string): string => s.replace(/\r\n/g, '\n');
+
+describe('block next until valid', () => {
+  it('refuses the move and names the field, on React', async () => {
+    const { container } = render(<App />);
+    const form = await waitFor(() => {
+      const found = container.querySelector('form');
+      if (found === null) throw new Error('no form yet');
+      return found;
+    });
+    await waitFor(() => {
+      expect((screen.getByLabelText('Your email') as HTMLInputElement).disabled).toBe(false);
+    });
+
+    await submit(form);
+
+    expect(screen.getByRole('alert').textContent).toContain('Enter your email address');
+    expect(screen.getByLabelText('Your email')).toHaveProperty('ariaInvalid', 'true');
+    expect(screen.queryByText('That address will do.')).toBeNull();
+
+    await type(screen.getByLabelText('Your email') as HTMLInputElement, 'ada@example.com');
+    await submit(form);
+
+    await waitFor(() => {
+      expect(screen.getByText('That address will do.')).toBeDefined();
+    });
+    expect(screen.queryByRole('alert')).toBeNull();
+  });
+
+  it('refuses the move and names the field, on Vue', async () => {
+    const app = mount(AppVue);
+    await flushPromises();
+
+    // In jsdom a click on a submit button does not run the form submission
+    // algorithm, so the event is dispatched on the form itself.
+    await app.get('form').trigger('submit');
+    await flushPromises();
+
+    expect(app.get('[role="alert"]').text()).toContain('Enter your email address');
+    expect(app.get('input').attributes('aria-invalid')).toBe('true');
+
+    await app.get('input').setValue('ada@example.com');
+    await app.get('form').trigger('submit');
+    await flushPromises();
+
+    expect(app.text()).toContain('That address will do.');
+    expect(app.find('[role="alert"]').exists()).toBe(false);
+  });
+
+  it('prints what the headless page shows', async () => {
+    const lines: unknown[] = [];
+    vi.spyOn(console, 'log').mockImplementation((line: unknown) => {
+      lines.push(line);
+    });
+
+    await import('./headless');
+
+    expect(`${lines.join('\n')}\n`).toBe(lf(expectedOutput));
+    vi.restoreAllMocks();
+  });
+});

--- a/examples/tasks/src/block-next/flow.ts
+++ b/examples/tasks/src/block-next/flow.ts
@@ -1,0 +1,20 @@
+import { defineFlow, step } from '@wizzard-packages/core/v1';
+
+/**
+ * The smallest flow with a guard on it: one step that will not be left until
+ * its validator is happy, and somewhere to go once it is.
+ *
+ * `validate` names a resolver rather than holding a function, because the flow
+ * has to stay JSON. `registry.ts` is where that name is answered.
+ */
+export const signup = defineFlow({
+  id: 'block-next',
+  order: ['details', 'done'],
+  steps: {
+    details: step<{ email: string }>({
+      label: 'Your details',
+      validate: { $ref: 'details' },
+    }),
+    done: step({ label: 'Done' }),
+  },
+});

--- a/examples/tasks/src/block-next/headless.out.txt
+++ b/examples/tasks/src/block-next/headless.out.txt
@@ -1,0 +1,5 @@
+step: details
+next: invalid ({"email":"Enter your email address."})
+step: details
+next: ok
+step: done

--- a/examples/tasks/src/block-next/headless.ts
+++ b/examples/tasks/src/block-next/headless.ts
@@ -1,0 +1,24 @@
+import { createWizard } from '@wizzard-packages/core/v1';
+
+import { signup } from './flow';
+import { registry } from './registry';
+
+/**
+ * The same guard without a framework. `next()` answers with a value either way,
+ * so the refusal is read, not caught.
+ */
+const wizard = createWizard({ flow: signup, registry });
+
+await wizard.start();
+console.log(`step: ${String(wizard.getSnapshot().current)}`);
+
+const refused = await wizard.next();
+if (!refused.ok) {
+  console.log(`next: ${refused.reason} (${JSON.stringify(refused.errors)})`);
+  console.log(`step: ${String(wizard.getSnapshot().current)}`);
+}
+
+wizard.set('details.email', 'ada@example.com');
+const moved = await wizard.next();
+console.log(`next: ${moved.ok ? 'ok' : moved.reason}`);
+console.log(`step: ${String(wizard.getSnapshot().current)}`);

--- a/examples/tasks/src/block-next/registry.ts
+++ b/examples/tasks/src/block-next/registry.ts
@@ -1,0 +1,25 @@
+import type { AsyncRegistry, Scope } from '@wizzard-packages/core/v1';
+
+/**
+ * What the flow could not serialize. A validator is an ordinary function of the
+ * data: it answers with the field messages it found, or `null` when the step is
+ * fit to leave.
+ *
+ * Returning messages keyed by field is what lets the rendering put each one
+ * beside the input it belongs to, rather than showing one sentence for the
+ * whole form.
+ */
+type Fields = Record<string, string> | null;
+
+const EMAIL = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+export const registry: AsyncRegistry = {
+  details: (_args, scope: Scope): Fields => {
+    const { email } = (scope.data['details'] as { email?: string } | undefined) ?? {};
+    if (typeof email !== 'string' || email.trim() === '') {
+      return { email: 'Enter your email address.' };
+    }
+    if (!EMAIL.test(email)) return { email: 'That does not look like an email address.' };
+    return null;
+  },
+};

--- a/examples/tasks/src/clear-branch-data/App.tsx
+++ b/examples/tasks/src/clear-branch-data/App.tsx
@@ -1,0 +1,86 @@
+import {
+  WizardProvider,
+  useField,
+  useNavigation,
+  useStep,
+  useWizardSelector,
+} from '@wizzard-packages/react/v1';
+
+import { checkout } from './flow';
+
+export function App() {
+  return (
+    <WizardProvider flow={checkout}>
+      <Wizard />
+    </WizardProvider>
+  );
+}
+
+export function Wizard() {
+  const { current, isLast } = useStep();
+  const { next, back, canBack } = useNavigation();
+  const [payer, setPayer] = useField<string>('plan.payer');
+  const [company, setCompany] = useField<string>('company.name');
+  const [code, setCode] = useField<string>('coupon.code');
+
+  // What would be submitted, read straight off the engine rather than tracked
+  // here: this is the whole point of the page, so it should not be a copy.
+  const data = useWizardSelector((s) => JSON.stringify(s.data, null, 2));
+
+  const step = current ?? 'plan';
+  const starting = current === null;
+
+  return (
+    <form onSubmit={(e) => e.preventDefault()}>
+      {step === 'plan' && (
+        <fieldset disabled={starting}>
+          <legend>Who is paying</legend>
+          {(['personal', 'business'] as const).map((choice) => (
+            <label key={choice}>
+              <input
+                type="radio"
+                name="payer"
+                value={choice}
+                checked={payer === choice}
+                onChange={() => setPayer(choice)}
+              />
+              {choice === 'personal' ? 'Personal' : 'Business'}
+            </label>
+          ))}
+        </fieldset>
+      )}
+
+      {step === 'company' && (
+        <label>
+          Company name
+          <input
+            value={company ?? ''}
+            onChange={(e) => setCompany(e.target.value)}
+            disabled={starting}
+          />
+        </label>
+      )}
+
+      {step === 'coupon' && (
+        <label>
+          Coupon code
+          <input value={code ?? ''} onChange={(e) => setCode(e.target.value)} disabled={starting} />
+        </label>
+      )}
+
+      {step === 'review' && (
+        <>
+          <p>This is what would be submitted:</p>
+          <pre>{data}</pre>
+        </>
+      )}
+
+      <button type="button" onClick={() => back()} disabled={starting || !canBack}>
+        Back
+      </button>
+      <button type="button" onClick={() => next()} disabled={starting || isLast}>
+        Next
+      </button>
+    </form>
+  );
+}

--- a/examples/tasks/src/clear-branch-data/App.vue
+++ b/examples/tasks/src/clear-branch-data/App.vue
@@ -1,0 +1,14 @@
+<script setup lang="ts">
+import { provideWizard } from '@wizzard-packages/vue/v1';
+
+import Wizard from './Wizard.vue';
+import { checkout } from './flow';
+
+// The wizard is provided here and consumed by the child. Vue's inject reads the
+// parent chain, so the component that provides cannot also use the composables.
+provideWizard({ flow: checkout });
+</script>
+
+<template>
+  <Wizard />
+</template>

--- a/examples/tasks/src/clear-branch-data/Wizard.vue
+++ b/examples/tasks/src/clear-branch-data/Wizard.vue
@@ -1,0 +1,47 @@
+<script setup lang="ts">
+import { useField, useNavigation, useStep, useWizardSelector } from '@wizzard-packages/vue/v1';
+import { computed } from 'vue';
+
+const { current, isLast } = useStep();
+const { next, back, canBack } = useNavigation();
+const payer = useField<string>('plan.payer');
+const company = useField<string>('company.name');
+const code = useField<string>('coupon.code');
+
+// What would be submitted, read straight off the engine rather than tracked
+// here: this is the whole point of the page, so it should not be a copy.
+const data = useWizardSelector((s) => JSON.stringify(s.data, null, 2));
+
+const step = computed(() => current.value ?? 'plan');
+const starting = computed(() => current.value === null);
+</script>
+
+<template>
+  <form @submit.prevent>
+    <fieldset v-if="step === 'plan'" :disabled="starting">
+      <legend>Who is paying</legend>
+      <label v-for="choice in ['personal', 'business']" :key="choice">
+        <input v-model="payer" type="radio" name="payer" :value="choice" />
+        {{ choice === 'personal' ? 'Personal' : 'Business' }}
+      </label>
+    </fieldset>
+
+    <label v-else-if="step === 'company'">
+      Company name
+      <input v-model="company" :disabled="starting" />
+    </label>
+
+    <label v-else-if="step === 'coupon'">
+      Coupon code
+      <input v-model="code" :disabled="starting" />
+    </label>
+
+    <template v-else-if="step === 'review'">
+      <p>This is what would be submitted:</p>
+      <pre>{{ data }}</pre>
+    </template>
+
+    <button type="button" :disabled="starting || !canBack" @click="back()">Back</button>
+    <button type="button" :disabled="starting || isLast" @click="next()">Next</button>
+  </form>
+</template>

--- a/examples/tasks/src/clear-branch-data/clear-branch-data.test.tsx
+++ b/examples/tasks/src/clear-branch-data/clear-branch-data.test.tsx
@@ -1,0 +1,92 @@
+import { mount, flushPromises } from '@vue/test-utils';
+import { render, screen, waitFor } from '@testing-library/react';
+import { act } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+import AppVue from './App.vue';
+import { App } from './App';
+import expectedOutput from './headless.out.txt?raw';
+
+/**
+ * The page's claim, checked: the step that says `clearOnLeave` does not put its
+ * answer in the submission, and the step that merely went off the route does.
+ */
+const click = async (element: HTMLElement): Promise<void> => {
+  await act(async () => {
+    element.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+  });
+};
+
+const type = async (input: HTMLInputElement, value: string): Promise<void> => {
+  const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')?.set as (
+    this: HTMLInputElement,
+    v: string
+  ) => void;
+  await act(async () => {
+    setter.call(input, value);
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+  });
+};
+
+/** Line endings differ between a Windows checkout and CI; the content does not. */
+const lf = (s: string): string => s.replace(/\r\n/g, '\n');
+
+const next = async (): Promise<void> => {
+  await click(screen.getByRole('button', { name: 'Next' }));
+};
+
+describe('clear abandoned branch data', () => {
+  it('keeps the branch it left and drops the step that asked to be dropped', async () => {
+    render(<App />);
+    await waitFor(() => {
+      expect(screen.getByRole('group')).toBeDefined();
+    });
+
+    await click(screen.getByLabelText('Business'));
+    await next();
+
+    await type(screen.getByLabelText('Company name') as HTMLInputElement, 'Acme');
+    await next();
+
+    await type(screen.getByLabelText('Coupon code') as HTMLInputElement, 'SPRING');
+    await next();
+
+    const submitted = screen.getByText(/"plan"/).textContent ?? '';
+    expect(submitted).toContain('Acme');
+    // Left the coupon step, so the code is not in what would be submitted.
+    expect(submitted).not.toContain('SPRING');
+    expect(submitted).not.toContain('coupon');
+  });
+
+  it('keeps what an abandoned branch collected, on Vue', async () => {
+    const app = mount(AppVue);
+    await flushPromises();
+
+    await app.get('input[value="business"]').setValue('business');
+    await app.get('button[type="button"]:last-of-type').trigger('click');
+    await flushPromises();
+
+    await app.get('input').setValue('Acme');
+    await app.get('button[type="button"]:last-of-type').trigger('click');
+    await flushPromises();
+
+    // Straight past the coupon step, which leaves it and clears it.
+    await app.get('button[type="button"]:last-of-type').trigger('click');
+    await flushPromises();
+
+    expect(app.get('pre').text()).toContain('Acme');
+    expect(app.get('pre').text()).not.toContain('coupon');
+  });
+
+  it('prints what the headless page shows', async () => {
+    const lines: unknown[] = [];
+    vi.spyOn(console, 'log').mockImplementation((line: unknown) => {
+      lines.push(line);
+    });
+
+    await import('./headless');
+
+    expect(`${lines.join('\n')}\n`).toBe(lf(expectedOutput));
+    vi.restoreAllMocks();
+  });
+});

--- a/examples/tasks/src/clear-branch-data/flow.ts
+++ b/examples/tasks/src/clear-branch-data/flow.ts
@@ -1,0 +1,39 @@
+import { defineFlow, step } from '@wizzard-packages/core/v1';
+import { eq, get } from '@wizzard-packages/core/expr';
+
+/**
+ * A branch, and one step whose answers must not travel with it.
+ *
+ * Two different rules are at work, and the page beside this file is about
+ * telling them apart:
+ *
+ * - `when` decides whether a step is on the route. A visitor who picks
+ *   `personal` never sees `company`, and anything they typed there before
+ *   changing their mind is *kept* - the engine does not throw data away
+ *   because a step stopped being reachable.
+ * - `clearOnLeave` is the opposite instruction, and it is per step: drop this
+ *   slice when the step is left, whichever way it is left. `coupon` is a code
+ *   that was either applied or was not; carrying it into the submission would
+ *   be keeping a receipt nobody asked for.
+ */
+export const checkout = defineFlow({
+  id: 'clear-branch-data',
+  version: 1,
+  order: ['plan', 'company', 'coupon', 'review'],
+  steps: {
+    plan: step<{ payer: 'personal' | 'business' }>({ label: 'Who is paying' }),
+
+    company: step<{ name: string }>({
+      label: 'Company',
+      when: eq(get('data.plan.payer'), 'business'),
+    }),
+
+    coupon: step<{ code: string }>({
+      label: 'Coupon',
+      clearOnLeave: true,
+    }),
+
+    review: step({ label: 'Review' }),
+  },
+  policy: 'free',
+});

--- a/examples/tasks/src/clear-branch-data/headless.out.txt
+++ b/examples/tasks/src/clear-branch-data/headless.out.txt
@@ -1,0 +1,5 @@
+step: review
+submitted: {"plan":{"payer":"business"},"company":{"name":"Acme"}}
+skipped to: coupon
+step: review
+submitted: {"plan":{"payer":"personal"},"company":{"name":"Acme"}}

--- a/examples/tasks/src/clear-branch-data/headless.ts
+++ b/examples/tasks/src/clear-branch-data/headless.ts
@@ -1,0 +1,38 @@
+import { createWizard } from '@wizzard-packages/core/v1';
+
+import { checkout } from './flow';
+
+/**
+ * The two rules side by side, with nothing rendering them.
+ *
+ * `coupon` declares `clearOnLeave`, so its slice is gone the moment the step is
+ * left - forwards included. `company` declares nothing, so what it collected
+ * stays in the data even after the visitor changes their mind and the step
+ * drops off the route.
+ */
+const wizard = createWizard({ flow: checkout });
+
+await wizard.start();
+wizard.set('plan.payer', 'business');
+await wizard.next();
+
+wizard.set('company.name', 'Acme');
+await wizard.next();
+
+wizard.set('coupon.code', 'SPRING');
+await wizard.next();
+
+console.log(`step: ${String(wizard.getSnapshot().current)}`);
+console.log(`submitted: ${JSON.stringify(wizard.getSnapshot().data)}`);
+
+// The visitor changes their mind: back to the first step, and pay personally.
+await wizard.go('plan');
+wizard.set('plan.payer', 'personal');
+
+// `company` is off the route now, so this lands on `coupon` and then `review`.
+await wizard.next();
+console.log(`skipped to: ${String(wizard.getSnapshot().current)}`);
+await wizard.next();
+
+console.log(`step: ${String(wizard.getSnapshot().current)}`);
+console.log(`submitted: ${JSON.stringify(wizard.getSnapshot().data)}`);

--- a/examples/tasks/src/raw.d.ts
+++ b/examples/tasks/src/raw.d.ts
@@ -1,0 +1,10 @@
+/**
+ * The bundler's `?raw` import, which reads a file as a string. The site gets
+ * this type from Astro; here the tests that compare a headless script's output
+ * against its checked-in file are the only users of it, and `tsc` alone knows
+ * nothing about the suffix.
+ */
+declare module '*?raw' {
+  const content: string;
+  export default content;
+}

--- a/examples/tasks/src/render-field-errors/App.tsx
+++ b/examples/tasks/src/render-field-errors/App.tsx
@@ -6,6 +6,7 @@ import {
   useStep,
   useWizard,
 } from '@wizzard-packages/react/v1';
+import { useId } from 'react';
 
 import { checkout } from './flow';
 import { registry } from './registry';
@@ -24,20 +25,24 @@ export function App() {
  * with `aria-invalid`, which is what a screen reader reads out.
  */
 function Field(props: {
-  id: string;
   label: string;
   value: string | undefined;
   error: string | undefined;
   disabled: boolean;
   onChange: (value: string) => void;
 }) {
-  const describedBy = props.error === undefined ? undefined : `${props.id}-error`;
+  // Generated, not written. Both renderings of this example are in the page at
+  // once - the tab that is not showing is hidden, not removed - so a fixed `id`
+  // would be in the document twice, and `for` and `aria-describedby` would both
+  // resolve to whichever came first rather than to the field beside them.
+  const id = useId();
+  const describedBy = props.error === undefined ? undefined : `${id}-error`;
 
   return (
     <p>
-      <label htmlFor={props.id}>{props.label}</label>
+      <label htmlFor={id}>{props.label}</label>
       <input
-        id={props.id}
+        id={id}
         value={props.value ?? ''}
         onChange={(e) => props.onChange(e.target.value)}
         disabled={props.disabled}
@@ -74,7 +79,6 @@ export function Wizard() {
       {step === 'details' && (
         <>
           <Field
-            id="email"
             label="Your email"
             value={email}
             error={errors['email']}
@@ -82,7 +86,6 @@ export function Wizard() {
             onChange={setEmail}
           />
           <Field
-            id="card"
             label="Card number"
             value={card}
             error={errors['card']}

--- a/examples/tasks/src/render-field-errors/App.tsx
+++ b/examples/tasks/src/render-field-errors/App.tsx
@@ -1,0 +1,111 @@
+import {
+  WizardProvider,
+  useErrors,
+  useField,
+  useNavigation,
+  useStep,
+  useWizard,
+} from '@wizzard-packages/react/v1';
+
+import { checkout } from './flow';
+import { registry } from './registry';
+
+export function App() {
+  return (
+    <WizardProvider flow={checkout} registry={registry}>
+      <Wizard />
+    </WizardProvider>
+  );
+}
+
+/**
+ * One field and its message, kept together so the two cannot drift apart: the
+ * input points at the message with `aria-describedby`, and says it is wrong
+ * with `aria-invalid`, which is what a screen reader reads out.
+ */
+function Field(props: {
+  id: string;
+  label: string;
+  value: string | undefined;
+  error: string | undefined;
+  disabled: boolean;
+  onChange: (value: string) => void;
+}) {
+  const describedBy = props.error === undefined ? undefined : `${props.id}-error`;
+
+  return (
+    <p>
+      <label htmlFor={props.id}>{props.label}</label>
+      <input
+        id={props.id}
+        value={props.value ?? ''}
+        onChange={(e) => props.onChange(e.target.value)}
+        disabled={props.disabled}
+        aria-invalid={props.error !== undefined}
+        aria-describedby={describedBy}
+      />
+      {props.error !== undefined && (
+        <span id={describedBy} role="alert">
+          {props.error}
+        </span>
+      )}
+    </p>
+  );
+}
+
+export function Wizard() {
+  const wizard = useWizard();
+  const { current } = useStep();
+  const { next, isBusy } = useNavigation();
+  const [email, setEmail] = useField<string>('details.email');
+  const [card, setCard] = useField<string>('details.card');
+  const errors = useErrors();
+
+  const step = current ?? 'details';
+  const starting = current === null;
+
+  return (
+    <form
+      onSubmit={(e) => {
+        e.preventDefault();
+        void next();
+      }}
+    >
+      {step === 'details' && (
+        <>
+          <Field
+            id="email"
+            label="Your email"
+            value={email}
+            error={errors['email']}
+            disabled={starting}
+            onChange={setEmail}
+          />
+          <Field
+            id="card"
+            label="Card number"
+            value={card}
+            error={errors['card']}
+            disabled={starting}
+            onChange={setCard}
+          />
+          {/* A message the engine could not have produced: the card was well
+              formed and the payment service still said no. It goes in the same
+              place, so the rendering needs no second path for it. */}
+          <button
+            type="button"
+            onClick={() => wizard.setErrors('details', { card: 'That card was declined.' })}
+            disabled={starting}
+          >
+            Pretend the server refused
+          </button>
+        </>
+      )}
+      {step === 'done' && <p>Both fields were fine.</p>}
+
+      <button type="submit" disabled={starting || isBusy || step === 'done'}>
+        Next
+      </button>
+    </form>
+  );
+}

--- a/examples/tasks/src/render-field-errors/App.vue
+++ b/examples/tasks/src/render-field-errors/App.vue
@@ -1,0 +1,15 @@
+<script setup lang="ts">
+import { provideWizard } from '@wizzard-packages/vue/v1';
+
+import Wizard from './Wizard.vue';
+import { checkout } from './flow';
+import { registry } from './registry';
+
+// The wizard is provided here and consumed by the child. Vue's inject reads the
+// parent chain, so the component that provides cannot also use the composables.
+provideWizard({ flow: checkout, registry });
+</script>
+
+<template>
+  <Wizard />
+</template>

--- a/examples/tasks/src/render-field-errors/Wizard.vue
+++ b/examples/tasks/src/render-field-errors/Wizard.vue
@@ -1,0 +1,63 @@
+<script setup lang="ts">
+import { useErrors, useField, useNavigation, useStep, useWizard } from '@wizzard-packages/vue/v1';
+import { computed } from 'vue';
+
+const wizard = useWizard();
+const { current } = useStep();
+const { next, isBusy } = useNavigation();
+const email = useField<string>('details.email');
+const card = useField<string>('details.card');
+const errors = useErrors();
+
+const step = computed(() => current.value ?? 'details');
+const starting = computed(() => current.value === null);
+</script>
+
+<template>
+  <form @submit.prevent="next()">
+    <template v-if="step === 'details'">
+      <!-- Each input points at its own message with `aria-describedby` and says
+           it is wrong with `aria-invalid`, which is what a screen reader reads. -->
+      <p>
+        <label for="email">Your email</label>
+        <input
+          id="email"
+          v-model="email"
+          :disabled="starting"
+          :aria-invalid="errors['email'] !== undefined"
+          :aria-describedby="errors['email'] === undefined ? undefined : 'email-error'"
+        />
+        <span v-if="errors['email'] !== undefined" id="email-error" role="alert">
+          {{ errors['email'] }}
+        </span>
+      </p>
+
+      <p>
+        <label for="card">Card number</label>
+        <input
+          id="card"
+          v-model="card"
+          :disabled="starting"
+          :aria-invalid="errors['card'] !== undefined"
+          :aria-describedby="errors['card'] === undefined ? undefined : 'card-error'"
+        />
+        <span v-if="errors['card'] !== undefined" id="card-error" role="alert">
+          {{ errors['card'] }}
+        </span>
+      </p>
+
+      <!-- A message the engine could not have produced: the card was well formed
+           and the payment service still said no. It goes in the same place. -->
+      <button
+        type="button"
+        :disabled="starting"
+        @click="wizard.setErrors('details', { card: 'That card was declined.' })"
+      >
+        Pretend the server refused
+      </button>
+    </template>
+    <p v-else-if="step === 'done'">Both fields were fine.</p>
+
+    <button type="submit" :disabled="starting || isBusy || step === 'done'">Next</button>
+  </form>
+</template>

--- a/examples/tasks/src/render-field-errors/Wizard.vue
+++ b/examples/tasks/src/render-field-errors/Wizard.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { useErrors, useField, useNavigation, useStep, useWizard } from '@wizzard-packages/vue/v1';
-import { computed } from 'vue';
+import { computed, useId } from 'vue';
 
 const wizard = useWizard();
 const { current } = useStep();
@@ -11,6 +11,13 @@ const errors = useErrors();
 
 const step = computed(() => current.value ?? 'details');
 const starting = computed(() => current.value === null);
+
+// Generated, not written. Both renderings of this example are in the page at
+// once - the tab that is not showing is hidden, not removed - so a fixed `id`
+// would be in the document twice, and `for` and `aria-describedby` would both
+// resolve to whichever came first rather than to the field beside them.
+const emailId = useId();
+const cardId = useId();
 </script>
 
 <template>
@@ -19,29 +26,29 @@ const starting = computed(() => current.value === null);
       <!-- Each input points at its own message with `aria-describedby` and says
            it is wrong with `aria-invalid`, which is what a screen reader reads. -->
       <p>
-        <label for="email">Your email</label>
+        <label :for="emailId">Your email</label>
         <input
-          id="email"
+          :id="emailId"
           v-model="email"
           :disabled="starting"
           :aria-invalid="errors['email'] !== undefined"
-          :aria-describedby="errors['email'] === undefined ? undefined : 'email-error'"
+          :aria-describedby="errors['email'] === undefined ? undefined : `${emailId}-error`"
         />
-        <span v-if="errors['email'] !== undefined" id="email-error" role="alert">
+        <span v-if="errors['email'] !== undefined" :id="`${emailId}-error`" role="alert">
           {{ errors['email'] }}
         </span>
       </p>
 
       <p>
-        <label for="card">Card number</label>
+        <label :for="cardId">Card number</label>
         <input
-          id="card"
+          :id="cardId"
           v-model="card"
           :disabled="starting"
           :aria-invalid="errors['card'] !== undefined"
-          :aria-describedby="errors['card'] === undefined ? undefined : 'card-error'"
+          :aria-describedby="errors['card'] === undefined ? undefined : `${cardId}-error`"
         />
-        <span v-if="errors['card'] !== undefined" id="card-error" role="alert">
+        <span v-if="errors['card'] !== undefined" :id="`${cardId}-error`" role="alert">
           {{ errors['card'] }}
         </span>
       </p>

--- a/examples/tasks/src/render-field-errors/flow.ts
+++ b/examples/tasks/src/render-field-errors/flow.ts
@@ -1,0 +1,17 @@
+import { defineFlow, step } from '@wizzard-packages/core/v1';
+
+/**
+ * One step with two fields, so there are two messages to place rather than one
+ * sentence to print. That is the whole difficulty this page is about.
+ */
+export const checkout = defineFlow({
+  id: 'render-field-errors',
+  order: ['details', 'done'],
+  steps: {
+    details: step<{ email: string; card: string }>({
+      label: 'Your details',
+      validate: { $ref: 'details' },
+    }),
+    done: step({ label: 'Done' }),
+  },
+});

--- a/examples/tasks/src/render-field-errors/headless.out.txt
+++ b/examples/tasks/src/render-field-errors/headless.out.txt
@@ -1,0 +1,6 @@
+both fields: {"email":"Enter your email address.","card":"A card number is sixteen digits."}
+email fixed: {"card":"A card number is sixteen digits."}
+from the host: {"card":"That card was declined."}
+next: ok
+step: done
+errors now: undefined

--- a/examples/tasks/src/render-field-errors/headless.ts
+++ b/examples/tasks/src/render-field-errors/headless.ts
@@ -1,0 +1,29 @@
+import { createWizard } from '@wizzard-packages/core/v1';
+
+import { checkout } from './flow';
+import { registry } from './registry';
+
+/**
+ * Where the messages live, with nothing rendering them: in the wizard's state,
+ * keyed by field, put there either by the validator or by the host.
+ */
+const wizard = createWizard({ flow: checkout, registry });
+
+await wizard.start();
+
+const refused = await wizard.next();
+if (!refused.ok) console.log(`both fields: ${JSON.stringify(refused.errors)}`);
+
+wizard.set('details.email', 'ada@example.com');
+const stillRefused = await wizard.next();
+if (!stillRefused.ok) console.log(`email fixed: ${JSON.stringify(stillRefused.errors)}`);
+
+// A message the engine could not have produced, put in the same place.
+wizard.setErrors('details', { card: 'That card was declined.' });
+console.log(`from the host: ${JSON.stringify(wizard.getSnapshot().errors['details'])}`);
+
+wizard.set('details.card', '4242424242424242');
+const moved = await wizard.next();
+console.log(`next: ${moved.ok ? 'ok' : moved.reason}`);
+console.log(`step: ${String(wizard.getSnapshot().current)}`);
+console.log(`errors now: ${JSON.stringify(wizard.getSnapshot().errors['details'])}`);

--- a/examples/tasks/src/render-field-errors/registry.ts
+++ b/examples/tasks/src/render-field-errors/registry.ts
@@ -1,0 +1,29 @@
+import type { AsyncRegistry, Scope } from '@wizzard-packages/core/v1';
+
+/**
+ * A validator answers with one message per field, keyed by the field's name, or
+ * `null` when there is nothing to say. The keys are what let the rendering put
+ * each message beside the input it belongs to.
+ */
+type Fields = Record<string, string> | null;
+
+const EMAIL = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+export const registry: AsyncRegistry = {
+  details: (_args, scope: Scope): Fields => {
+    const { email, card } =
+      (scope.data['details'] as { email?: string; card?: string } | undefined) ?? {};
+
+    const errors: Record<string, string> = {};
+    if (typeof email !== 'string' || email.trim() === '') {
+      errors['email'] = 'Enter your email address.';
+    } else if (!EMAIL.test(email)) {
+      errors['email'] = 'That does not look like an email address.';
+    }
+
+    const digits = typeof card === 'string' ? card.replace(/\s/g, '') : '';
+    if (!/^\d{16}$/.test(digits)) errors['card'] = 'A card number is sixteen digits.';
+
+    return Object.keys(errors).length === 0 ? null : errors;
+  },
+};

--- a/examples/tasks/src/render-field-errors/render-field-errors.test.tsx
+++ b/examples/tasks/src/render-field-errors/render-field-errors.test.tsx
@@ -1,0 +1,110 @@
+import { mount, flushPromises } from '@vue/test-utils';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+import AppVue from './App.vue';
+import { App } from './App';
+import expectedOutput from './headless.out.txt?raw';
+
+/**
+ * The page's claim, checked: every field that is wrong says so next to itself,
+ * fixing one leaves the other alone, and a message the host produced lands in
+ * the same place as the validator's.
+ */
+const type = async (input: HTMLInputElement, value: string): Promise<void> => {
+  const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')?.set as (
+    this: HTMLInputElement,
+    v: string
+  ) => void;
+  await act(async () => {
+    setter.call(input, value);
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+  });
+};
+
+const click = async (element: HTMLElement): Promise<void> => {
+  await act(async () => {
+    element.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+  });
+};
+
+const submit = async (form: HTMLFormElement): Promise<void> => {
+  await act(async () => {
+    fireEvent.submit(form);
+  });
+};
+
+/** Line endings differ between a Windows checkout and CI; the content does not. */
+const lf = (s: string): string => s.replace(/\r\n/g, '\n');
+
+describe('render field errors', () => {
+  it('puts a message beside each field that is wrong, on React', async () => {
+    const { container } = render(<App />);
+    const form = container.querySelector('form') as HTMLFormElement;
+    await waitFor(() => {
+      expect((screen.getByLabelText('Your email') as HTMLInputElement).disabled).toBe(false);
+    });
+
+    await submit(form);
+
+    expect(screen.getAllByRole('alert')).toHaveLength(2);
+    expect(screen.getByLabelText('Your email')).toHaveProperty('ariaInvalid', 'true');
+    expect(screen.getByLabelText('Card number')).toHaveProperty('ariaInvalid', 'true');
+
+    // Fixing one field leaves the other one's message where it was.
+    await type(screen.getByLabelText('Your email') as HTMLInputElement, 'ada@example.com');
+    await submit(form);
+    expect(screen.getAllByRole('alert')).toHaveLength(1);
+    expect(screen.getByRole('alert').textContent).toContain('sixteen digits');
+
+    // A message the engine could not have produced, in the same place.
+    await click(screen.getByRole('button', { name: 'Pretend the server refused' }));
+    expect(screen.getByRole('alert').textContent).toContain('declined');
+
+    await type(screen.getByLabelText('Card number') as HTMLInputElement, '4242424242424242');
+    await submit(form);
+
+    await waitFor(() => {
+      expect(screen.getByText('Both fields were fine.')).toBeDefined();
+    });
+    expect(screen.queryByRole('alert')).toBeNull();
+  });
+
+  it('puts a message beside each field that is wrong, on Vue', async () => {
+    const app = mount(AppVue);
+    await flushPromises();
+
+    // In jsdom a click on a submit button does not run the form submission
+    // algorithm, so the event is dispatched on the form itself.
+    await app.get('form').trigger('submit');
+    await flushPromises();
+
+    expect(app.findAll('[role="alert"]')).toHaveLength(2);
+    expect(app.get('#email').attributes('aria-invalid')).toBe('true');
+    expect(app.get('#card').attributes('aria-invalid')).toBe('true');
+
+    await app.get('#email').setValue('ada@example.com');
+    await app.get('form').trigger('submit');
+    await flushPromises();
+    expect(app.findAll('[role="alert"]')).toHaveLength(1);
+
+    await app.get('#card').setValue('4242424242424242');
+    await app.get('form').trigger('submit');
+    await flushPromises();
+
+    expect(app.text()).toContain('Both fields were fine.');
+  });
+
+  it('prints what the headless page shows', async () => {
+    const lines: unknown[] = [];
+    vi.spyOn(console, 'log').mockImplementation((line: unknown) => {
+      lines.push(line);
+    });
+
+    await import('./headless');
+
+    expect(`${lines.join('\n')}\n`).toBe(lf(expectedOutput));
+    vi.restoreAllMocks();
+  });
+});

--- a/examples/tasks/src/render-field-errors/render-field-errors.test.tsx
+++ b/examples/tasks/src/render-field-errors/render-field-errors.test.tsx
@@ -75,25 +75,56 @@ describe('render field errors', () => {
     const app = mount(AppVue);
     await flushPromises();
 
+    /**
+     * The field a label points at, found the way a screen reader finds it. Not
+     * `#email`: the ids are generated, and a test that writes one out is a test
+     * that keeps passing while the association it exists to check is broken.
+     */
+    const field = (label: string) => {
+      const id = app
+        .findAll('label')
+        .find((l) => l.text() === label)
+        ?.attributes('for');
+      if (id === undefined) throw new Error(`no label reads "${label}"`);
+      return app.get(`#${id}`);
+    };
+
     // In jsdom a click on a submit button does not run the form submission
     // algorithm, so the event is dispatched on the form itself.
     await app.get('form').trigger('submit');
     await flushPromises();
 
     expect(app.findAll('[role="alert"]')).toHaveLength(2);
-    expect(app.get('#email').attributes('aria-invalid')).toBe('true');
-    expect(app.get('#card').attributes('aria-invalid')).toBe('true');
+    expect(field('Your email').attributes('aria-invalid')).toBe('true');
+    expect(field('Card number').attributes('aria-invalid')).toBe('true');
 
-    await app.get('#email').setValue('ada@example.com');
+    await field('Your email').setValue('ada@example.com');
     await app.get('form').trigger('submit');
     await flushPromises();
     expect(app.findAll('[role="alert"]')).toHaveLength(1);
 
-    await app.get('#card').setValue('4242424242424242');
+    await field('Card number').setValue('4242424242424242');
     await app.get('form').trigger('submit');
     await flushPromises();
 
     expect(app.text()).toContain('Both fields were fine.');
+  });
+
+  it('gives each rendering its own ids when both share a document', async () => {
+    // The page this example appears on has both renderings in it at once: the
+    // tab that is not showing is hidden, not removed. Written-out ids were
+    // therefore in the document twice, and every `for` and `aria-describedby`
+    // resolved to whichever came first - so on the Vue tab a label pointed at
+    // the React field. That is the association these pages exist to teach.
+    render(<App />);
+    const vue = mount(AppVue, { attachTo: document.body });
+    await flushPromises();
+
+    const ids = [...document.querySelectorAll('[id]')].map((el) => el.id);
+    expect(ids.length).toBeGreaterThan(0);
+    expect(new Set(ids).size).toBe(ids.length);
+
+    vue.unmount();
   });
 
   it('prints what the headless page shows', async () => {

--- a/examples/tasks/src/restore-after-reload/App.tsx
+++ b/examples/tasks/src/restore-after-reload/App.tsx
@@ -1,0 +1,85 @@
+import { persist, type RestoreOutcome } from '@wizzard-packages/plugins/persist';
+import { WizardProvider, useField, useNavigation, useStep } from '@wizzard-packages/react/v1';
+import { useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
+
+import { APP_VERSION, STORAGE_KEY, signup } from './flow';
+import { describeRestore } from './outcome';
+
+export function App(): ReactNode {
+  // What the plugin decided, kept out of React's state until it is safe to
+  // read: `onRestore` runs while the engine is being created, which is during a
+  // render, and setting state there is not allowed.
+  const restored = useRef<RestoreOutcome | null>(null);
+
+  // In the browser only. On a server there is no storage to read, and a session
+  // restored into the server's markup is a hydration mismatch waiting to happen.
+  const plugins = useMemo(
+    () =>
+      typeof window === 'undefined'
+        ? []
+        : [
+            persist({
+              key: STORAGE_KEY,
+              version: APP_VERSION,
+              onRestore: (outcome) => {
+                restored.current = outcome;
+              },
+            }),
+          ],
+    []
+  );
+
+  return (
+    <WizardProvider flow={signup} plugins={plugins}>
+      <Wizard restored={restored} />
+    </WizardProvider>
+  );
+}
+
+export function Wizard(props: { restored: { current: RestoreOutcome | null } }): ReactNode {
+  const { current, isLast } = useStep();
+  const { next, back, canBack } = useNavigation();
+  const [full, setFull] = useField<string>('name.full');
+  const [favourite, setFavourite] = useField<string>('colour.favourite');
+
+  // Said after the first paint, for the same reason the plugin is installed in
+  // the browser only: the server never saw this session.
+  const [outcome, setOutcome] = useState<string>('Starting.');
+  useEffect(() => {
+    setOutcome(describeRestore(props.restored.current));
+  }, [props.restored]);
+
+  const step = current ?? 'name';
+  const starting = current === null;
+
+  return (
+    <form onSubmit={(e) => e.preventDefault()}>
+      <p role="status">{outcome}</p>
+
+      {step === 'name' && (
+        <label>
+          Your name
+          <input value={full ?? ''} onChange={(e) => setFull(e.target.value)} disabled={starting} />
+        </label>
+      )}
+      {step === 'colour' && (
+        <label>
+          A colour
+          <input
+            value={favourite ?? ''}
+            onChange={(e) => setFavourite(e.target.value)}
+            disabled={starting}
+          />
+        </label>
+      )}
+      {step === 'done' && <p>Saved as you went. Reload the page and see.</p>}
+
+      <button type="button" onClick={() => back()} disabled={starting || !canBack}>
+        Back
+      </button>
+      <button type="button" onClick={() => next()} disabled={starting || isLast}>
+        Next
+      </button>
+    </form>
+  );
+}

--- a/examples/tasks/src/restore-after-reload/App.vue
+++ b/examples/tasks/src/restore-after-reload/App.vue
@@ -1,0 +1,34 @@
+<script setup lang="ts">
+import { persist, type RestoreOutcome } from '@wizzard-packages/plugins/persist';
+import { provideWizard } from '@wizzard-packages/vue/v1';
+
+import Wizard from './Wizard.vue';
+import { APP_VERSION, STORAGE_KEY, signup } from './flow';
+
+/**
+ * The plugin is installed in the browser only: on a server there is no storage
+ * to read, and a session restored into the server's markup is a hydration
+ * mismatch waiting to happen. What it restored is shown by the child, one tick
+ * after mount, for the same reason.
+ */
+const restored: { outcome: RestoreOutcome | null } = { outcome: null };
+
+const plugins =
+  typeof window === 'undefined'
+    ? []
+    : [
+        persist({
+          key: STORAGE_KEY,
+          version: APP_VERSION,
+          onRestore: (outcome) => {
+            restored.outcome = outcome;
+          },
+        }),
+      ];
+
+provideWizard({ flow: signup, plugins });
+</script>
+
+<template>
+  <Wizard :restored="restored" />
+</template>

--- a/examples/tasks/src/restore-after-reload/Wizard.vue
+++ b/examples/tasks/src/restore-after-reload/Wizard.vue
@@ -1,0 +1,43 @@
+<script setup lang="ts">
+import type { RestoreOutcome } from '@wizzard-packages/plugins/persist';
+import { useField, useNavigation, useStep } from '@wizzard-packages/vue/v1';
+import { computed, onMounted, ref } from 'vue';
+
+import { describeRestore } from './outcome';
+
+const props = defineProps<{ restored: { outcome: RestoreOutcome | null } }>();
+
+const { current, isLast } = useStep();
+const { next, back, canBack } = useNavigation();
+const full = useField<string>('name.full');
+const favourite = useField<string>('colour.favourite');
+
+// Said after the first paint, for the same reason the plugin is installed in
+// the browser only: the server never saw this session.
+const outcome = ref('Starting.');
+onMounted(() => {
+  outcome.value = describeRestore(props.restored.outcome);
+});
+
+const step = computed(() => current.value ?? 'name');
+const starting = computed(() => current.value === null);
+</script>
+
+<template>
+  <form @submit.prevent>
+    <p role="status">{{ outcome }}</p>
+
+    <label v-if="step === 'name'">
+      Your name
+      <input v-model="full" :disabled="starting" />
+    </label>
+    <label v-else-if="step === 'colour'">
+      A colour
+      <input v-model="favourite" :disabled="starting" />
+    </label>
+    <p v-else-if="step === 'done'">Saved as you went. Reload the page and see.</p>
+
+    <button type="button" :disabled="starting || !canBack" @click="back()">Back</button>
+    <button type="button" :disabled="starting || isLast" @click="next()">Next</button>
+  </form>
+</template>

--- a/examples/tasks/src/restore-after-reload/flow.ts
+++ b/examples/tasks/src/restore-after-reload/flow.ts
@@ -1,0 +1,22 @@
+import { defineFlow, step } from '@wizzard-packages/core/v1';
+
+/** One key per flow. Change it and every stored session is orphaned. */
+export const STORAGE_KEY = 'restore-after-reload';
+
+/**
+ * The application's own version, which is not the flow's. Bump it when the
+ * meaning of what you collected changes, and sessions written before the change
+ * are refused rather than half-read.
+ */
+export const APP_VERSION = 1;
+
+export const signup = defineFlow({
+  id: 'restore-after-reload',
+  version: 1,
+  order: ['name', 'colour', 'done'],
+  steps: {
+    name: step<{ full: string }>({ label: 'Your name' }),
+    colour: step<{ favourite: string }>({ label: 'A colour' }),
+    done: step({ label: 'Done' }),
+  },
+});

--- a/examples/tasks/src/restore-after-reload/headless.out.txt
+++ b/examples/tasks/src/restore-after-reload/headless.out.txt
@@ -1,0 +1,5 @@
+first visit: Nothing saved yet. This one will be, from the first answer.
+left on: colour
+after reload: Restored. You are back where you left off.
+back on: colour
+name kept: Ada

--- a/examples/tasks/src/restore-after-reload/headless.ts
+++ b/examples/tasks/src/restore-after-reload/headless.ts
@@ -1,0 +1,62 @@
+import { createWizard } from '@wizzard-packages/core/v1';
+import { persist, type RestoreOutcome, type SyncStorage } from '@wizzard-packages/plugins/persist';
+
+import { APP_VERSION, STORAGE_KEY, signup } from './flow';
+import { describeRestore } from './outcome';
+
+/**
+ * A reload, without a browser to reload.
+ *
+ * The plugin writes to `localStorage` unless it is handed something else, and
+ * what it needs is three methods. A `Map` behind them is enough to show the
+ * whole round trip: fill a session in, throw the wizard away, build another
+ * one over the same storage, and read what came back.
+ */
+const kept = new Map<string, string>();
+
+const storage: SyncStorage = {
+  getItem: (key) => kept.get(key) ?? null,
+  setItem: (key, value) => {
+    kept.set(key, value);
+  },
+  removeItem: (key) => {
+    kept.delete(key);
+  },
+};
+
+const open = async (): Promise<{ wizard: ReturnType<typeof createWizard>; said: string }> => {
+  let outcome: RestoreOutcome | null = null;
+  const wizard = createWizard({
+    flow: signup,
+    plugins: [
+      persist({
+        key: STORAGE_KEY,
+        version: APP_VERSION,
+        storage,
+        onRestore: (o) => {
+          outcome = o;
+        },
+      }),
+    ],
+  });
+  await wizard.start();
+  return { wizard, said: describeRestore(outcome) };
+};
+
+const first = await open();
+console.log(`first visit: ${first.said}`);
+first.wizard.set('name.full', 'Ada');
+await first.wizard.next();
+console.log(`left on: ${String(first.wizard.getSnapshot().current)}`);
+
+// The tab closes here. Writes are coalesced - one per frame, not one per
+// keystroke - so the plugin flushes what is pending when it is torn down, which
+// is what `destroy()` does and what a browser's `pagehide` does for it. Without
+// this, the last answer would still be waiting on a timer nobody will see.
+first.wizard.destroy();
+
+// Nothing of the wizard above survives except the bytes.
+const second = await open();
+console.log(`after reload: ${second.said}`);
+console.log(`back on: ${String(second.wizard.getSnapshot().current)}`);
+console.log(`name kept: ${String(second.wizard.get('name.full'))}`);

--- a/examples/tasks/src/restore-after-reload/outcome.ts
+++ b/examples/tasks/src/restore-after-reload/outcome.ts
@@ -1,0 +1,28 @@
+import type { RestoreOutcome } from '@wizzard-packages/plugins/persist';
+
+/**
+ * What the person is told about the session they did or did not get back.
+ *
+ * A form that was half filled in and is now empty looks like a bug to whoever
+ * filled it, and silence is why they would think so. The plugin answers with a
+ * reason for exactly this; turning it into a sentence is the host's job,
+ * because only the host knows what the form is called.
+ *
+ * Shared by both renderings so the two cannot drift into saying different
+ * things about the same event.
+ */
+export function describeRestore(outcome: RestoreOutcome | null): string {
+  if (outcome === null) return 'Starting.';
+  if (outcome.restored) return 'Restored. You are back where you left off.';
+
+  switch (outcome.reason) {
+    case 'persist/nothing-stored':
+      return 'Nothing saved yet. This one will be, from the first answer.';
+    case 'persist/unavailable':
+      return 'Saving unavailable: this browser did not allow storage, which private windows do.';
+    case 'snapshot/version':
+      return 'Reset: the saved session is in a format this build does not read.';
+    default:
+      return `Reset: the saved session could not be read (${outcome.reason}).`;
+  }
+}

--- a/examples/tasks/src/restore-after-reload/restore-after-reload.test.tsx
+++ b/examples/tasks/src/restore-after-reload/restore-after-reload.test.tsx
@@ -1,0 +1,102 @@
+import { mount, flushPromises } from '@vue/test-utils';
+import { render, screen, waitFor } from '@testing-library/react';
+import { act } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import AppVue from './App.vue';
+import { App } from './App';
+import { STORAGE_KEY } from './flow';
+import expectedOutput from './headless.out.txt?raw';
+
+/**
+ * The page's claim, checked: what was typed comes back after the page is thrown
+ * away, and the person is told which of the two happened.
+ *
+ * Mounting twice is this suite's stand-in for a reload - the second mount reads
+ * the storage the first one wrote, which is all a reload does here.
+ */
+const type = async (input: HTMLInputElement, value: string): Promise<void> => {
+  const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')?.set as (
+    this: HTMLInputElement,
+    v: string
+  ) => void;
+  await act(async () => {
+    setter.call(input, value);
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+  });
+};
+
+const click = async (button: HTMLElement): Promise<void> => {
+  await act(async () => {
+    button.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+  });
+};
+
+/** Line endings differ between a Windows checkout and CI; the content does not. */
+const lf = (s: string): string => s.replace(/\r\n/g, '\n');
+
+describe('restore after reload', () => {
+  beforeEach(() => {
+    // One storage key, one jsdom, several tests: without this the next test
+    // restores the previous one's session and measures the wrong thing.
+    localStorage.clear();
+  });
+
+  it('brings the session back on React, and says so', async () => {
+    const first = render(<App />);
+    await type((await screen.findByRole('textbox')) as HTMLInputElement, 'Ada');
+    await click(screen.getByRole('button', { name: 'Next' }));
+    expect(screen.getByLabelText('A colour')).toBeDefined();
+    first.unmount();
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('status').textContent).toContain('Restored');
+    });
+    expect(screen.getByLabelText('A colour')).toBeDefined();
+  });
+
+  it('brings the session back on Vue, and says so', async () => {
+    const first = mount(AppVue);
+    await flushPromises();
+    await first.get('input').setValue('Ada');
+    await first.get('button[type="button"]:last-of-type').trigger('click');
+    await flushPromises();
+    first.unmount();
+
+    const second = mount(AppVue);
+    await flushPromises();
+
+    expect(second.get('[role="status"]').text()).toContain('Restored');
+    expect(second.text()).toContain('A colour');
+  });
+
+  it('says nothing was stored on a first visit, and saves from then on', async () => {
+    const first = render(<App />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('status').textContent).toContain('Nothing saved yet');
+    });
+
+    // Not "the key is still absent" here. The plugin writes on every commit and
+    // `start()` is one, behind a coalescing timer - so that assertion is a race
+    // with the timer, and it is the kind that passes alone and fails in a full
+    // run. Tearing the wizard down flushes what is pending, which is where the
+    // answer stops depending on timing.
+    first.unmount();
+    expect(localStorage.getItem(STORAGE_KEY)).not.toBeNull();
+  });
+
+  it('prints what the headless page shows', async () => {
+    const lines: unknown[] = [];
+    vi.spyOn(console, 'log').mockImplementation((line: unknown) => {
+      lines.push(line);
+    });
+
+    await import('./headless');
+
+    expect(`${lines.join('\n')}\n`).toBe(lf(expectedOutput));
+    vi.restoreAllMocks();
+  });
+});

--- a/examples/tasks/src/vue-shim.d.ts
+++ b/examples/tasks/src/vue-shim.d.ts
@@ -1,0 +1,7 @@
+// Single-file components are compiled by the bundler, not by tsc; this is the
+// shim every Vue-in-TypeScript project carries so an import of one type-checks.
+declare module '*.vue' {
+  import type { DefineComponent } from 'vue';
+  const component: DefineComponent<Record<string, never>, Record<string, never>, unknown>;
+  export default component;
+}

--- a/examples/tasks/tsconfig.json
+++ b/examples/tasks/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "noEmit": true,
+    "types": ["vitest/globals"]
+  },
+  "include": ["src"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -446,6 +446,46 @@ importers:
         specifier: ^7.2.4
         version: 7.3.0(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.33.0)(yaml@2.9.0)
 
+  examples/tasks:
+    dependencies:
+      '@wizzard-packages/core':
+        specifier: workspace:*
+        version: link:../../packages/core
+      '@wizzard-packages/plugins':
+        specifier: workspace:*
+        version: link:../../packages/plugins
+      '@wizzard-packages/react':
+        specifier: workspace:*
+        version: link:../../packages/react
+      '@wizzard-packages/vue':
+        specifier: workspace:*
+        version: link:../../packages/vue
+      react:
+        specifier: ^19.2.0
+        version: 19.2.3
+      react-dom:
+        specifier: ^19.2.0
+        version: 19.2.3(react@19.2.3)
+      vue:
+        specifier: ^3.5.13
+        version: 3.5.27(typescript@5.9.3)
+    devDependencies:
+      '@testing-library/react':
+        specifier: ^16.3.1
+        version: 16.3.1(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@types/react':
+        specifier: ^19.2.7
+        version: 19.2.7
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.7)
+      '@vue/test-utils':
+        specifier: ^2.4.6
+        version: 2.4.6
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+
   examples/vue-demo:
     dependencies:
       '@wizzard-packages/adapter-zod':
@@ -777,6 +817,9 @@ importers:
       '@examples/reference':
         specifier: workspace:*
         version: link:../examples/reference
+      '@examples/tasks':
+        specifier: workspace:*
+        version: link:../examples/tasks
       '@fontsource-variable/inter-tight':
         specifier: ^5.3.0
         version: 5.3.0

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -44,6 +44,17 @@ export default defineConfig({
           items: [{ label: 'Getting started', link: '/docs/start/' }],
         },
         {
+          // Titled by the phrase a person would search for, because that is how
+          // they arrive: with a task, not with a concept.
+          label: 'Tasks',
+          items: [
+            { label: 'Block Next until valid', link: '/docs/block-next-until-valid/' },
+            { label: 'Restore after reload', link: '/docs/restore-after-reload/' },
+            { label: 'Clear abandoned branch data', link: '/docs/clear-abandoned-branch-data/' },
+            { label: 'Render field errors', link: '/docs/render-field-errors/' },
+          ],
+        },
+        {
           label: 'Guides',
           items: [
             { label: 'The flow', link: '/docs/flow/' },

--- a/site/package.json
+++ b/site/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@examples/quickstart": "workspace:*",
     "@examples/reference": "workspace:*",
+    "@examples/tasks": "workspace:*",
     "@fontsource-variable/inter-tight": "^5.3.0",
     "@fontsource-variable/jetbrains-mono": "^5.3.0",
     "@wizzard-packages/core": "workspace:^",

--- a/site/src/content/docs/docs/block-next-until-valid.mdx
+++ b/site/src/content/docs/docs/block-next-until-valid.mdx
@@ -1,0 +1,93 @@
+---
+title: Block Next until valid
+description: Stop a wizard leaving a step until its validator is happy, and say which field is wrong.
+---
+
+import RunnableExample from '../../../components/RunnableExample.astro';
+import BlockNextReact from '../../../islands/BlockNextReact';
+import BlockNextVue from '../../../islands/BlockNextVue.vue';
+import flowSource from '@examples/tasks/src/block-next/flow.ts?raw';
+import registrySource from '@examples/tasks/src/block-next/registry.ts?raw';
+import appSource from '@examples/tasks/src/block-next/App.tsx?raw';
+import appVueSource from '@examples/tasks/src/block-next/App.vue?raw';
+import wizardVueSource from '@examples/tasks/src/block-next/Wizard.vue?raw';
+import headlessSource from '@examples/tasks/src/block-next/headless.ts?raw';
+import headlessOutput from '@examples/tasks/src/block-next/headless.out.txt?raw';
+
+A step that must be filled in correctly before the flow moves on declares a validator, and the
+engine refuses the move until it passes. You do not write that check into the button.
+
+Press Next below with the field empty.
+
+<RunnableExample
+  reactSources={[
+    {
+      name: 'flow.ts',
+      lang: 'ts',
+      code: flowSource,
+      note: '`validate` names a resolver rather than holding a function, because the flow has to stay JSON.',
+    },
+    {
+      name: 'registry.ts',
+      lang: 'ts',
+      code: registrySource,
+      note: 'The function that name resolves to. It answers with a message per field, or `null` when the step is fit to leave.',
+    },
+    { name: 'App.tsx', lang: 'tsx', code: appSource },
+  ]}
+  vueSources={[
+    { name: 'flow.ts', lang: 'ts', code: flowSource },
+    { name: 'registry.ts', lang: 'ts', code: registrySource },
+    {
+      name: 'App.vue',
+      lang: 'vue',
+      code: appVueSource,
+      note: 'The parent provides the wizard; `inject` reads the parent chain.',
+    },
+    { name: 'Wizard.vue', lang: 'vue', code: wizardVueSource },
+  ]}
+  headlessSources={[
+    { name: 'flow.ts', lang: 'ts', code: flowSource },
+    { name: 'registry.ts', lang: 'ts', code: registrySource },
+    { name: 'headless.ts', lang: 'ts', code: headlessSource },
+    {
+      name: 'Output',
+      lang: 'text',
+      code: headlessOutput,
+      note: 'A test in the repository asserts these exact lines.',
+    },
+  ]}
+>
+  <BlockNextReact client:visible slot="react" />
+  <BlockNextVue client:visible slot="vue" />
+</RunnableExample>
+
+## What happens
+
+`next()` does not throw when the validator refuses. It resolves to a value that says why:
+
+```ts
+const result = await next();
+// { ok: false, reason: 'invalid', errors: { email: 'Enter your email address.' } }
+```
+
+The flow stays where it was, and the messages are written into the wizard's state, where
+`useErrors()` reads them. A component that renders a field does not need the result of the call
+that produced its message.
+
+## Things worth knowing
+
+The validator is a function of the data, not of a form: it reads `scope.data` and returns field
+messages. That is what makes it testable without a browser, and what lets the headless tab above
+drive the same check with no rendering at all.
+
+A validator may be asynchronous. While it is in the air `isBusy` is true, which is what disables
+the button - and if the person presses Back before it answers, the answer is discarded rather
+than applied to a step they have left.
+
+## Where to read more
+
+[Validation](../validation/) separates checking a definition from checking a user's answers and
+covers `validate(step?)`, `validateAll()` and `setErrors`. [Navigation](../navigation/) has the
+full table of refusal reasons. [Render field errors](../render-field-errors/) is the other half
+of this page: where the messages go once you have them.

--- a/site/src/content/docs/docs/clear-abandoned-branch-data.mdx
+++ b/site/src/content/docs/docs/clear-abandoned-branch-data.mdx
@@ -76,10 +76,25 @@ paths drops exactly those:
 clearOnLeave: ['payment.cvv'],
 ```
 
-The rule is **whenever the step is left**, forwards included. That is right for a one-time code,
-a card's security number, a coupon that was either applied or was not - things you never want in
-the object the last step submits, or in a snapshot waiting in storage. It is wrong for anything
-the review step needs, so do not reach for it to tidy up a branch.
+The rule is **whenever the step is left**, forwards included. That is right for a one-time code
+or a coupon that was either applied or was not - things the last step has no business submitting.
+It is wrong for anything the review step needs, so do not reach for it to tidy up a branch.
+
+## What it does not protect
+
+`clearOnLeave` runs on a move away from the step, and only on that. Two things follow, and both
+matter if you were about to reach for it to keep a card number out of storage.
+
+**While the person is still on the step, what they typed is already written.** Every edit is a
+commit, and a persistence plugin writes on every commit. Leaving the step keeps the value out of
+the next write; it does not reach back into the one that has already happened.
+
+**Completion is not a move away.** A flow that ends keeps the last step's data, because that data
+is the submission.
+
+So for a field that must never be stored, keep it out of the persisted state rather than clearing
+it afterwards: hold it in the component that collects it, or give the wizard a storage that
+refuses to write that path.
 
 ## Where to read more
 

--- a/site/src/content/docs/docs/clear-abandoned-branch-data.mdx
+++ b/site/src/content/docs/docs/clear-abandoned-branch-data.mdx
@@ -1,0 +1,89 @@
+---
+title: Clear abandoned branch data
+description: Decide what a step leaves behind when the visitor changes their mind, and what never reaches the submission.
+---
+
+import RunnableExample from '../../../components/RunnableExample.astro';
+import ClearBranchReact from '../../../islands/ClearBranchReact';
+import ClearBranchVue from '../../../islands/ClearBranchVue.vue';
+import flowSource from '@examples/tasks/src/clear-branch-data/flow.ts?raw';
+import appSource from '@examples/tasks/src/clear-branch-data/App.tsx?raw';
+import appVueSource from '@examples/tasks/src/clear-branch-data/App.vue?raw';
+import wizardVueSource from '@examples/tasks/src/clear-branch-data/Wizard.vue?raw';
+import headlessSource from '@examples/tasks/src/clear-branch-data/headless.ts?raw';
+import headlessOutput from '@examples/tasks/src/clear-branch-data/headless.out.txt?raw';
+
+Two different questions get confused here, so this page separates them:
+
+- A step went **off the route** because a condition changed. What it collected is **kept**.
+- A step says its answers **must not travel onward**. They are dropped whenever it is left.
+
+Pick Business, fill the company in, then go back and pick Personal. The review step shows what
+would be submitted.
+
+<RunnableExample
+  reactSources={[
+    {
+      name: 'flow.ts',
+      lang: 'ts',
+      code: flowSource,
+      note: '`when` decides reachability; `clearOnLeave` decides what survives leaving. They are not the same instruction.',
+    },
+    { name: 'App.tsx', lang: 'tsx', code: appSource },
+  ]}
+  vueSources={[
+    { name: 'flow.ts', lang: 'ts', code: flowSource },
+    { name: 'App.vue', lang: 'vue', code: appVueSource },
+    { name: 'Wizard.vue', lang: 'vue', code: wizardVueSource },
+  ]}
+  headlessSources={[
+    { name: 'flow.ts', lang: 'ts', code: flowSource },
+    { name: 'headless.ts', lang: 'ts', code: headlessSource },
+    {
+      name: 'Output',
+      lang: 'text',
+      code: headlessOutput,
+      note: 'A test in the repository asserts these exact lines.',
+    },
+  ]}
+>
+  <ClearBranchReact client:visible slot="react" />
+  <ClearBranchVue client:visible slot="vue" />
+</RunnableExample>
+
+## Abandoned is not deleted
+
+A step whose `when` is false is off the route: it is skipped forwards and backwards, and it is
+drawn as a step this visitor will not see. The engine does not throw away what it collected
+before the condition changed, because it cannot know whether you wanted that. A visitor who
+switches back to Business finds the company name still there.
+
+If that is not what you want for a particular step, say so on the step:
+
+```ts
+coupon: step<{ code: string }>({
+  label: 'Coupon',
+  clearOnLeave: true,
+}),
+```
+
+## What `clearOnLeave` drops, and when
+
+`true` drops the whole slice - the step's own `slice`, or its id when it has none. A list of
+paths drops exactly those:
+
+```ts
+clearOnLeave: ['payment.cvv'],
+```
+
+The rule is **whenever the step is left**, forwards included. That is right for a one-time code,
+a card's security number, a coupon that was either applied or was not - things you never want in
+the object the last step submits, or in a snapshot waiting in storage. It is wrong for anything
+the review step needs, so do not reach for it to tidy up a branch.
+
+## Where to read more
+
+[The flow](../flow/) has the full step table, including `slice` and `when`.
+[Expressions](../expressions/) is the language a `when` is written in, and
+[Navigation](../navigation/) covers what happens to the back stack when a step stops being
+reachable.

--- a/site/src/content/docs/docs/render-field-errors.mdx
+++ b/site/src/content/docs/docs/render-field-errors.mdx
@@ -1,0 +1,100 @@
+---
+title: Render field errors
+description: Put each validation message beside the field it belongs to, accessibly, from the validator or from your server.
+---
+
+import RunnableExample from '../../../components/RunnableExample.astro';
+import FieldErrorsReact from '../../../islands/FieldErrorsReact';
+import FieldErrorsVue from '../../../islands/FieldErrorsVue.vue';
+import flowSource from '@examples/tasks/src/render-field-errors/flow.ts?raw';
+import registrySource from '@examples/tasks/src/render-field-errors/registry.ts?raw';
+import appSource from '@examples/tasks/src/render-field-errors/App.tsx?raw';
+import appVueSource from '@examples/tasks/src/render-field-errors/App.vue?raw';
+import wizardVueSource from '@examples/tasks/src/render-field-errors/Wizard.vue?raw';
+import headlessSource from '@examples/tasks/src/render-field-errors/headless.ts?raw';
+import headlessOutput from '@examples/tasks/src/render-field-errors/headless.out.txt?raw';
+
+Validation messages are keyed by field, so each one can be drawn next to the input it is about
+rather than collected into a list at the top of the form.
+
+Press Next with both fields empty.
+
+<RunnableExample
+  reactSources={[
+    { name: 'flow.ts', lang: 'ts', code: flowSource },
+    {
+      name: 'registry.ts',
+      lang: 'ts',
+      code: registrySource,
+      note: 'One message per field, keyed by the field name. The keys are what make the placement possible.',
+    },
+    {
+      name: 'App.tsx',
+      lang: 'tsx',
+      code: appSource,
+      note: 'The field and its message are one component, so the two cannot drift apart.',
+    },
+  ]}
+  vueSources={[
+    { name: 'flow.ts', lang: 'ts', code: flowSource },
+    { name: 'registry.ts', lang: 'ts', code: registrySource },
+    { name: 'App.vue', lang: 'vue', code: appVueSource },
+    { name: 'Wizard.vue', lang: 'vue', code: wizardVueSource },
+  ]}
+  headlessSources={[
+    { name: 'flow.ts', lang: 'ts', code: flowSource },
+    { name: 'registry.ts', lang: 'ts', code: registrySource },
+    { name: 'headless.ts', lang: 'ts', code: headlessSource },
+    {
+      name: 'Output',
+      lang: 'text',
+      code: headlessOutput,
+      note: 'A test in the repository asserts these exact lines.',
+    },
+  ]}
+>
+  <FieldErrorsReact client:visible slot="react" />
+  <FieldErrorsVue client:visible slot="vue" />
+</RunnableExample>
+
+## Reading the messages
+
+`useErrors()` returns the map for the current step, or for a step you name. It is a plain
+object keyed by field:
+
+```ts
+const errors = useErrors();
+errors['email']; // string | undefined
+```
+
+On Vue it is a `ComputedRef` of the same object, which the template unwraps for you.
+
+## Making it accessible
+
+Three attributes do the work, and the example above carries all three:
+
+- `aria-invalid` on the input, so the field announces itself as wrong.
+- `aria-describedby` pointing at the message's `id`, so the message is read with the field
+  rather than stranded somewhere after it.
+- `role="alert"` on the message, so it is announced when it appears.
+
+A message that is only a red border says nothing to anyone who cannot see the border.
+
+## Messages your server produced
+
+A card can be perfectly well formed and still be declined. `setErrors` puts that message in the
+same place as the validator's, so the rendering needs no second path for it:
+
+```ts
+wizard.setErrors('details', { card: 'That card was declined.' });
+wizard.setErrors('details', null); // clear
+```
+
+The next successful validation of that step replaces what is there, which is why the message
+disappears once the field is corrected.
+
+## Where to read more
+
+[Validation](../validation/) covers when validators run and how to run one by hand.
+[Block Next until valid](../block-next-until-valid/) is the other half of this page: the refusal
+that produces these messages in the first place.

--- a/site/src/content/docs/docs/restore-after-reload.mdx
+++ b/site/src/content/docs/docs/restore-after-reload.mdx
@@ -1,0 +1,94 @@
+---
+title: Restore after reload
+description: Save a half-finished wizard and bring it back after the page reloads, telling the person what happened.
+---
+
+import RunnableExample from '../../../components/RunnableExample.astro';
+import RestoreReact from '../../../islands/RestoreReact';
+import RestoreVue from '../../../islands/RestoreVue.vue';
+import flowSource from '@examples/tasks/src/restore-after-reload/flow.ts?raw';
+import outcomeSource from '@examples/tasks/src/restore-after-reload/outcome.ts?raw';
+import appSource from '@examples/tasks/src/restore-after-reload/App.tsx?raw';
+import appVueSource from '@examples/tasks/src/restore-after-reload/App.vue?raw';
+import wizardVueSource from '@examples/tasks/src/restore-after-reload/Wizard.vue?raw';
+import headlessSource from '@examples/tasks/src/restore-after-reload/headless.ts?raw';
+import headlessOutput from '@examples/tasks/src/restore-after-reload/headless.out.txt?raw';
+
+A wizard that loses everything when someone reloads the page is a wizard people restart in a
+worse mood. The `persist` plugin writes each commit to storage and reads it back on start.
+
+Type a name below, press Next, then reload this page.
+
+<RunnableExample
+  reactSources={[
+    {
+      name: 'flow.ts',
+      lang: 'ts',
+      code: flowSource,
+      note: 'The storage key and the application version live beside the flow they belong to.',
+    },
+    {
+      name: 'App.tsx',
+      lang: 'tsx',
+      code: appSource,
+      note: 'The plugin is installed in the browser only, and what it restored is said after the first paint.',
+    },
+    {
+      name: 'outcome.ts',
+      lang: 'ts',
+      code: outcomeSource,
+      note: 'The reason turned into a sentence. Only the host knows what the form is called.',
+    },
+  ]}
+  vueSources={[
+    { name: 'flow.ts', lang: 'ts', code: flowSource },
+    { name: 'App.vue', lang: 'vue', code: appVueSource },
+    { name: 'Wizard.vue', lang: 'vue', code: wizardVueSource },
+    { name: 'outcome.ts', lang: 'ts', code: outcomeSource },
+  ]}
+  headlessSources={[
+    { name: 'flow.ts', lang: 'ts', code: flowSource },
+    {
+      name: 'headless.ts',
+      lang: 'ts',
+      code: headlessSource,
+      note: 'A reload without a browser: a `Map` behind the three storage methods, and a second wizard over the same bytes.',
+    },
+    {
+      name: 'Output',
+      lang: 'text',
+      code: headlessOutput,
+      note: 'A test in the repository asserts these exact lines.',
+    },
+  ]}
+>
+  <RestoreReact client:visible slot="react" />
+  <RestoreVue client:visible slot="vue" />
+</RunnableExample>
+
+## Three things this gets right
+
+**It never throws.** A browser that refuses storage, a quota that fills up, a session written
+before the flow changed shape: each one means this session is not coming back, and none of them
+is a reason to break the wizard someone is filling in right now.
+
+**It says what happened.** `onRestore` hands you `{ restored: true }` or a reason, and the
+example turns that into a sentence. A form that was half filled in and is now empty looks like a
+bug to whoever filled it, and silence is why they would think so.
+
+**It writes once per frame, not once per keystroke.** A pending write is flushed when the page
+hides and when the wizard is destroyed, so the last answer is not lost to a timer nobody waited
+for.
+
+## Install it in the browser only
+
+On a server there is no storage to read, and a session restored into the server's markup is a
+hydration mismatch waiting to happen. Both renderings above build the plugin list behind a
+`typeof window === 'undefined'` check for that reason, and say what they restored one tick after
+mount rather than during the first paint.
+
+## Where to read more
+
+[Persistence](../persistence/) is the format underneath: what a snapshot carries, which stored
+sessions are refused and why, and the `migrate` hook for the ones you would rather upgrade than
+discard.

--- a/site/src/content/docs/docs/restore-after-reload.mdx
+++ b/site/src/content/docs/docs/restore-after-reload.mdx
@@ -62,8 +62,8 @@ Type a name below, press Next, then reload this page.
     },
   ]}
 >
-  <RestoreReact client:visible slot="react" />
-  <RestoreVue client:visible slot="vue" />
+  <RestoreReact client:only="react" slot="react" />
+  <RestoreVue client:only="vue" slot="vue" />
 </RunnableExample>
 
 ## Three things this gets right
@@ -80,12 +80,27 @@ bug to whoever filled it, and silence is why they would think so.
 hides and when the wizard is destroyed, so the last answer is not lost to a timer nobody waited
 for.
 
-## Install it in the browser only
+## This one is mounted in the browser only
 
-On a server there is no storage to read, and a session restored into the server's markup is a
-hydration mismatch waiting to happen. Both renderings above build the plugin list behind a
-`typeof window === 'undefined'` check for that reason, and say what they restored one tick after
-mount rather than during the first paint.
+A wizard is created with its plugins already in place: the engine initialises them before it
+hands itself out, so by the time anything renders, `persist` has read storage and committed what
+it found. That is what makes a restored session available on the first frame instead of the
+second, and it is also why this example is not rendered on the server.
+
+Follow it through with a stored session. The server has no storage, so it renders the first step.
+The browser restores the third and renders that. The two do not match, the framework throws its
+markup away and starts again, and the person watching sees the first step flash past. Rendering
+nothing on the server is the honest answer here, not a workaround: there is no correct server
+rendering of a session the server cannot see.
+
+Both renderings above are mounted with Astro's `client:only` for that reason. Every framework
+spells the same instruction differently - `dynamic(() => import('./App'), { ssr: false })` in
+Next.js, `<ClientOnly>` in Nuxt - and what it means in each is that this subtree belongs to the
+browser.
+
+The `typeof window === 'undefined'` guard in the sources stays regardless. It is what keeps the
+plugin from being built at all where there is no storage to build it against, and your own
+application may reach that code by a path this page does not.
 
 ## Where to read more
 

--- a/site/src/islands/BlockNextReact.tsx
+++ b/site/src/islands/BlockNextReact.tsx
@@ -1,0 +1,6 @@
+import { App } from '@examples/tasks/src/block-next/App';
+
+import { restartable } from '../components/StageBoundary';
+
+/** "Block Next until valid" on the React binding, mounted beside its source. */
+export default restartable(App);

--- a/site/src/islands/BlockNextVue.vue
+++ b/site/src/islands/BlockNextVue.vue
@@ -1,0 +1,12 @@
+<script setup lang="ts">
+import App from '@examples/tasks/src/block-next/App.vue';
+
+import RestartableStage from '../components/RestartableStage.vue';
+</script>
+
+<!-- "Block Next until valid" on the Vue binding, mounted beside its source. -->
+<template>
+  <RestartableStage v-slot="{ attempt }">
+    <App :key="attempt" />
+  </RestartableStage>
+</template>

--- a/site/src/islands/ClearBranchReact.tsx
+++ b/site/src/islands/ClearBranchReact.tsx
@@ -1,0 +1,6 @@
+import { App } from '@examples/tasks/src/clear-branch-data/App';
+
+import { restartable } from '../components/StageBoundary';
+
+/** "Clear abandoned branch data" on the React binding, mounted beside its source. */
+export default restartable(App);

--- a/site/src/islands/ClearBranchVue.vue
+++ b/site/src/islands/ClearBranchVue.vue
@@ -1,0 +1,12 @@
+<script setup lang="ts">
+import App from '@examples/tasks/src/clear-branch-data/App.vue';
+
+import RestartableStage from '../components/RestartableStage.vue';
+</script>
+
+<!-- "Clear abandoned branch data" on the Vue binding, mounted beside its source. -->
+<template>
+  <RestartableStage v-slot="{ attempt }">
+    <App :key="attempt" />
+  </RestartableStage>
+</template>

--- a/site/src/islands/FieldErrorsReact.tsx
+++ b/site/src/islands/FieldErrorsReact.tsx
@@ -1,0 +1,6 @@
+import { App } from '@examples/tasks/src/render-field-errors/App';
+
+import { restartable } from '../components/StageBoundary';
+
+/** "Render field errors" on the React binding, mounted beside its source. */
+export default restartable(App);

--- a/site/src/islands/FieldErrorsVue.vue
+++ b/site/src/islands/FieldErrorsVue.vue
@@ -1,0 +1,12 @@
+<script setup lang="ts">
+import App from '@examples/tasks/src/render-field-errors/App.vue';
+
+import RestartableStage from '../components/RestartableStage.vue';
+</script>
+
+<!-- "Render field errors" on the Vue binding, mounted beside its source. -->
+<template>
+  <RestartableStage v-slot="{ attempt }">
+    <App :key="attempt" />
+  </RestartableStage>
+</template>

--- a/site/src/islands/RestoreReact.tsx
+++ b/site/src/islands/RestoreReact.tsx
@@ -1,0 +1,6 @@
+import { App } from '@examples/tasks/src/restore-after-reload/App';
+
+import { restartable } from '../components/StageBoundary';
+
+/** "Restore after reload" on the React binding, mounted beside its source. */
+export default restartable(App);

--- a/site/src/islands/RestoreVue.vue
+++ b/site/src/islands/RestoreVue.vue
@@ -1,0 +1,12 @@
+<script setup lang="ts">
+import App from '@examples/tasks/src/restore-after-reload/App.vue';
+
+import RestartableStage from '../components/RestartableStage.vue';
+</script>
+
+<!-- "Restore after reload" on the Vue binding, mounted beside its source. -->
+<template>
+  <RestartableStage v-slot="{ attempt }">
+    <App :key="attempt" />
+  </RestartableStage>
+</template>


### PR DESCRIPTION
S4-2 of the documentation epic: four pages, each titled by the phrase a person would search for,
each with a runnable example on the mechanism S4-1 built.

- **Block Next until valid** - a step's validator refuses the move, and the refusal is a value.
- **Restore after reload** - the `persist` plugin, and telling the person what came back.
- **Clear abandoned branch data** - what `when` keeps and what `clearOnLeave` drops.
- **Render field errors** - one message per field, placed accessibly, from the validator or from
  your server.

## The examples are their own package

`@examples/tasks` holds one small set per page: a flow, a React rendering, a Vue pair, and a
headless script, each between forty and sixty lines. The reference applications already show all
four behaviours, but `App.tsx` is 358 lines there - a page about one narrow thing cannot teach
from an application about ten. Every set is asserted by vitest the way the quickstart is, and the
headless script's printed output is a checked-in file the test compares against, so the lines the
page shows are not a transcript someone pasted.

The workspace globs one level deep (`examples/*`), so the four sets share one package rather than
being four.

## Notes from building it

- `clearOnLeave` drops the slice **whenever the step is left**, forwards included
  (`navigate.ts:210`). That is right for a coupon or a one-time code and wrong for anything the
  review step needs, so the page says both halves - and says plainly that data from a branch that
  went off the route is *kept*, because the engine cannot know whether you wanted it gone.
- The `persist` plugin coalesces writes to one per frame and flushes on teardown, so the headless
  example destroys the first wizard before opening the second. Without that the last answer is
  still sitting on a timer when the "reload" happens.
- Pagefind's index cannot be queried from Node - it resolves its shards against the page's origin
  - so the acceptance check ("searching each phrase returns its page first") runs inside the
  browser against Pagefind's own API rather than through the search dialog, which is Starlight's
  to test.

## Tests

- unit: thirteen across the four example sets - the refusal and the recovery on both bindings, the
  restore round trip through an in-memory storage, what reaches the submission after a branch is
  abandoned, and every headless script against its output file.
- end-to-end (`e2e/tests/site/docs-tasks.spec.ts`): each page mounts and runs its example, the
  refusal names its field, the dropped step is absent from the submission, and each of the four
  search phrases returns its own page first. The four pages join the axe sweep in `docs.spec.ts`.

`pnpm verify` green, `pnpm test:e2e --project=site` green, site build clean.

## Documentation

The four pages are the change. Each links to the concept page that owns the detail rather than
repeating it: Validation and Navigation for the refusal, Persistence for the snapshot format, The
flow and Expressions for reachability. The sidebar gains a **Tasks** group above **Guides**,
which is the order the launch design asks for: getting started, then tasks, then concepts.

`docs/PLAN.md` now says S4-1 landed and S4-2 is being built.

Closes #72
