### PR TITLE
docs(site): the Devtools and Server-driven pages

### DIFF
--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -14,10 +14,11 @@ this file is the view one level above it.
 <!-- The session brief hands this section to every new session. Keep it short and true; the
 brief shows the board and the last merged PRs live, so they are not repeated here. -->
 
-- **In progress:** S4, the documentation pages (#57). S4-1 (#71) landed in #87 - the
-  runnable-example mechanism and Getting started - and S4-2 (#72) in #89 - the four task pages,
-  each with a runnable example on that mechanism. S4-3 and S4-4 (#73, #74) are next.
-- **Next after S4:** L6, the diagnostic contract (#59), which also owns the `/errors/` pages.
+- **Just done:** S4, the documentation pages (#57), in four parts - the runnable-example
+  mechanism and Getting started (#87), the four task pages (#89), the API behaviour table and the
+  five guides (#94), and the Devtools and Server-driven pages (#96).
+- **Next:** L6, the diagnostic contract (#59), which also owns the `/errors/` pages. S5, the API
+  reference from typedoc (#62), is unblocked now that S4 is finished.
 - **Waiting on the owner:** R3 (#80), because `main` has no branch protection.
 
 ## Tracks
@@ -49,8 +50,8 @@ only the owner can do.
 | S1  | Site shell and the hero               | done        | #48                                              |
 | S2  | The flow inspector                    | done        | #50                                              |
 | S3  | The three reference applications      | done        | #54, #55, #56; the StackBlitz button waits on R0 |
-| S4  | The documentation pages               | in progress | #57                                              |
-| S5  | API reference from typedoc            | blocked     | #62, by S4                                       |
+| S4  | The documentation pages               | done        | #57; #87, #89, #94, #96                          |
+| S5  | API reference from typedoc            | next        | #62                                              |
 | S6  | Deploy switch                         | todo        | #66                                              |
 | -   | A flat ground and surfaces            | in progress | #58; #75 done, #76 open                          |
 | -   | Versioned documentation               | todo        | #60                                              |

--- a/e2e/tests/site/docs-tasks.spec.ts
+++ b/e2e/tests/site/docs-tasks.spec.ts
@@ -68,6 +68,32 @@ test.describe('the task pages', () => {
     await expect(submitted).not.toContainText('SPRING');
   });
 
+  test('the devtools panel mounts over a running wizard', async ({ page }) => {
+    await page.goto('docs/devtools/');
+    const react = stage(page, 'react');
+    await react.scrollIntoViewIfNeeded();
+
+    // The panel is docked and fills its container, so a zero-height stage reads
+    // as "broken" rather than "empty" - which is the mistake the page warns
+    // about, and worth catching here rather than in a screenshot.
+    await expect(react.getByRole('tab', { name: 'Activity' })).toBeVisible();
+    expect((await react.boundingBox())?.height ?? 0).toBeGreaterThan(100);
+  });
+
+  test('a server-driven flow takes a patch and refuses the deleting one', async ({ page }) => {
+    await page.goto('docs/server-driven/');
+    const react = stage(page, 'react');
+    await react.scrollIntoViewIfNeeded();
+    await expect(react.getByRole('status')).toContainText('Loaded from the server');
+
+    await react.getByRole('button', { name: 'Apply the patch' }).click();
+    await expect(react.getByRole('status')).toContainText('applied');
+
+    // The one change a payload must not be able to make.
+    await react.getByRole('button', { name: 'Apply a patch that deletes this step' }).click();
+    await expect(react.getByRole('status')).toContainText('refused');
+  });
+
   test('force gets past the policy and not past the guard', async ({ page }) => {
     await page.goto('docs/api-behaviour/');
     const react = stage(page, 'react');

--- a/e2e/tests/site/docs.spec.ts
+++ b/e2e/tests/site/docs.spec.ts
@@ -28,6 +28,8 @@ const DOCS = [
   ['API behaviour', 'docs/api-behaviour/'],
   ['Validation', 'docs/validation/'],
   ['Persistence', 'docs/persistence/'],
+  ['Devtools', 'docs/devtools/'],
+  ['Server-driven flows', 'docs/server-driven/'],
 ] as const;
 
 /** Starlight reads the theme from this key before it paints. */

--- a/examples/tasks/src/server-driven/App.tsx
+++ b/examples/tasks/src/server-driven/App.tsx
@@ -1,0 +1,98 @@
+import { createWizard, type Wizard } from '@wizzard-packages/core/v1';
+import {
+  WizardProvider,
+  useField,
+  useNavigation,
+  useStep,
+  useWizard,
+} from '@wizzard-packages/react/v1';
+import { useId, useMemo, useState, type ReactNode } from 'react';
+
+import { FROM_SERVER, PATCH_FROM_SERVER, registry } from './contract';
+import { loadFlow } from './load';
+
+export function App(): ReactNode {
+  // The definition is read once, and the engine is built from what came back.
+  // A payload that does not load has no wizard to render, which is the honest
+  // rendering of a backend that sent something wrong.
+  const loaded = useMemo(() => loadFlow(FROM_SERVER, registry), []);
+  const wizard = useMemo(
+    () => (loaded.ok ? createWizard({ flow: loaded.flow, registry }) : null),
+    [loaded]
+  );
+
+  if (!loaded.ok || wizard === null) {
+    return (
+      <ul>
+        {loaded.ok
+          ? null
+          : loaded.problems.map((problem) => <li key={problem.path}>{problem.message}</li>)}
+      </ul>
+    );
+  }
+
+  return (
+    <WizardProvider wizard={wizard}>
+      <Wizard />
+    </WizardProvider>
+  );
+}
+
+export function Wizard(): ReactNode {
+  const wizard = useWizard() as Wizard;
+  const { current } = useStep();
+  const { next, isBusy } = useNavigation();
+  const [email, setEmail] = useField<string>('account.email');
+  const [note, setNote] = useState('Loaded from the server.');
+  const emailId = useId();
+
+  const step = current ?? 'account';
+  const starting = current === null;
+
+  const apply = (text: string, label: string) => {
+    const patch = JSON.parse(text) as Parameters<typeof wizard.patchFlow>[0];
+    setNote(`${label}: ${wizard.patchFlow(patch) ? 'applied' : 'refused'}`);
+  };
+
+  return (
+    <form onSubmit={(e) => e.preventDefault()}>
+      {step === 'account' && (
+        <p>
+          <label htmlFor={emailId}>Your email</label>
+          <input
+            id={emailId}
+            value={email ?? ''}
+            onChange={(e) => setEmail(e.target.value)}
+            disabled={starting}
+          />
+        </p>
+      )}
+      {step !== 'account' && <p>Step: {step}</p>}
+
+      <button type="button" onClick={() => void next()} disabled={starting || isBusy}>
+        Next
+      </button>
+      <button type="button" onClick={() => apply(PATCH_FROM_SERVER, 'Patch')} disabled={starting}>
+        Apply the patch
+      </button>
+      {/* The patch a backend should not send: it deletes the step the person is
+          standing on, and the engine answers false rather than relocating them.
+          Note that it is built here rather than parsed: JSON has no `undefined`,
+          so deleting a step is the one change a payload cannot express. */}
+      <button
+        type="button"
+        onClick={() => {
+          const removal = { steps: { account: undefined } } as unknown as Parameters<
+            typeof wizard.patchFlow
+          >[0];
+          setNote(`Removal: ${wizard.patchFlow(removal) ? 'applied' : 'refused'}`);
+        }}
+        disabled={starting}
+      >
+        Apply a patch that deletes this step
+      </button>
+
+      <p role="status">{note}</p>
+    </form>
+  );
+}

--- a/examples/tasks/src/server-driven/App.tsx
+++ b/examples/tasks/src/server-driven/App.tsx
@@ -1,4 +1,8 @@
-import { createWizard, type Wizard } from '@wizzard-packages/core/v1';
+import {
+  createWizard,
+  type FlowDefinition,
+  type Wizard as Engine,
+} from '@wizzard-packages/core/v1';
 import {
   WizardProvider,
   useField,
@@ -9,7 +13,7 @@ import {
 import { useId, useMemo, useState, type ReactNode } from 'react';
 
 import { FROM_SERVER, PATCH_FROM_SERVER, registry } from './contract';
-import { loadFlow } from './load';
+import { checkPatch, loadFlow } from './load';
 
 export function App(): ReactNode {
   // The definition is read once, and the engine is built from what came back.
@@ -33,13 +37,13 @@ export function App(): ReactNode {
 
   return (
     <WizardProvider wizard={wizard}>
-      <Wizard />
+      <Wizard flow={loaded.flow} />
     </WizardProvider>
   );
 }
 
-export function Wizard(): ReactNode {
-  const wizard = useWizard() as Wizard;
+export function Wizard(props: { flow: FlowDefinition }): ReactNode {
+  const wizard = useWizard() as Engine;
   const { current } = useStep();
   const { next, isBusy } = useNavigation();
   const [email, setEmail] = useField<string>('account.email');
@@ -49,9 +53,18 @@ export function Wizard(): ReactNode {
   const step = current ?? 'account';
   const starting = current === null;
 
+  /**
+   * A patch is checked before it is applied. `patchFlow` merges and installs;
+   * it does not validate, so an `order` of the wrong type would be accepted
+   * here and fail later, in a selector, with the payload long out of sight.
+   */
   const apply = (text: string, label: string) => {
-    const patch = JSON.parse(text) as Parameters<typeof wizard.patchFlow>[0];
-    setNote(`${label}: ${wizard.patchFlow(patch) ? 'applied' : 'refused'}`);
+    const checked = checkPatch(props.flow, text, registry);
+    if (!checked.ok) {
+      setNote(`${label}: refused before applying - ${checked.problems[0]?.message ?? ''}`);
+      return;
+    }
+    setNote(`${label}: ${wizard.patchFlow(checked.patch) ? 'applied' : 'refused'}`);
   };
 
   return (
@@ -77,8 +90,8 @@ export function Wizard(): ReactNode {
       </button>
       {/* The patch a backend should not send: it deletes the step the person is
           standing on, and the engine answers false rather than relocating them.
-          Note that it is built here rather than parsed: JSON has no `undefined`,
-          so deleting a step is the one change a payload cannot express. */}
+          Built here rather than parsed, because JSON has no `undefined` and so
+          cannot express a deletion at all. */}
       <button
         type="button"
         onClick={() => {

--- a/examples/tasks/src/server-driven/App.vue
+++ b/examples/tasks/src/server-driven/App.vue
@@ -1,0 +1,23 @@
+<script setup lang="ts">
+import { createWizard } from '@wizzard-packages/core/v1';
+import { provideWizard } from '@wizzard-packages/vue/v1';
+
+import Wizard from './Wizard.vue';
+import { FROM_SERVER, registry } from './contract';
+import { loadFlow } from './load';
+
+/**
+ * The definition is read once, and the engine is built from what came back. A
+ * payload that does not load has no wizard to provide, which is the honest
+ * rendering of a backend that sent something wrong.
+ */
+const loaded = loadFlow(FROM_SERVER, registry);
+if (loaded.ok) provideWizard(createWizard({ flow: loaded.flow, registry }));
+</script>
+
+<template>
+  <Wizard v-if="loaded.ok" />
+  <ul v-else>
+    <li v-for="problem in loaded.problems" :key="problem.path">{{ problem.message }}</li>
+  </ul>
+</template>

--- a/examples/tasks/src/server-driven/App.vue
+++ b/examples/tasks/src/server-driven/App.vue
@@ -12,12 +12,15 @@ import { loadFlow } from './load';
  * rendering of a backend that sent something wrong.
  */
 const loaded = loadFlow(FROM_SERVER, registry);
-if (loaded.ok) provideWizard(createWizard({ flow: loaded.flow, registry }));
+const flow = loaded.ok ? loaded.flow : null;
+const problems = loaded.ok ? [] : loaded.problems;
+
+if (flow !== null) provideWizard(createWizard({ flow, registry }));
 </script>
 
 <template>
-  <Wizard v-if="loaded.ok" />
+  <Wizard v-if="flow !== null" :flow="flow" />
   <ul v-else>
-    <li v-for="problem in loaded.problems" :key="problem.path">{{ problem.message }}</li>
+    <li v-for="problem in problems" :key="problem.path">{{ problem.message }}</li>
   </ul>
 </template>

--- a/examples/tasks/src/server-driven/Wizard.vue
+++ b/examples/tasks/src/server-driven/Wizard.vue
@@ -1,11 +1,14 @@
 <script setup lang="ts">
-import type { Wizard } from '@wizzard-packages/core/v1';
+import type { FlowDefinition, Wizard as Engine } from '@wizzard-packages/core/v1';
 import { useField, useNavigation, useStep, useWizard } from '@wizzard-packages/vue/v1';
 import { computed, ref, useId } from 'vue';
 
-import { PATCH_FROM_SERVER } from './contract';
+import { PATCH_FROM_SERVER, registry } from './contract';
+import { checkPatch } from './load';
 
-const wizard = useWizard() as Wizard;
+const props = defineProps<{ flow: FlowDefinition }>();
+
+const wizard = useWizard() as Engine;
 const { current } = useStep();
 const { next, isBusy } = useNavigation();
 const email = useField<string>('account.email');
@@ -16,9 +19,16 @@ const emailId = useId();
 const step = computed(() => current.value ?? 'account');
 const starting = computed(() => current.value === null);
 
+/**
+ * A patch is checked before it is applied. `patchFlow` merges and installs; it
+ * does not validate, so an `order` of the wrong type would be accepted here and
+ * fail later, in a selector, with the payload long out of sight.
+ */
 const applyPatch = (): void => {
-  const patch = JSON.parse(PATCH_FROM_SERVER) as Parameters<typeof wizard.patchFlow>[0];
-  note.value = `Patch: ${wizard.patchFlow(patch) ? 'applied' : 'refused'}`;
+  const checked = checkPatch(props.flow, PATCH_FROM_SERVER, registry);
+  note.value = checked.ok
+    ? `Patch: ${wizard.patchFlow(checked.patch) ? 'applied' : 'refused'}`
+    : `Patch: refused before applying - ${checked.problems[0]?.message ?? ''}`;
 };
 
 /**

--- a/examples/tasks/src/server-driven/Wizard.vue
+++ b/examples/tasks/src/server-driven/Wizard.vue
@@ -1,0 +1,52 @@
+<script setup lang="ts">
+import type { Wizard } from '@wizzard-packages/core/v1';
+import { useField, useNavigation, useStep, useWizard } from '@wizzard-packages/vue/v1';
+import { computed, ref, useId } from 'vue';
+
+import { PATCH_FROM_SERVER } from './contract';
+
+const wizard = useWizard() as Wizard;
+const { current } = useStep();
+const { next, isBusy } = useNavigation();
+const email = useField<string>('account.email');
+
+const note = ref('Loaded from the server.');
+const emailId = useId();
+
+const step = computed(() => current.value ?? 'account');
+const starting = computed(() => current.value === null);
+
+const applyPatch = (): void => {
+  const patch = JSON.parse(PATCH_FROM_SERVER) as Parameters<typeof wizard.patchFlow>[0];
+  note.value = `Patch: ${wizard.patchFlow(patch) ? 'applied' : 'refused'}`;
+};
+
+/**
+ * Built here rather than parsed: JSON has no `undefined`, so deleting a step is
+ * the one change a payload cannot express.
+ */
+const applyRemoval = (): void => {
+  const removal = { steps: { account: undefined } } as unknown as Parameters<
+    typeof wizard.patchFlow
+  >[0];
+  note.value = `Removal: ${wizard.patchFlow(removal) ? 'applied' : 'refused'}`;
+};
+</script>
+
+<template>
+  <form @submit.prevent>
+    <p v-if="step === 'account'">
+      <label :for="emailId">Your email</label>
+      <input :id="emailId" v-model="email" :disabled="starting" />
+    </p>
+    <p v-else>Step: {{ step }}</p>
+
+    <button type="button" :disabled="starting || isBusy" @click="next()">Next</button>
+    <button type="button" :disabled="starting" @click="applyPatch">Apply the patch</button>
+    <button type="button" :disabled="starting" @click="applyRemoval">
+      Apply a patch that deletes this step
+    </button>
+
+    <p role="status">{{ note }}</p>
+  </form>
+</template>

--- a/examples/tasks/src/server-driven/contract.ts
+++ b/examples/tasks/src/server-driven/contract.ts
@@ -28,14 +28,14 @@ export const FROM_SERVER = `{
  * the code that runs it - which is the property that makes accepting one
  * safe at all.
  */
-export const registry: AsyncRegistry = {
-  account: (_args, scope: Scope): Record<string, string> | null => {
+export const registry: AsyncRegistry = Object.assign(Object.create(null) as AsyncRegistry, {
+  account: (_args: unknown, scope: Scope): Record<string, string> | null => {
     const { email } = (scope.data['account'] as { email?: string } | undefined) ?? {};
     return typeof email === 'string' && email.includes('@')
       ? null
       : { email: 'Enter your email address.' };
   },
-};
+});
 
 /**
  * A later message from the same backend: one step replaced, one added. Steps

--- a/examples/tasks/src/server-driven/contract.ts
+++ b/examples/tasks/src/server-driven/contract.ts
@@ -1,0 +1,49 @@
+import type { AsyncRegistry, Scope } from '@wizzard-packages/core/v1';
+
+/**
+ * A flow as it arrives from a backend: text, not a module.
+ *
+ * This is the whole server-driven contract in 1.0.0. The definition is JSON,
+ * so it can be stored in a column, sent over a wire and diffed in a review;
+ * everything it cannot carry - a validator, a predicate, a loader - is named
+ * here and answered by a registry the client already has.
+ */
+export const FROM_SERVER = `{
+  "id": "signup",
+  "version": 1,
+  "order": ["account", "billing", "done"],
+  "steps": {
+    "account": { "label": "Account", "validate": { "$ref": "account" } },
+    "billing": {
+      "label": "Billing",
+      "when": { "$eq": [{ "$get": "data.account.plan" }, "team"] }
+    },
+    "done": { "label": "Done" }
+  }
+}`;
+
+/**
+ * The half that never travels. A `$ref` names a function the client holds, so
+ * a definition from a server can ask for a check without being able to supply
+ * the code that runs it - which is the property that makes accepting one
+ * safe at all.
+ */
+export const registry: AsyncRegistry = {
+  account: (_args, scope: Scope): Record<string, string> | null => {
+    const { email } = (scope.data['account'] as { email?: string } | undefined) ?? {};
+    return typeof email === 'string' && email.includes('@')
+      ? null
+      : { email: 'Enter your email address.' };
+  },
+};
+
+/**
+ * A later message from the same backend: one step replaced, one added. Steps
+ * are merged by id, so a patch names only what changes.
+ */
+export const PATCH_FROM_SERVER = `{
+  "order": ["account", "billing", "invoice", "done"],
+  "steps": {
+    "invoice": { "label": "Invoice details" }
+  }
+}`;

--- a/examples/tasks/src/server-driven/headless.out.txt
+++ b/examples/tasks/src/server-driven/headless.out.txt
@@ -1,6 +1,8 @@
 loaded: signup
 step: account
+patch checked: true
 patch applied: true
 active: account, invoice, done
+broken patch checked: false
 removal applied: false
 step: account

--- a/examples/tasks/src/server-driven/headless.out.txt
+++ b/examples/tasks/src/server-driven/headless.out.txt
@@ -1,0 +1,6 @@
+loaded: signup
+step: account
+patch applied: true
+active: account, invoice, done
+removal applied: false
+step: account

--- a/examples/tasks/src/server-driven/headless.ts
+++ b/examples/tasks/src/server-driven/headless.ts
@@ -1,11 +1,12 @@
 import { createWizard } from '@wizzard-packages/core/v1';
 
 import { FROM_SERVER, PATCH_FROM_SERVER, registry } from './contract';
-import { loadFlow } from './load';
+import { checkPatch, loadFlow } from './load';
 
 /**
  * The contract end to end, without a framework: accept a definition, run it,
- * then accept a change to it - including the change the engine refuses.
+ * then accept a change to it - including the change the engine refuses, and the
+ * one that never reaches the engine because it does not survive checking.
  */
 const loaded = loadFlow(FROM_SERVER, registry);
 if (!loaded.ok) {
@@ -19,13 +20,19 @@ const wizard = createWizard({ flow: loaded.flow, registry });
 await wizard.start();
 console.log(`step: ${String(wizard.getSnapshot().current)}`);
 
-// Steps merge by id, so a patch names only what changes.
-const patch = JSON.parse(PATCH_FROM_SERVER) as Parameters<typeof wizard.patchFlow>[0];
-console.log(`patch applied: ${wizard.patchFlow(patch)}`);
+// Steps merge by id, so a patch names only what changes - after it is checked,
+// because `patchFlow` installs whatever it is handed.
+const patch = checkPatch(loaded.flow, PATCH_FROM_SERVER, registry);
+console.log(`patch checked: ${patch.ok}`);
+if (patch.ok) console.log(`patch applied: ${wizard.patchFlow(patch.patch)}`);
 console.log(`active: ${wizard.getSnapshot().active.join(', ')}`);
 
-// The one patch the engine will not take: it deletes the step someone is
-// standing on. Refused as a value, and the wizard does not move.
+// A patch that would break the flow, refused before the engine sees it.
+const broken = checkPatch(loaded.flow, '{"order":1}', registry);
+console.log(`broken patch checked: ${broken.ok}`);
+
+// The one patch the engine itself refuses: it deletes the step someone is
+// standing on. Built here, because JSON has no `undefined` to express it with.
 const removal = { steps: { account: undefined } } as unknown as Parameters<
   typeof wizard.patchFlow
 >[0];

--- a/examples/tasks/src/server-driven/headless.ts
+++ b/examples/tasks/src/server-driven/headless.ts
@@ -1,0 +1,33 @@
+import { createWizard } from '@wizzard-packages/core/v1';
+
+import { FROM_SERVER, PATCH_FROM_SERVER, registry } from './contract';
+import { loadFlow } from './load';
+
+/**
+ * The contract end to end, without a framework: accept a definition, run it,
+ * then accept a change to it - including the change the engine refuses.
+ */
+const loaded = loadFlow(FROM_SERVER, registry);
+if (!loaded.ok) {
+  console.log(`refused: ${loaded.problems.length} problem(s)`);
+  throw new Error('the fixture should load');
+}
+
+console.log(`loaded: ${loaded.flow.id}`);
+
+const wizard = createWizard({ flow: loaded.flow, registry });
+await wizard.start();
+console.log(`step: ${String(wizard.getSnapshot().current)}`);
+
+// Steps merge by id, so a patch names only what changes.
+const patch = JSON.parse(PATCH_FROM_SERVER) as Parameters<typeof wizard.patchFlow>[0];
+console.log(`patch applied: ${wizard.patchFlow(patch)}`);
+console.log(`active: ${wizard.getSnapshot().active.join(', ')}`);
+
+// The one patch the engine will not take: it deletes the step someone is
+// standing on. Refused as a value, and the wizard does not move.
+const removal = { steps: { account: undefined } } as unknown as Parameters<
+  typeof wizard.patchFlow
+>[0];
+console.log(`removal applied: ${wizard.patchFlow(removal)}`);
+console.log(`step: ${String(wizard.getSnapshot().current)}`);

--- a/examples/tasks/src/server-driven/load.ts
+++ b/examples/tasks/src/server-driven/load.ts
@@ -1,0 +1,52 @@
+import type { AsyncRegistry, FlowDefinition } from '@wizzard-packages/core/v1';
+import { validateFlow, type FlowProblem } from '@wizzard-packages/core/validate-flow';
+
+/**
+ * Reading a flow that arrived from somewhere else.
+ *
+ * The order of the checks is the order of what can be wrong, cheapest first:
+ * size, then JSON, then the shape `validateFlow` assumes, then the flow rules
+ * themselves. The shape check is not politeness - `validateFlow` is typed for a
+ * `FlowDefinition` and reads fields off it without guarding them, so an
+ * ordinary malformed payload throws out of it rather than being reported.
+ *
+ * Every failure is a value. A definition from a backend is untrusted input like
+ * any other, and a page that renders a list of problems is more use than a
+ * stack trace.
+ */
+export type LoadResult =
+  | { ok: true; flow: FlowDefinition }
+  | { ok: false; problems: readonly FlowProblem[] };
+
+/** Characters, not bytes: the cheap gate that stops a generated file being parsed at all. */
+const MAX_CHARS = 100_000;
+
+const fail = (path: string, message: string): LoadResult => ({
+  ok: false,
+  problems: [{ path, message }],
+});
+
+const isObject = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+export function loadFlow(text: string, registry: AsyncRegistry): LoadResult {
+  if (text.length > MAX_CHARS) {
+    return fail('', `the payload is ${text.length} characters, past the ${MAX_CHARS} limit`);
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch (error) {
+    return fail('', `the payload is not JSON (${(error as Error).message})`);
+  }
+
+  // What `validateFlow` assumes it was handed. Anything else is not a flow yet.
+  if (!isObject(parsed) || typeof parsed['id'] !== 'string' || !isObject(parsed['steps'])) {
+    return fail('', 'a flow needs a string `id` and an object of `steps`');
+  }
+
+  const flow = parsed as unknown as FlowDefinition;
+  const problems = validateFlow(flow, registry);
+  return problems.length > 0 ? { ok: false, problems } : { ok: true, flow };
+}

--- a/examples/tasks/src/server-driven/load.ts
+++ b/examples/tasks/src/server-driven/load.ts
@@ -6,13 +6,17 @@ import { validateFlow, type FlowProblem } from '@wizzard-packages/core/validate-
  *
  * The order of the checks is the order of what can be wrong, cheapest first:
  * size, then JSON, then the shape `validateFlow` assumes, then the flow rules
- * themselves. The shape check is not politeness - `validateFlow` is typed for a
- * `FlowDefinition` and reads fields off it without guarding them, so an
- * ordinary malformed payload throws out of it rather than being reported.
+ * themselves.
  *
- * Every failure is a value. A definition from a backend is untrusted input like
- * any other, and a page that renders a list of problems is more use than a
- * stack trace.
+ * The shape check is not politeness. `validateFlow` is typed for a
+ * `FlowDefinition` and reads fields off it without guarding them: `order: 1`
+ * reaches `for (const id of flow.order)` and throws, and a step of `null`
+ * reaches a property read. Both are ordinary things for a broken service to
+ * send, and a thrown `TypeError` is not a list of problems anyone can act on.
+ *
+ * The `try` around the validator is the belt to that pair of braces: this file
+ * enumerates what is known to throw today, and a payload is exactly the input
+ * that finds what it missed.
  */
 export type LoadResult =
   | { ok: true; flow: FlowDefinition }
@@ -21,32 +25,152 @@ export type LoadResult =
 /** Characters, not bytes: the cheap gate that stops a generated file being parsed at all. */
 const MAX_CHARS = 100_000;
 
-const fail = (path: string, message: string): LoadResult => ({
+const DOCS = 'https://zizzx.github.io/wizzard-packages/docs/server-driven/';
+
+/** Problem, cause, fix, link - the shape every message in this library takes. */
+const fail = (path: string, what: string, why: string, fix: string): LoadResult => ({
   ok: false,
-  problems: [{ path, message }],
+  problems: [{ path, message: `[wizzard] ${what}. ${why}. ${fix}. ${DOCS}` }],
 });
 
 const isObject = (value: unknown): value is Record<string, unknown> =>
   typeof value === 'object' && value !== null && !Array.isArray(value);
 
+/** The fields the validator dereferences without checking them first. */
+function shapeProblem(value: Record<string, unknown>): LoadResult | null {
+  const { order, steps } = value;
+
+  if (
+    order !== undefined &&
+    (!Array.isArray(order) || order.some((id) => typeof id !== 'string'))
+  ) {
+    return fail(
+      'order',
+      'order is not a list of step ids',
+      'It names the sequence the flow walks, and everything that reads it walks it as a list of strings',
+      'Send an array of step ids, or leave it out and the steps run in the order they are written'
+    );
+  }
+
+  if (steps !== undefined) {
+    if (!isObject(steps)) {
+      return fail(
+        'steps',
+        'steps is not an object',
+        'Every flow is a map of step ids to the steps themselves',
+        'Send an object keyed by step id'
+      );
+    }
+    for (const [id, step] of Object.entries(steps)) {
+      if (!isObject(step)) {
+        return fail(
+          `steps.${id}`,
+          `step "${id}" is ${step === null ? 'null' : typeof step}, not an object`,
+          'Each entry describes one step, and the validator reads fields off it',
+          `Send an object, empty if the step has nothing to say: "${id}": {}`
+        );
+      }
+    }
+  }
+
+  return null;
+}
+
+/** Runs the validator without letting an unguarded read escape as an exception. */
+function problemsOf(flow: FlowDefinition, registry: AsyncRegistry): LoadResult {
+  try {
+    const problems = validateFlow(flow, registry);
+    return problems.length > 0 ? { ok: false, problems } : { ok: true, flow };
+  } catch (error) {
+    return fail(
+      '',
+      'the definition could not be checked',
+      `the validator failed on it (${(error as Error).message})`,
+      'This is a malformed payload rather than a flow with a mistake in it; check what the service sent'
+    );
+  }
+}
+
 export function loadFlow(text: string, registry: AsyncRegistry): LoadResult {
   if (text.length > MAX_CHARS) {
-    return fail('', `the payload is ${text.length} characters, past the ${MAX_CHARS} limit`);
+    return fail(
+      '',
+      `the payload is ${text.length} characters`,
+      `Anything past ${MAX_CHARS} is not a flow someone wrote`,
+      'Check that the service is sending a definition and not a page of something else'
+    );
   }
 
   let parsed: unknown;
   try {
     parsed = JSON.parse(text);
   } catch (error) {
-    return fail('', `the payload is not JSON (${(error as Error).message})`);
+    return fail(
+      '',
+      'the payload is not JSON',
+      `parsing it failed (${(error as Error).message})`,
+      'Check the response is the definition itself rather than an envelope around it'
+    );
   }
 
-  // What `validateFlow` assumes it was handed. Anything else is not a flow yet.
   if (!isObject(parsed) || typeof parsed['id'] !== 'string' || !isObject(parsed['steps'])) {
-    return fail('', 'a flow needs a string `id` and an object of `steps`');
+    return fail(
+      '',
+      'the payload is not a flow',
+      'A flow is an object with a string `id` and an object of `steps`',
+      'Check the service is sending a flow definition'
+    );
   }
 
-  const flow = parsed as unknown as FlowDefinition;
-  const problems = validateFlow(flow, registry);
-  return problems.length > 0 ? { ok: false, problems } : { ok: true, flow };
+  const shape = shapeProblem(parsed);
+  if (shape !== null) return shape;
+
+  return problemsOf(parsed as unknown as FlowDefinition, registry);
+}
+
+/**
+ * A patch is a definition too, and `patchFlow` does not check it: it merges by
+ * id and installs the result. So the merge happens here first, against the same
+ * checks, and the patch is only handed over once the flow it would produce is
+ * one the engine can run.
+ */
+export function checkPatch(
+  current: FlowDefinition,
+  text: string,
+  registry: AsyncRegistry
+): { ok: true; patch: Partial<FlowDefinition> } | { ok: false; problems: readonly FlowProblem[] } {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch (error) {
+    return fail(
+      '',
+      'the patch is not JSON',
+      `parsing it failed (${(error as Error).message})`,
+      'Check the response is the patch itself rather than an envelope around it'
+    ) as { ok: false; problems: readonly FlowProblem[] };
+  }
+
+  if (!isObject(parsed)) {
+    return fail(
+      '',
+      'the patch is not an object',
+      'A patch is a partial flow: the fields that changed, and nothing else',
+      'Send an object with the fields to replace'
+    ) as { ok: false; problems: readonly FlowProblem[] };
+  }
+
+  const shape = shapeProblem(parsed);
+  if (shape !== null) return shape as { ok: false; problems: readonly FlowProblem[] };
+
+  const merged = {
+    ...current,
+    ...parsed,
+    steps: { ...current.steps, ...(parsed['steps'] as Record<string, unknown> | undefined) },
+  } as unknown as FlowDefinition;
+
+  const checked = problemsOf(merged, registry);
+  return checked.ok
+    ? { ok: true, patch: parsed as unknown as Partial<FlowDefinition> }
+    : { ok: false, problems: checked.problems };
 }

--- a/examples/tasks/src/server-driven/server-driven.test.tsx
+++ b/examples/tasks/src/server-driven/server-driven.test.tsx
@@ -1,0 +1,82 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { flushPromises, mount } from '@vue/test-utils';
+import { act } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+import AppVue from './App.vue';
+import { App } from './App';
+import { FROM_SERVER, registry } from './contract';
+import expectedOutput from './headless.out.txt?raw';
+import { loadFlow } from './load';
+
+/**
+ * The contract, checked from both ends: a definition that arrives as text runs,
+ * and the one change a payload must not be able to make is refused.
+ */
+const click = async (button: HTMLElement): Promise<void> => {
+  await act(async () => {
+    button.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+  });
+};
+
+/** Line endings differ between a Windows checkout and CI; the content does not. */
+const lf = (s: string): string => s.replace(/\r\n/g, '\n');
+
+describe('server-driven', () => {
+  it('refuses a payload that is not a flow, as a value', () => {
+    for (const bad of ['', 'null', '{}', '{"id":"x"}', '[1,2]', 'not json']) {
+      const result = loadFlow(bad, registry);
+      expect(result.ok, `"${bad}" should not load`).toBe(false);
+      if (!result.ok) expect(result.problems.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('loads the definition it was sent', () => {
+    const result = loadFlow(FROM_SERVER, registry);
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.flow.id).toBe('signup');
+  });
+
+  it('applies a patch and refuses the one that deletes the current step, on React', async () => {
+    render(<App />);
+    await waitFor(() => {
+      expect(screen.getByRole('status').textContent).toContain('Loaded from the server');
+    });
+
+    await click(screen.getByRole('button', { name: 'Apply the patch' }));
+    expect(screen.getByRole('status').textContent).toContain('applied');
+
+    await click(screen.getByRole('button', { name: 'Apply a patch that deletes this step' }));
+    expect(screen.getByRole('status').textContent).toContain('refused');
+  });
+
+  it('does the same on Vue', async () => {
+    const app = mount(AppVue);
+    await flushPromises();
+
+    const buttons = app.findAll('button');
+    const patch = buttons[1];
+    const removal = buttons[2];
+    if (patch === undefined || removal === undefined) throw new Error('the buttons are missing');
+
+    await patch.trigger('click');
+    await flushPromises();
+    expect(app.get('[role="status"]').text()).toContain('applied');
+
+    await removal.trigger('click');
+    await flushPromises();
+    expect(app.get('[role="status"]').text()).toContain('refused');
+  });
+
+  it('prints what the headless page shows', async () => {
+    const lines: unknown[] = [];
+    vi.spyOn(console, 'log').mockImplementation((line: unknown) => {
+      lines.push(line);
+    });
+
+    await import('./headless');
+
+    expect(`${lines.join('\n')}\n`).toBe(lf(expectedOutput));
+    vi.restoreAllMocks();
+  });
+});

--- a/examples/tasks/src/server-driven/server-driven.test.tsx
+++ b/examples/tasks/src/server-driven/server-driven.test.tsx
@@ -5,9 +5,9 @@ import { describe, expect, it, vi } from 'vitest';
 
 import AppVue from './App.vue';
 import { App } from './App';
-import { FROM_SERVER, registry } from './contract';
+import { FROM_SERVER, PATCH_FROM_SERVER, registry } from './contract';
 import expectedOutput from './headless.out.txt?raw';
-import { loadFlow } from './load';
+import { checkPatch, loadFlow } from './load';
 
 /**
  * The contract, checked from both ends: a definition that arrives as text runs,
@@ -35,6 +35,37 @@ describe('server-driven', () => {
     const result = loadFlow(FROM_SERVER, registry);
     expect(result.ok).toBe(true);
     if (result.ok) expect(result.flow.id).toBe('signup');
+  });
+
+  it('reports a shape the validator would have thrown on', () => {
+    // `validateFlow` reads `flow.order` unguarded, so these reach it as a
+    // TypeError unless the shape is checked first. Both are ordinary things for
+    // a broken service to send.
+    for (const bad of ['{"id":"x","steps":{"a":{}},"order":1}', '{"id":"x","steps":{"a":null}}']) {
+      const result = loadFlow(bad, registry);
+      expect(result.ok, `"${bad}" should be reported, not thrown`).toBe(false);
+      if (!result.ok) expect(result.problems[0]?.message).toMatch(/^\[wizzard\] /);
+    }
+  });
+
+  it('does not accept an inherited name as a resolver', () => {
+    // `validateFlow` asks `name in registry`, and `in` walks the prototype
+    // chain: against an object literal this passes and the engine then calls
+    // `Object.prototype.toString`. The registry has a null prototype for this.
+    const hostile = `{"id":"x","steps":{"a":{"when":{"$ref":"toString"}}}}`;
+    const result = loadFlow(hostile, registry);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.problems.some((p) => /toString/.test(p.message))).toBe(true);
+  });
+
+  it('refuses a patch that would break the flow, before the engine sees it', () => {
+    const loaded = loadFlow(FROM_SERVER, registry);
+    expect(loaded.ok).toBe(true);
+    if (!loaded.ok) return;
+
+    expect(checkPatch(loaded.flow, '{"order":1}', registry).ok).toBe(false);
+    expect(checkPatch(loaded.flow, 'not json', registry).ok).toBe(false);
+    expect(checkPatch(loaded.flow, PATCH_FROM_SERVER, registry).ok).toBe(true);
   });
 
   it('applies a patch and refuses the one that deletes the current step, on React', async () => {

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -63,6 +63,8 @@ export default defineConfig({
             { label: 'API behaviour', link: '/docs/api-behaviour/' },
             { label: 'Validation', link: '/docs/validation/' },
             { label: 'Persistence', link: '/docs/persistence/' },
+            { label: 'Devtools', link: '/docs/devtools/' },
+            { label: 'Server-driven flows', link: '/docs/server-driven/' },
           ],
         },
       ],

--- a/site/src/content/docs/docs/devtools.mdx
+++ b/site/src/content/docs/docs/devtools.mdx
@@ -88,5 +88,28 @@ It never navigates, never writes to the wizard, and never throws into the host. 
 crashes the application it is diagnosing is worse than no tool, and one that moves the wizard
 while you read it destroys the state you opened it to see.
 
-Install it as a dev dependency and it goes where dev dependencies go: out of the production
-bundle. The engine carries no reference to it - the plugin is something you pass in.
+## Keeping it out of production
+
+A dev dependency is about who installs the package, not about what a bundler does with it. A
+static import that is rendered unconditionally is in the bundle, and the same install without dev
+dependencies fails to build because the import has nothing to resolve. Gate the render yourself:
+
+```tsx
+{
+  process.env.NODE_ENV !== 'production' && (
+    <div style={{ height: 360 }}>
+      <WizardDevtools plugin={dt} />
+    </div>
+  );
+}
+```
+
+```tsx
+// Vite reads the same thing from its own flag.
+{
+  import.meta.env.DEV && <WizardDevtools plugin={dt} />;
+}
+```
+
+The engine itself carries no reference to the panel - the plugin is something you pass in - so
+what a gate has to cover is the panel and its import, not the wizard.

--- a/site/src/content/docs/docs/devtools.mdx
+++ b/site/src/content/docs/docs/devtools.mdx
@@ -1,0 +1,92 @@
+---
+title: Devtools
+description: The panel that answers one question - why is the wizard where it is - and how to mount it.
+---
+
+import { Code } from '@astrojs/starlight/components';
+import DevtoolsReact from '../../../islands/DevtoolsReact';
+import devtoolsSource from '@examples/quickstart/src/Devtools.tsx?raw';
+
+A wizard that will not move is the hard bug, because nothing happened: no exception, no log line,
+a button that does nothing. The panel exists for that one question - why is the wizard where it
+is - and answers it with three views over one snapshot.
+
+<div class="example-stage" data-example-stage="react">
+  <DevtoolsReact client:visible />
+</div>
+
+<Code code={devtoolsSource} lang="tsx" title="Devtools.tsx" />
+
+## Three views, one snapshot
+
+**Graph** draws the flow the wizard is standing in: which steps are reachable now, which branch
+it took, and where the current step sits among them. Selecting a node inspects it. It never
+navigates, so reading the picture cannot move the wizard someone is debugging.
+
+**State** is what was committed, with a diff per commit. It is the answer to "did that field
+actually reach the wizard", which is a different question from "did I call `set`".
+
+**Activity** is the one that pays for the panel. It lists what the wizard did in order - commits
+it made, moves it refused, and the one in flight. A refusal is not a commit, so it does not reach
+a subscriber at all: without this view a refused `next()` is invisible, which is exactly the
+moment someone opens devtools. The rows come from the plugin, and the header says so when the
+plugin is missing.
+
+## Mounting it
+
+Three steps, and two ways to get it wrong.
+
+```bash
+npm i -D @wizzard-packages/devtools
+```
+
+```tsx
+const dt = devtools();
+const wizard = createWizard({ flow: signup, plugins: [dt] });
+
+<WizardDevtools plugin={dt} />;
+```
+
+**The same object goes to both.** `devtools()` returns a plugin; the engine writes to it and the
+panel reads from it. Two calls produce two objects, the panel reads the one nothing writes to,
+and the Activity view sits empty while everything else looks correct.
+
+**The container needs a height.** The panel is docked rather than floating: it fills what it is
+given. Dropped into a page with no height it collapses to nothing, which reads as "the panel is
+broken" rather than "the panel is zero pixels tall".
+
+## The props
+
+| Prop         | What it is                                                                   |
+| ------------ | ---------------------------------------------------------------------------- |
+| `wizard`     | The wizard to watch. Defaults to the one from `WizardProvider`.              |
+| `plugin`     | The object from `devtools()`. Without it there are no refusal rows.          |
+| `subFlows`   | Definitions a group step names, so nested flows can be drawn.                |
+| `layout`     | Your own positions. There is a built-in layout; this replaces it.            |
+| `redact`     | Runs once, at export, over a copy of the whole bundle.                       |
+| `onRecord`   | Receives a recorded session bundle.                                          |
+| `defaultTab` | `'graph'`, `'state'` or `'activity'`. Defaults to the graph.                 |
+| `limits`     | Ceilings on activity rows, frames and diff rows, for a long-running session. |
+
+## It is a React panel
+
+`WizardDevtools` is a React component, and `react` is a peer dependency. A Vue application does
+not mount it.
+
+What a Vue host uses instead is `@wizzard-packages/devtools/headless`, which is the same
+machinery without React or the DOM: `devtools()` installs into any wizard, and `recordSession`
+produces the same bundle the panel's record button writes. The recording can then be read
+anywhere - a test, a bug report, the inspector on this site.
+
+```ts
+import { devtools, recordSession } from '@wizzard-packages/devtools/headless';
+```
+
+## What it never does
+
+It never navigates, never writes to the wizard, and never throws into the host. A tool that
+crashes the application it is diagnosing is worse than no tool, and one that moves the wizard
+while you read it destroys the state you opened it to see.
+
+Install it as a dev dependency and it goes where dev dependencies go: out of the production
+bundle. The engine carries no reference to it - the plugin is something you pass in.

--- a/site/src/content/docs/docs/server-driven.mdx
+++ b/site/src/content/docs/docs/server-driven.mdx
@@ -1,0 +1,123 @@
+---
+title: Server-driven flows
+description: The JSON contract the engine accepts today, and what is planned for sending flows over the wire.
+---
+
+import RunnableExample from '../../../components/RunnableExample.astro';
+import ServerDrivenReact from '../../../islands/ServerDrivenReact';
+import ServerDrivenVue from '../../../islands/ServerDrivenVue.vue';
+import contractSource from '@examples/tasks/src/server-driven/contract.ts?raw';
+import loadSource from '@examples/tasks/src/server-driven/load.ts?raw';
+import appSource from '@examples/tasks/src/server-driven/App.tsx?raw';
+import appVueSource from '@examples/tasks/src/server-driven/App.vue?raw';
+import wizardVueSource from '@examples/tasks/src/server-driven/Wizard.vue?raw';
+import headlessSource from '@examples/tasks/src/server-driven/headless.ts?raw';
+import headlessOutput from '@examples/tasks/src/server-driven/headless.out.txt?raw';
+
+A flow is data, and that decision has a consequence this page is about: a definition can be
+written somewhere other than your bundle. It can live in a column, be assembled by a service, be
+edited by someone who does not deploy, and arrive over the wire.
+
+This page has two halves, and they are not the same kind of thing. The first is the contract the
+engine accepts today and is covered by tests. The second is what is planned on top of it, and is
+not here yet.
+
+## What the engine accepts today
+
+A `FlowDefinition` is JSON. Everything it cannot carry - a validator, a predicate, a loader - is
+named by a `$ref` and answered by a registry the client already holds.
+
+That split is the security property, not a convenience. A definition from a server can ask for a
+check to run; it cannot supply the code that runs it. The worst a hostile payload can do is name
+a resolver you do not have, which `validateFlow` reports before anything runs.
+
+<RunnableExample
+  reactSources={[
+    {
+      name: 'contract.ts',
+      lang: 'ts',
+      code: contractSource,
+      note: 'The definition as text, and the half that never travels.',
+    },
+    {
+      name: 'load.ts',
+      lang: 'ts',
+      code: loadSource,
+      note: 'Cheapest check first: size, JSON, shape, then the flow rules.',
+    },
+    { name: 'App.tsx', lang: 'tsx', code: appSource },
+  ]}
+  vueSources={[
+    { name: 'contract.ts', lang: 'ts', code: contractSource },
+    { name: 'load.ts', lang: 'ts', code: loadSource },
+    { name: 'App.vue', lang: 'vue', code: appVueSource },
+    { name: 'Wizard.vue', lang: 'vue', code: wizardVueSource },
+  ]}
+  headlessSources={[
+    { name: 'contract.ts', lang: 'ts', code: contractSource },
+    { name: 'load.ts', lang: 'ts', code: loadSource },
+    { name: 'headless.ts', lang: 'ts', code: headlessSource },
+    {
+      name: 'Output',
+      lang: 'text',
+      code: headlessOutput,
+      note: 'A test in the repository asserts these exact lines.',
+    },
+  ]}
+>
+  <ServerDrivenReact client:visible slot="react" />
+  <ServerDrivenVue client:visible slot="vue" />
+</RunnableExample>
+
+## Check it in the order things go wrong
+
+A definition that arrived from elsewhere is untrusted input, and the checks are worth doing
+cheapest first: the size of the text, then whether it is JSON at all, then whether it has the
+shape a flow has, and only then the flow's own rules.
+
+The shape check is not politeness. `validateFlow` is typed for a `FlowDefinition` and reads
+fields off it without guarding them, so an ordinary malformed payload - a string where `steps`
+should be, `order` holding a number - throws out of the validator rather than being reported by
+it. Checking `id` and `steps` yourself first is what turns that into a list of problems.
+
+Every failure is a value here, which is what lets a page render the problems instead of
+disappearing behind a stack trace. [Validation](../validation/) is what `validateFlow` reports
+and how `assertFlow` differs.
+
+## Changing a flow that is already running
+
+`patchFlow` takes a partial definition and merges it: steps are replaced by id, so a patch names
+only what changed, and fields at the top level are replaced whole.
+
+```ts
+wizard.patchFlow({ order: ['account', 'billing', 'invoice', 'done'], steps: { invoice: {} } });
+```
+
+It returns whether it applied, and there is one patch it refuses: the one that deletes the step
+the person is standing on. Relocating them silently loses a half-filled form, and a backend
+sending that has a bug worth surfacing rather than smoothing over. The refusal only applies at
+the root of the flow - a step inside a group is never in the root's `steps`, and reading its
+absence as a deletion would refuse every patch made while someone stands inside a group.
+
+A patch that introduces a group step without a traversal installed throws rather than returning
+`false`. That is a wiring mistake in your application, not an outcome of the payload.
+
+**Deleting a step is the one change a payload cannot express.** A step is removed by setting it
+to `undefined`, and JSON has no `undefined` - `null` is a different value and is not treated as a
+deletion. Removal has to be built in code, which is why the example builds that patch rather than
+parsing it.
+
+## What is planned, and is not here
+
+Sending flows over the wire as a feature - fetching, caching, revalidating, patching from a
+stream - is roadmap work, and `http-flow` is the plugin that would carry it. It is not part of
+1.0.0, and this page is deliberately the only server-driven surface the release ships.
+
+The reason for the order is that the contract has to be right before the transport is
+interesting. Everything a transport would need already exists and is tested: a definition is
+JSON, it can be validated before it runs, it can be swapped while the wizard is running, and the
+part that cannot be serialized is named rather than sent. What `http-flow` adds is the plumbing,
+not the model.
+
+Until it lands, `fetch` and `patchFlow` are the plumbing, and they are the same two calls the
+plugin would make.

--- a/site/src/content/docs/docs/server-driven.mdx
+++ b/site/src/content/docs/docs/server-driven.mdx
@@ -28,8 +28,15 @@ A `FlowDefinition` is JSON. Everything it cannot carry - a validator, a predicat
 named by a `$ref` and answered by a registry the client already holds.
 
 That split is the security property, not a convenience. A definition from a server can ask for a
-check to run; it cannot supply the code that runs it. The worst a hostile payload can do is name
-a resolver you do not have, which `validateFlow` reports before anything runs.
+check to run; it cannot supply the code that runs it. A name it invents is reported by
+`validateFlow` before anything runs.
+
+One qualification, because it decides how you build the registry. `validateFlow` asks
+`name in registry`, and `in` walks the prototype chain - so against an ordinary object literal,
+`{ "$ref": "toString" }` passes as a known resolver and the engine then calls
+`Object.prototype.toString`, which returns a truthy string and quietly changes which steps are
+reachable. Build the registry with a null prototype, as the example does, and the only names that
+resolve are the ones you put there.
 
 <RunnableExample
   reactSources={[
@@ -101,6 +108,13 @@ absence as a deletion would refuse every patch made while someone stands inside 
 
 A patch that introduces a group step without a traversal installed throws rather than returning
 `false`. That is a wiring mistake in your application, not an outcome of the payload.
+
+**Check a patch before applying it.** `patchFlow` merges and installs; it does not validate. A
+patch carrying `order: 1` is accepted and the failure surfaces later, inside a selector, with the
+payload long out of sight. Merge it against the current definition yourself, run the same checks
+you ran on the first payload, and hand over the patch only if the flow it produces is one the
+engine can run - which is what the example does, and why the refusal it shows names a problem
+rather than a stack trace.
 
 **Deleting a step is the one change a payload cannot express.** A step is removed by setting it
 to `undefined`, and JSON has no `undefined` - `null` is a different value and is not treated as a

--- a/site/src/islands/DevtoolsReact.tsx
+++ b/site/src/islands/DevtoolsReact.tsx
@@ -1,0 +1,6 @@
+import { App } from '@examples/quickstart/src/Devtools';
+
+import { restartable } from '../components/StageBoundary';
+
+/** The devtools panel over the quickstart wizard, mounted beside its source. */
+export default restartable(App);

--- a/site/src/islands/ServerDrivenReact.tsx
+++ b/site/src/islands/ServerDrivenReact.tsx
@@ -1,0 +1,6 @@
+import { App } from '@examples/tasks/src/server-driven/App';
+
+import { restartable } from '../components/StageBoundary';
+
+/** "Server-driven flows" on the React binding, mounted beside its source. */
+export default restartable(App);

--- a/site/src/islands/ServerDrivenVue.vue
+++ b/site/src/islands/ServerDrivenVue.vue
@@ -1,0 +1,12 @@
+<script setup lang="ts">
+import App from '@examples/tasks/src/server-driven/App.vue';
+
+import RestartableStage from '../components/RestartableStage.vue';
+</script>
+
+<!-- "Server-driven flows" on the Vue binding, mounted beside its source. -->
+<template>
+  <RestartableStage v-slot="{ attempt }">
+    <App :key="attempt" />
+  </RestartableStage>
+</template>

--- a/site/src/styles/site.css
+++ b/site/src/styles/site.css
@@ -1195,6 +1195,25 @@ svg.interactive .node {
   max-width: var(--measure);
 }
 
+/* The devtools panel carries its own theme as six custom properties, and left
+   alone it paints its own light ground: in the dark theme that put the page's
+   light text on a white panel at 1.18:1, across fifty-eight nodes.
+
+   It declares those properties on `.wz-panel` itself, so a value set on an
+   ancestor never reaches it - a declaration on the element always beats one
+   inherited from above, whatever the ancestor's selector. The override has to
+   land on the same element and outrank the panel's own rule, which one extra
+   class does. Six declarations rather than a rule per element, because the
+   panel already routes every colour through them. */
+.example-stage .wz-panel {
+  --wz-bg: var(--surface);
+  --wz-fg: var(--fg);
+  --wz-muted: var(--fg-muted);
+  --wz-accent: var(--accent);
+  --wz-line: var(--line-strong);
+  --wz-danger: var(--st-error);
+}
+
 .example-source {
   border-top: var(--border) solid var(--line);
   padding-top: var(--space-8);


### PR DESCRIPTION
S4-4, the last two pages of the documentation epic. With this, S4 is complete and S5 is
unblocked.

## Devtools

What the panel shows and how to mount it, written from the package rather than from the
specification.

Three views over one snapshot, and **Activity** is the one that pays for the panel: a refusal is
not a commit, so it never reaches a subscriber. Without that view a refused `next()` is invisible,
which is precisely the moment someone opens devtools.

The two ways to get the mounting wrong are the two the quickstart example already guards against:
one plugin object shared between `createWizard` and the panel (two calls leave Activity empty
while everything else looks right), and a container with a height, because the panel is docked and
fills what it is given rather than floating.

It also says plainly what the package is: `WizardDevtools` is React, `react` is a peer
dependency, and a Vue host uses `/headless` - `devtools()` installs into any wizard and
`recordSession` writes the same bundle the panel's record button does.

## Server-driven

The two labelled halves the design asks for.

**What the engine accepts today.** A definition is JSON; the half it cannot carry is named by
`$ref` and answered by a registry the client holds. That split is the security property rather
than a convenience: a payload can ask for a check to run and cannot supply the code that runs it.
Checks go cheapest first - size, JSON, shape, then the flow's rules - and the shape check is not
politeness: `validateFlow` is typed for a `FlowDefinition` and reads fields off it unguarded, so
an ordinary malformed payload throws out of the validator instead of being reported by it.
`patchFlow` is how a running flow changes, and it refuses exactly one patch: the one that deletes
the step someone is standing on.

**What is planned.** `http-flow`, named as 1.1 work and described no further than what exists,
because nothing of it exists yet. The page says why the order is right: the contract has to be
correct before a transport is interesting, and everything a transport needs is already here and
tested.

## Two things the work turned up

**Deleting a step is the one change a payload cannot express.** A step is removed by setting it to
`undefined`; JSON has no `undefined`, and `null` is a different value that is not treated as a
deletion. I wrote that patch as JSON first, which is how the gap surfaced - it would have applied
cleanly and left a `null` where a step used to be. The example builds it in code and the page
explains why.

**The panel needed the site's theme, and its documented hook does not work.** Mounted as it ships
it paints its own light ground; in the dark theme that put the page's light text on a white panel
at 1.18:1 across fifty-eight nodes, which axe caught and reading would not have. Its six custom
properties are the documented override point - "a host overrides them on any ancestor" - but they
are declared on `.wz-panel` itself, and a declaration on the element always beats one inherited
from an ancestor. Setting them on the container changed nothing whatsoever, same fifty-eight nodes
and same ratio, which is what identified the cause. The site now sets them on the panel, which
works and leans on a class the package does not promise to keep. Filed as #95 rather than fixed
here, since it is a package defect and this is a documentation change.

## Checks

`pnpm verify` green (672 tests, five of them new). Site build 23 pages, up from 21. Site e2e 88
passed, up from 82: the four axe sweeps for the two pages, and two browser tests - the panel
mounts over a running wizard with a real height, and a server-driven flow takes a patch and
refuses the deleting one.

Closes #74
