### PR TITLE
chore: two lessons from the documentation epic

### DIFF
--- a/.agent/memory/MEMORY.md
+++ b/.agent/memory/MEMORY.md
@@ -39,3 +39,5 @@
 - [Unlayered CSS beats Starlight](unlayered-css-beats-starlight.md) — layers outrank specificity; the 1.00:1 sidebar bug.
 - [Docs pages had no e2e coverage](docs-pages-had-no-e2e-coverage.md) — and the three screenshot findings that were not real.
 - [Project state lives in three places](project-state-lives-in-three-places.md) — PLAN.md, board projects/2, the issue; beads retired; the SessionStart brief hands them over.
+- [Prose drifts from the engine](prose-drifts-from-the-engine.md) — eight documented rules the engine does not have, and the only two things that found them.
+- [A watch can report green early](a-watch-can-report-green-early.md) — `--watch` exits 0 mid-run; a verify run beside e2e fails a healthy test.

--- a/.agent/memory/a-watch-can-report-green-early.md
+++ b/.agent/memory/a-watch-can-report-green-early.md
@@ -17,19 +17,36 @@ while any check is still pending (`gh pr checks --help`, "Additional exit codes"
 2.98). So the answer is the exit code of a plain call, not the end of a watch.
 
 ```bash
-for i in $(seq 1 45); do
+for i in $(seq 1 60); do
   out=$(gh pr checks <n> 2>&1)
   status=$?
-  [ "$status" -ne 8 ] && { echo "$out"; exit "$status"; }
-  sleep 20
+  # 8 is running. Exit 1 with "no checks reported" is the window after a push
+  # where the checks do not exist yet, and it carries the same code as a failure.
+  if [ "$status" -eq 8 ] || echo "$out" | grep -q 'no checks reported'; then
+    sleep 20
+    continue
+  fi
+  echo "$out"
+  exit "$status"
 done
-echo "still pending after 15 minutes"
+echo "checks never settled"
 exit 2
 ```
 
-The last two lines are the point. A loop that runs out of iterations and falls through returns
+There are three states, not two, and the third is what makes this harder than it looks. Between
+the push and the checks being registered, the command prints
+`no checks reported on the '<branch>' branch` and exits **1** - the same code a failed run gives.
+A loop waiting only on 8 leaves in the first twenty seconds and calls that settled; a caller
+reading 1 as "the checks failed" is wrong the other way. Wait for the checks to exist before
+waiting for them to finish, and tell that state apart by the message, since the code cannot.
+
+The last two lines matter as much. A loop that runs out of iterations and falls through returns
 whatever the final `sleep` returned, which is zero - the same false green, rebuilt by the thing
 written to avoid it. Every bounded wait needs an explicit failure at the bound.
+
+This note was wrong twice before it was right, both times in the direction of reporting success:
+first the fall-through, then the missing third state. That is the shape of the mistake worth
+remembering, more than the commands.
 
 **A heavy run beside the e2e suite fails a test that is fine.** `pnpm verify` and
 `pnpm test:e2e` at the same time failed the inspector's "label as text" spec on a five-second

--- a/.agent/memory/a-watch-can-report-green-early.md
+++ b/.agent/memory/a-watch-can-report-green-early.md
@@ -12,15 +12,24 @@ while `e2e` was still `pending`, printing only the jobs that had finished. Pushi
 while it watched was one trigger; the second had no obvious cause. Exit 0 from it means "the
 command ended", not "the checks passed".
 
-What works: poll until nothing reads `pending`, then decide.
+What the command does say, and what to read instead of "it finished": `gh pr checks` exits **8**
+while any check is still pending (`gh pr checks --help`, "Additional exit codes", confirmed on
+2.98). So the answer is the exit code of a plain call, not the end of a watch.
 
 ```bash
 for i in $(seq 1 45); do
   out=$(gh pr checks <n> 2>&1)
-  echo "$out" | grep -q pending || { echo "$out"; break; }
+  status=$?
+  [ "$status" -ne 8 ] && { echo "$out"; exit "$status"; }
   sleep 20
 done
+echo "still pending after 15 minutes"
+exit 2
 ```
+
+The last two lines are the point. A loop that runs out of iterations and falls through returns
+whatever the final `sleep` returned, which is zero - the same false green, rebuilt by the thing
+written to avoid it. Every bounded wait needs an explicit failure at the bound.
 
 **A heavy run beside the e2e suite fails a test that is fine.** `pnpm verify` and
 `pnpm test:e2e` at the same time failed the inspector's "label as text" spec on a five-second

--- a/.agent/memory/a-watch-can-report-green-early.md
+++ b/.agent/memory/a-watch-can-report-green-early.md
@@ -1,0 +1,37 @@
+---
+name: a-watch-can-report-green-early
+description: gh pr checks --watch exited 0 twice while a job was still running, and a full verify run beside the e2e suite fails an unrelated hydration test; read the settled list, and run heavy suites alone.
+metadata:
+  type: project
+---
+
+Two ways a green result was not one, both hit more than once in a single day.
+
+**A watch can exit before the checks settle.** `gh pr checks <n> --watch` returned exit 0 twice
+while `e2e` was still `pending`, printing only the jobs that had finished. Pushing a new commit
+while it watched was one trigger; the second had no obvious cause. Exit 0 from it means "the
+command ended", not "the checks passed".
+
+What works: poll until nothing reads `pending`, then decide.
+
+```bash
+for i in $(seq 1 45); do
+  out=$(gh pr checks <n> 2>&1)
+  echo "$out" | grep -q pending || { echo "$out"; break; }
+  sleep 20
+done
+```
+
+**A heavy run beside the e2e suite fails a test that is fine.** `pnpm verify` and
+`pnpm test:e2e` at the same time failed the inspector's "label as text" spec on a five-second
+wait for hydration. It passed alone, and passed in a clean full run of the same build. The suite
+is not flaky; the machine was busy.
+
+**Why:** both produce the same wrong conclusion from opposite directions - one calls a
+half-finished run green, the other calls a healthy suite broken. The first merges something
+unverified; the second sends you debugging a test that has nothing wrong with it.
+
+**How to apply:** never read exit status alone from a watch - read the settled list of checks.
+Run `verify` and `e2e` one after another, not beside each other. When an unrelated browser test
+fails, re-run it by itself before believing it, the way
+[[layout-perf-test-flakes-on-ci]] says for the CI-side version of the same trap.

--- a/.agent/memory/prose-drifts-from-the-engine.md
+++ b/.agent/memory/prose-drifts-from-the-engine.md
@@ -1,0 +1,35 @@
+---
+name: prose-drifts-from-the-engine
+description: Eight claims across the documentation pages described an engine this repository does not have; each was found by checking the rule against the code or by an example failing, never by reading.
+metadata:
+  type: project
+---
+
+Writing the S4 pages turned up eight sentences that described behaviour the engine does not have.
+Six were already published, two were mine, and not one of them was caught by reading.
+
+- `back()` walks `order` backwards (`resolve.ts:78`); it never reads `state.history`. `'auto'` is
+  that same walk, not a return to where the user came from.
+- The default policy is `visited`, not `sequential` (`resolve.ts:122`), and `sequential` means an
+  adjacent step, not "the next one and everything behind it".
+- The policy refuses with `blocked` (`navigate.ts:362`), which is indistinguishable by reason
+  from a guard refusing. `not-reachable` is about `when`, not about the policy.
+- `force` skips the policy and nothing else. Guards run on every move, validation is its own
+  option.
+- `validateAll()` does not exist.
+- `keyBy` identifies a repeat item; it does not move the answers written under a literal path.
+- `clearOnLeave` runs on a move away from the step, so it protects no snapshot: a persistence
+  plugin has already written what was typed, and completion clears nothing.
+- A step cannot be deleted by a payload at all: removal is `undefined` and JSON has no
+  `undefined`.
+
+**Why:** prose about an engine is a claim nobody executes. A sentence that was true once survives
+every rewrite of the code around it, and a sentence that was never true reads exactly the same.
+Two of these were found only because a runnable example failed: the expected output disagreed with
+what the engine printed, which no amount of re-reading would have produced.
+
+**How to apply:** when a page states a rule, open the code that implements it and read the branch,
+before the sentence is written. Where a page carries an example, let the example assert the rule -
+a checked-in output file that a test compares against is what turns a claim into something that
+can fail. Suspect any sentence that explains what a method "follows", "respects" or "protects";
+those verbs are where the drift collects. See [[docs-follow-every-change]].


### PR DESCRIPTION
Two notes in `.agent/memory/`, both things that cost time twice in one day and neither of them
visible in the code they are about.

## Prose drifts from the engine

Eight rules stated across the documentation pages described behaviour this library does not have.
Six were already published, two were written during S4, and not one was caught by reading:

- `back()` walks `order` backwards; it never reads `state.history`, and `'auto'` is that same walk
- the default policy is `visited`, and `sequential` means an adjacent step
- the policy refuses with `blocked`, indistinguishable by reason from a guard
- `force` skips the policy alone
- `validateAll()` does not exist (#93)
- `keyBy` identifies an item without moving its answers
- `clearOnLeave` protects no snapshot
- a payload cannot delete a step at all, because JSON has no `undefined`

What found them was opening the branch that implements each rule before writing the sentence, and
twice an example disagreeing with its own checked-in output. The note says which verbs the drift
collects around - "follows", "respects", "protects" - because those are the sentences that were
true once and stayed on the page.

## A watch can report green early

`gh pr checks --watch` exited 0 twice while a job was still pending, printing only the jobs that
had finished. Exit status from it means the command ended, not that the checks passed; the note
carries the poll-until-settled loop that replaces it.

Beside it, the opposite failure: a `verify` run next to the e2e suite failed an unrelated
hydration test on a five-second wait, which passed alone and in a clean full run. One trap calls a
half-finished run green, the other calls a healthy suite broken.

## Checks

`prettier` clean. The directory still holds no assistant, model or vendor names and no
non-English text, every `[[link]]` resolves, and the index matches the files exactly - 41 entries,
41 facts. The session brief renders all 41.
